### PR TITLE
Parseconf and man-page generator

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -59,14 +59,14 @@ dist_dnsjit_SOURCES += \
 # Lua sources
 dist_dnsjit_SOURCES += \
 	core.lua core/chelpers.lua core/log.lua core/mutex.lua core/query.lua core/receiver.lua core/timespec.lua \
-	lib.lua lib/getopt.lua \
+	lib.lua lib/getopt.lua lib/parseconf.lua \
     input.lua input/lua.lua input/pcap.lua \
 	filter.lua filter/lua.lua filter/roundrobin.lua filter/thread.lua filter/timing.lua \
     output.lua output/cpool.lua output/null.lua
 dnsjit_LDFLAGS = -Wl,-E
 lua_objects = \
 	core/chelpers.luao core/log.luao core/log.luaho core/mutex.luaho core/query.luaho core/receiver.luaho core/timespec.luaho \
-	lib.luao lib/getopt.luao \
+	lib.luao lib/getopt.luao lib/parseconf.luao \
     input/pcap.luaho \
 	filter/lua.luaho filter/roundrobin.luaho filter/thread.luaho filter/timing.luaho \
     output/cpool.luaho output/null.luaho \
@@ -81,7 +81,7 @@ man1_MANS = dnsjit.1
 CLEANFILES += $(man1_MANS)
 
 man3_MANS = dnsjit.core.3 dnsjit.core.chelpers.3 dnsjit.core.log.3 dnsjit.core.mutex.3 dnsjit.core.query.3 dnsjit.core.receiver.3 dnsjit.core.timespec.3 \
-    dnsjit.lib.3 dnsjit.lib.getopt.3 \
+    dnsjit.lib.3 dnsjit.lib.getopt.3 dnsjit.lib.parseconf.3 \
     dnsjit.input.3 dnsjit.input.lua.3 dnsjit.input.pcap.3 \
 	dnsjit.filter.3 dnsjit.filter.lua.3 dnsjit.filter.roundrobin.3 dnsjit.filter.thread.3 dnsjit.filter.timing.3 \
 	dnsjit.output.3 dnsjit.output.cpool.3 dnsjit.output.null.3
@@ -141,6 +141,9 @@ dnsjit.lib.3in: lib.lua gen-manpage.lua
 
 dnsjit.lib.getopt.3in: lib/getopt.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/lib/getopt.lua" > "$@"
+
+dnsjit.lib.parseconf.3in: lib/parseconf.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/lib/parseconf.lua" > "$@"
 
 
 dnsjit.input.3in: input.lua gen-manpage.lua

--- a/src/gen-manpage.lua
+++ b/src/gen-manpage.lua
@@ -24,9 +24,9 @@ ss_func = false
 doc = {}
 funcs = {}
 for line in io.lines(arg[1]) do
-    if string.match(line, "^[-][-]") then
-        table.insert(doc, string.sub(line, 4))
-    elseif string.match(line, "^module") then
+    if line:match("^[-][-]") then
+        table.insert(doc, line:sub(4))
+    elseif line:match("^module") then
         if table.maxn(doc) < 2 then
             error("Minimum required module doc missing")
         end
@@ -34,24 +34,30 @@ for line in io.lines(arg[1]) do
         print(".SH NAME")
         print(doc[1].." \\- "..doc[2])
         n, line = next(doc, 2)
-        while line and line > "" do
-            if not sh_syn then
-                print(".SH SYNOPSIS")
-                sh_syn = true
+        if n and n > 2 then
+            local n2 = n
+            while line and line > "" do
+                if not sh_syn then
+                    print(".SH SYNOPSIS")
+                    sh_syn = true
+                end
+                print(line)
+                n2 = n
+                n, line = next(doc, n)
             end
-            print(line)
             n, line = next(doc, n)
-        end
-        n, line = next(doc, n)
-        while line and line > "" do
-            if not sh_desc then
-                print(".SH DESCRIPTION")
-                sh_desc = true
+            if n and n > n2 then
+                while line and line > "" do
+                    if not sh_desc then
+                        print(".SH DESCRIPTION")
+                        sh_desc = true
+                    end
+                    print(line)
+                    n, line = next(doc, n)
+                end
             end
-            print(line)
-            n, line = next(doc, n)
         end
-    elseif string.match(line, "^function") then
+    elseif line:match("^function") then
         if table.maxn(doc) > 0 then
             if not ss_func then
                 if not sh_desc then
@@ -62,12 +68,17 @@ for line in io.lines(arg[1]) do
                 ss_func = true
             end
             print(".TP")
-            print(".BR "..string.sub(line, 10))
+            local fn,fd = line:match("(%S+)(%(.+)")
+            if fn and fd then
+                print(".BR "..fn.." \""..fd.."\"")
+            else
+                print(".B "..line:sub(10))
+            end
             for _, line in pairs(doc) do
                 print(line)
             end
         end
-    elseif string.match(line, "^return") then
+    elseif line:match("^return") then
         if table.maxn(doc) > 0 then
             print(".SH SEE ALSO")
             for _, line in pairs(doc) do

--- a/src/lib/parseconf.lua
+++ b/src/lib/parseconf.lua
@@ -1,0 +1,159 @@
+-- Copyright (c) 2018, OARC, Inc.
+-- All rights reserved.
+--
+-- This file is part of dnsjit.
+--
+-- dnsjit is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- dnsjit is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+
+-- dnsjit.lib.parseconf
+-- Parse simple config files
+--   local conf = require("dnsjit.lib.parseconf").new()
+--   conf:func("config_name", function(k,...)
+--       print(k,...)
+--   end)
+--   conf:parse(file)
+--   print(conf:val("another_config_name"))
+--
+-- This module parses simple config files that are based on the config
+-- syntax of DSC, drool and parseconf helper library.
+-- Each config begins with a
+-- .B name
+-- followed by
+-- .B options
+-- and ends with a
+-- .BR ; .
+-- Multiple configs can be given on the same line.
+-- Valid option types are
+-- .IR number ,
+-- .IR float ,
+-- .IR string ,
+-- .IR "quoted string" .
+-- Comments can be added by prefixing the comment with
+-- .BR # .
+-- .SS Example
+--   # Comment
+--   number 12345;
+--   float 123.456;
+--   string string string;
+--   quoted_string "string string string";
+--   multi config; on one line;
+module(...,package.seeall)
+
+Parseconf = {}
+
+-- Create a new Parseconf object.
+function Parseconf.new()
+    return setmetatable({ conf = {}, cf = {} }, { __index = Parseconf })
+end
+
+-- Set a function to call when config
+-- .I name
+-- is found.
+function Parseconf:func(name, func)
+    self.cf[name] = func
+end
+
+function Parseconf:part(l, n)
+    local p
+    p = l:match("^(%d+)[%s;]", n)
+    if p then
+        return p, tonumber(p)
+    end
+    p = l:match("^(%d+%.%d+)[%s;]", n)
+    if p then
+        return p, tonumber(p)
+    end
+    p = l:match("^([^%s;]+)[%s;]", n)
+    if p then
+        return p, p
+    end
+    p = l:match("^(\"[^\"]+\")[%s;]", n)
+    if p then
+        return p, p:sub(2, -2)
+    end
+end
+
+function Parseconf:next(l, n)
+    local eol = l:match("^%s*;%s*", n)
+    if eol then
+        return true, eol
+    end
+    local ws = l:match("^%s+", n)
+    if ws then
+        return ws
+    end
+    return false
+end
+
+-- Parse the given file.
+function Parseconf:file(fn)
+    local ln, l, c, e, m
+    ln = 1
+    for l in io.lines(fn) do
+        c = l:find("#")
+        if c then
+            l = l:sub(1, c - 1)
+        end
+        e, m = pcall(self.line, self, l)
+        if e == false then
+            error("parse error in "..fn.."["..ln.."]: "..m)
+        end
+        ln = ln + 1
+    end
+end
+
+-- Parse the given line.
+function Parseconf:line(l)
+    local n, p, v, va, c, ws, n, eol
+    n = 1
+    while n <= l:len() do
+        c = nil
+        va = {}
+        while true do
+            p, v = self:part(l, n)
+            if not p then
+                error("invalid config at character "..n..": "..l:sub(n))
+            end
+            if not c then
+                c = p
+            else
+                table.insert(va, v)
+            end
+            n = n + p:len()
+            ws, eol = self:next(l, n)
+            if ws == true then
+                if eol then
+                    n = n + eol:len()
+                end
+                break
+            elseif ws == false then
+                error("invalid config at character "..n..": "..l:sub(n))
+            end
+            n = n + ws:len()
+        end
+        if self.cf[c] then
+            self.cf[c](c, unpack(va))
+        else
+            self.conf[c] = va
+        end
+    end
+end
+
+-- Get the value of a config
+-- .IR name .
+function Parseconf:val(name)
+    return self.conf[name]
+end
+
+return Parseconf


### PR DESCRIPTION
- Add `dnsjit.lib.parseconf`
- `gen-manpage.lua`
  - Use short hand call to string functions
  - Fix leak of module name and short description into synopsis
  - Verify that synopsis and description works independent
  - Fix function display, arguments are normal text