### PR TITLE
Logging and Makefile

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -56,26 +56,34 @@ dist_dnsjit_SOURCES += \
     input/pcap.hh \
 	filter/lua.hh filter/roundrobin.hh filter/thread.hh filter/timing.hh \
     output/cpool.hh output/null.hh
-# Lua sources
-dist_dnsjit_SOURCES += \
-	core.lua core/chelpers.lua core/log.lua core/mutex.lua core/query.lua core/receiver.lua core/timespec.lua \
-	lib.lua lib/getopt.lua lib/parseconf.lua \
-    input.lua input/lua.lua input/pcap.lua \
-	filter.lua filter/lua.lua filter/roundrobin.lua filter/thread.lua filter/timing.lua \
-    output.lua output/cpool.lua output/null.lua
-dnsjit_LDFLAGS = -Wl,-E
-lua_objects = \
-	core/chelpers.luao core/log.luao core/log.luaho core/mutex.luaho core/query.luaho core/receiver.luaho core/timespec.luaho \
-	lib.luao lib/getopt.luao lib/parseconf.luao \
+lua_hobjects = \
+	core/log.luaho core/mutex.luaho core/query.luaho core/receiver.luaho core/timespec.luaho \
     input/pcap.luaho \
 	filter/lua.luaho filter/roundrobin.luaho filter/thread.luaho filter/timing.luaho \
-    output/cpool.luaho output/null.luaho \
-	core/mutex.luao core/query.luao \
+    output/cpool.luaho output/null.luaho
+# Lua sources
+dist_dnsjit_SOURCES += \
+	core/chelpers.lua core/log.lua core/mutex.lua core/query.lua \
+	lib/getopt.lua lib/parseconf.lua \
+    input/lua.lua input/pcap.lua \
+	filter/lua.lua filter/roundrobin.lua filter/thread.lua filter/timing.lua \
+    output/cpool.lua output/null.lua
+lua_objects = \
+	core/chelpers.luao core/log.luao core/mutex.luao core/query.luao \
+	lib/getopt.luao lib/parseconf.luao \
     input/lua.luao input/pcap.luao \
 	filter/lua.luao filter/roundrobin.luao filter/thread.luao filter/timing.luao \
     output/cpool.luao output/null.luao
-dnsjit_LDADD += $(lua_objects)
-CLEANFILES += $(lua_objects)
+# Documentation only sources
+dist_dnsjit_SOURCES += \
+	core.lua core/receiver.lua core/timespec.lua \
+	lib.lua \
+    input.lua \
+	filter.lua \
+    output.lua
+dnsjit_LDFLAGS = -Wl,-E
+dnsjit_LDADD += $(lua_hobjects) $(lua_objects)
+CLEANFILES += $(lua_hobjects) $(lua_objects)
 
 man1_MANS = dnsjit.1
 CLEANFILES += $(man1_MANS)

--- a/src/core/log.c
+++ b/src/core/log.c
@@ -26,50 +26,271 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-static log_t _log = LOG_T_INIT;
+static log_t _log = LOG_T_INIT("core");
 
-log_t* core_log()
+void log_debug(const log_t* l, const char* file, size_t line, const char* msg, ...)
 {
-    return &_log;
-}
-
-struct _name {
-    const char* debug;
-    const char* info;
-    const char* notice;
-    const char* warning;
-    const char* critical;
-    const char* fatal;
-};
-static struct _name _name = {
-    "debug",
-    "info",
-    "notice",
-    "warning",
-    "critical",
-    "fatal"
-};
-
-#define log_func(name, level)                                                      \
-    void name(const log_t* l, const char* file, size_t line, const char* msg, ...) \
-    {                                                                              \
-        char    buf[512];                                                          \
-        va_list ap;                                                                \
-        if (!l)                                                                    \
-            l = &_log;                                                             \
-        if (l->level == 3 || (_log.level == 3 && l->level != 2)) {                 \
-            va_start(ap, msg);                                                     \
-            vsnprintf(buf, sizeof(buf), msg, ap);                                  \
-            va_end(ap);                                                            \
-            buf[sizeof(buf) - 1] = 0;                                              \
-            printf("%s[%lu] %s: %s\n", file, line, _name.level, buf);              \
-        }                                                                          \
+    char    buf[512];
+    va_list ap;
+    if (!l) {
+        if (_log.settings.debug != 3) {
+            return;
+        }
+    } else {
+        if (l->settings.debug) {
+            if (l->settings.debug != 3) {
+                return;
+            }
+        } else if (l->module && l->module->debug) {
+            if (l->module->debug != 3) {
+                return;
+            }
+        } else if (_log.settings.debug != 3) {
+            return;
+        }
+    }
+    va_start(ap, msg);
+    vsnprintf(buf, sizeof(buf), msg, ap);
+    va_end(ap);
+    buf[sizeof(buf) - 1] = 0;
+    for (;;) {
+        if (!l) {
+            if (_log.settings.display_file_line != 3) {
+                break;
+            }
+        } else {
+            if (l->settings.display_file_line) {
+                if (l->settings.display_file_line != 3) {
+                    break;
+                }
+            } else if (l->module && l->module->display_file_line) {
+                if (l->module->display_file_line != 3) {
+                    break;
+                }
+            } else if (_log.settings.display_file_line != 3) {
+                break;
+            }
+        }
+        if (l) {
+            if (l->is_obj) {
+                printf("%s[%lu] %s[%p] debug: %s\n", file, line, l->name, l, buf);
+                return;
+            }
+            printf("%s[%lu] %s debug: %s\n", file, line, l->name, buf);
+            return;
+        }
+        printf("%s[%lu] %s debug: %s\n", file, line, _log.name, buf);
+        return;
     }
 
-log_func(log_debug, debug);
-log_func(log_info, info);
-log_func(log_notice, notice);
-log_func(log_warning, warning);
+    if (l) {
+        if (l->is_obj) {
+            printf("%s[%p] debug: %s\n", l->name, l, buf);
+            return;
+        }
+        printf("%s debug: %s\n", l->name, buf);
+        return;
+    }
+    printf("%s debug: %s\n", _log.name, buf);
+}
+
+void log_info(const log_t* l, const char* file, size_t line, const char* msg, ...)
+{
+    char    buf[512];
+    va_list ap;
+    if (!l) {
+        if (_log.settings.info != 3) {
+            return;
+        }
+    } else {
+        if (l->settings.info) {
+            if (l->settings.info != 3) {
+                return;
+            }
+        } else if (l->module && l->module->info) {
+            if (l->module->info != 3) {
+                return;
+            }
+        } else if (_log.settings.info != 3) {
+            return;
+        }
+    }
+    va_start(ap, msg);
+    vsnprintf(buf, sizeof(buf), msg, ap);
+    va_end(ap);
+    buf[sizeof(buf) - 1] = 0;
+    for (;;) {
+        if (!l) {
+            if (_log.settings.display_file_line != 3) {
+                break;
+            }
+        } else {
+            if (l->settings.display_file_line) {
+                if (l->settings.display_file_line != 3) {
+                    break;
+                }
+            } else if (l->module && l->module->display_file_line) {
+                if (l->module->display_file_line != 3) {
+                    break;
+                }
+            } else if (_log.settings.display_file_line != 3) {
+                break;
+            }
+        }
+        if (l) {
+            if (l->is_obj) {
+                printf("%s[%lu] %s[%p] info: %s\n", file, line, l->name, l, buf);
+                return;
+            }
+            printf("%s[%lu] %s info: %s\n", file, line, l->name, buf);
+            return;
+        }
+        printf("%s[%lu] %s info: %s\n", file, line, _log.name, buf);
+        return;
+    }
+
+    if (l) {
+        if (l->is_obj) {
+            printf("%s[%p] info: %s\n", l->name, l, buf);
+            return;
+        }
+        printf("%s info: %s\n", l->name, buf);
+        return;
+    }
+    printf("%s info: %s\n", _log.name, buf);
+}
+
+void log_notice(const log_t* l, const char* file, size_t line, const char* msg, ...)
+{
+    char    buf[512];
+    va_list ap;
+    if (!l) {
+        if (_log.settings.notice != 3) {
+            return;
+        }
+    } else {
+        if (l->settings.notice) {
+            if (l->settings.notice != 3) {
+                return;
+            }
+        } else if (l->module && l->module->notice) {
+            if (l->module->notice != 3) {
+                return;
+            }
+        } else if (_log.settings.notice != 3) {
+            return;
+        }
+    }
+    va_start(ap, msg);
+    vsnprintf(buf, sizeof(buf), msg, ap);
+    va_end(ap);
+    buf[sizeof(buf) - 1] = 0;
+    for (;;) {
+        if (!l) {
+            if (_log.settings.display_file_line != 3) {
+                break;
+            }
+        } else {
+            if (l->settings.display_file_line) {
+                if (l->settings.display_file_line != 3) {
+                    break;
+                }
+            } else if (l->module && l->module->display_file_line) {
+                if (l->module->display_file_line != 3) {
+                    break;
+                }
+            } else if (_log.settings.display_file_line != 3) {
+                break;
+            }
+        }
+        if (l) {
+            if (l->is_obj) {
+                printf("%s[%lu] %s[%p] notice: %s\n", file, line, l->name, l, buf);
+                return;
+            }
+            printf("%s[%lu] %s notice: %s\n", file, line, l->name, buf);
+            return;
+        }
+        printf("%s[%lu] %s notice: %s\n", file, line, _log.name, buf);
+        return;
+    }
+
+    if (l) {
+        if (l->is_obj) {
+            printf("%s[%p] notice: %s\n", l->name, l, buf);
+            return;
+        }
+        printf("%s notice: %s\n", l->name, buf);
+        return;
+    }
+    printf("%s notice: %s\n", _log.name, buf);
+}
+
+void log_warning(const log_t* l, const char* file, size_t line, const char* msg, ...)
+{
+    char    buf[512];
+    va_list ap;
+    if (!l) {
+        if (_log.settings.warning != 3) {
+            return;
+        }
+    } else {
+        if (l->settings.warning) {
+            if (l->settings.warning != 3) {
+                return;
+            }
+        } else if (l->module && l->module->warning) {
+            if (l->module->warning != 3) {
+                return;
+            }
+        } else if (_log.settings.warning != 3) {
+            return;
+        }
+    }
+    va_start(ap, msg);
+    vsnprintf(buf, sizeof(buf), msg, ap);
+    va_end(ap);
+    buf[sizeof(buf) - 1] = 0;
+    for (;;) {
+        if (!l) {
+            if (_log.settings.display_file_line != 3) {
+                break;
+            }
+        } else {
+            if (l->settings.display_file_line) {
+                if (l->settings.display_file_line != 3) {
+                    break;
+                }
+            } else if (l->module && l->module->display_file_line) {
+                if (l->module->display_file_line != 3) {
+                    break;
+                }
+            } else if (_log.settings.display_file_line != 3) {
+                break;
+            }
+        }
+        if (l) {
+            if (l->is_obj) {
+                printf("%s[%lu] %s[%p] warning: %s\n", file, line, l->name, l, buf);
+                return;
+            }
+            printf("%s[%lu] %s warning: %s\n", file, line, l->name, buf);
+            return;
+        }
+        printf("%s[%lu] %s warning: %s\n", file, line, _log.name, buf);
+        return;
+    }
+
+    if (l) {
+        if (l->is_obj) {
+            printf("%s[%p] warning: %s\n", l->name, l, buf);
+            return;
+        }
+        printf("%s warning: %s\n", l->name, buf);
+        return;
+    }
+    printf("%s warning: %s\n", _log.name, buf);
+}
 
 void log_critical(const log_t* l, const char* file, size_t line, const char* msg, ...)
 {
@@ -79,7 +300,45 @@ void log_critical(const log_t* l, const char* file, size_t line, const char* msg
     vsnprintf(buf, sizeof(buf), msg, ap);
     va_end(ap);
     buf[sizeof(buf) - 1] = 0;
-    printf("%s[%lu] %s: %s\n", file, line, _name.critical, buf);
+    for (;;) {
+        if (!l) {
+            if (_log.settings.display_file_line != 3) {
+                break;
+            }
+        } else {
+            if (l->settings.display_file_line) {
+                if (l->settings.display_file_line != 3) {
+                    break;
+                }
+            } else if (l->module && l->module->display_file_line) {
+                if (l->module->display_file_line != 3) {
+                    break;
+                }
+            } else if (_log.settings.display_file_line != 3) {
+                break;
+            }
+        }
+        if (l) {
+            if (l->is_obj) {
+                printf("%s[%lu] %s[%p] critical: %s\n", file, line, l->name, l, buf);
+                return;
+            }
+            printf("%s[%lu] %s critical: %s\n", file, line, l->name, buf);
+            return;
+        }
+        printf("%s[%lu] %s critical: %s\n", file, line, _log.name, buf);
+        return;
+    }
+
+    if (l) {
+        if (l->is_obj) {
+            printf("%s[%p] critical: %s\n", l->name, l, buf);
+            return;
+        }
+        printf("%s critical: %s\n", l->name, buf);
+        return;
+    }
+    printf("%s critical: %s\n", _log.name, buf);
 }
 
 void log_fatal(const log_t* l, const char* file, size_t line, const char* msg, ...)
@@ -90,6 +349,49 @@ void log_fatal(const log_t* l, const char* file, size_t line, const char* msg, .
     vsnprintf(buf, sizeof(buf), msg, ap);
     va_end(ap);
     buf[sizeof(buf) - 1] = 0;
-    printf("%s[%lu] %s: %s\n", file, line, _name.fatal, buf);
+    for (;;) {
+        if (!l) {
+            if (_log.settings.display_file_line != 3) {
+                break;
+            }
+        } else {
+            if (l->settings.display_file_line) {
+                if (l->settings.display_file_line != 3) {
+                    break;
+                }
+            } else if (l->module && l->module->display_file_line) {
+                if (l->module->display_file_line != 3) {
+                    break;
+                }
+            } else if (_log.settings.display_file_line != 3) {
+                break;
+            }
+        }
+        if (l) {
+            if (l->is_obj) {
+                printf("%s[%lu] %s[%p] fatal: %s\n", file, line, l->name, l, buf);
+                exit(1);
+            }
+            printf("%s[%lu] %s fatal: %s\n", file, line, l->name, buf);
+            exit(1);
+        }
+        printf("%s[%lu] %s fatal: %s\n", file, line, _log.name, buf);
+        exit(1);
+    }
+
+    if (l) {
+        if (l->is_obj) {
+            printf("%s[%p] fatal: %s\n", l->name, l, buf);
+            exit(1);
+        }
+        printf("%s fatal: %s\n", l->name, buf);
+        exit(1);
+    }
+    printf("%s fatal: %s\n", _log.name, buf);
     exit(1);
+}
+
+log_t* core_log()
+{
+    return &_log;
 }

--- a/src/core/log.h
+++ b/src/core/log.h
@@ -23,25 +23,41 @@
 
 #include <stdlib.h>
 
-#define LOG_T_INIT \
-    {              \
-        0, 0, 0, 0 \
+#define LOG_SETTINGS_T_INIT \
+    {                       \
+        0, 0, 0, 0, 0       \
     }
+#define LOG_T_INIT(name)                \
+    {                                   \
+        name, 0, LOG_SETTINGS_T_INIT, 0 \
+    }
+#define LOG_T_INIT_OBJ(name)                         \
+    {                                                \
+        name, 1, LOG_SETTINGS_T_INIT, &_log.settings \
+    }
+
 #include "core/log.hh"
 
-void log_debug(const log_t* l, const char* file, size_t line, const char* msg, ...);
-void log_info(const log_t* l, const char* file, size_t line, const char* msg, ...);
-void log_notice(const log_t* l, const char* file, size_t line, const char* msg, ...);
-void log_warning(const log_t* l, const char* file, size_t line, const char* msg, ...);
-void log_critical(const log_t* l, const char* file, size_t line, const char* msg, ...);
-void log_fatal(const log_t* l, const char* file, size_t line, const char* msg, ...);
+#define ldebug(msg...) log_debug(&self->_log, __FILE__, __LINE__, msg)
+#define linfo(msg...) log_info(&self->_log, __FILE__, __LINE__, msg)
+#define lnotice(msg...) log_notice(&self->_log, __FILE__, __LINE__, msg)
+#define lwarning(msg...) log_warning(&self->_log, __FILE__, __LINE__, msg)
+#define lcritical(msg...) log_critical(&self->_log, __FILE__, __LINE__, msg)
+#define lfatal(msg...) log_fatal(&self->_log, __FILE__, __LINE__, msg)
 
-#define ldebug(msg...) log_debug(&self->log, __FILE__, __LINE__, msg)
-#define linfo(msg...) log_info(&self->log, __FILE__, __LINE__, msg)
-#define lnotice(msg...) log_notice(&self->log, __FILE__, __LINE__, msg)
-#define lwarning(msg...) log_warning(&self->log, __FILE__, __LINE__, msg)
-#define lcritical(msg...) log_critical(&self->log, __FILE__, __LINE__, msg)
-#define lfatal(msg...) log_fatal(&self->log, __FILE__, __LINE__, msg)
+#define lpdebug(msg...) log_debug(self->_log, __FILE__, __LINE__, msg)
+#define lpinfo(msg...) log_info(self->_log, __FILE__, __LINE__, msg)
+#define lpnotice(msg...) log_notice(self->_log, __FILE__, __LINE__, msg)
+#define lpwarning(msg...) log_warning(self->_log, __FILE__, __LINE__, msg)
+#define lpcritical(msg...) log_critical(self->_log, __FILE__, __LINE__, msg)
+#define lpfatal(msg...) log_fatal(self->_log, __FILE__, __LINE__, msg)
+
+#define mldebug(msg...) log_debug(&_log, __FILE__, __LINE__, msg)
+#define mlinfo(msg...) log_info(&_log, __FILE__, __LINE__, msg)
+#define mlnotice(msg...) log_notice(&_log, __FILE__, __LINE__, msg)
+#define mlwarning(msg...) log_warning(&_log, __FILE__, __LINE__, msg)
+#define mlcritical(msg...) log_critical(&_log, __FILE__, __LINE__, msg)
+#define mlfatal(msg...) log_fatal(&_log, __FILE__, __LINE__, msg)
 
 #define gldebug(msg...) log_debug(0, __FILE__, __LINE__, msg)
 #define glinfo(msg...) log_info(0, __FILE__, __LINE__, msg)

--- a/src/core/log.hh
+++ b/src/core/log.hh
@@ -18,11 +18,26 @@
  * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+typedef struct log_settings {
+    unsigned short debug : 2;
+    unsigned short info : 2;
+    unsigned short notice : 2;
+    unsigned short warning : 2;
+    unsigned short display_file_line : 2;
+} log_settings_t;
+
 typedef struct log {
-    int debug;
-    int info;
-    int notice;
-    int warning;
+    const char*           name;
+    unsigned short        is_obj : 1;
+    log_settings_t        settings;
+    const log_settings_t* module;
 } log_t;
+
+void log_debug(const log_t* l, const char* file, size_t line, const char* msg, ...);
+void log_info(const log_t* l, const char* file, size_t line, const char* msg, ...);
+void log_notice(const log_t* l, const char* file, size_t line, const char* msg, ...);
+void log_warning(const log_t* l, const char* file, size_t line, const char* msg, ...);
+void log_critical(const log_t* l, const char* file, size_t line, const char* msg, ...);
+void log_fatal(const log_t* l, const char* file, size_t line, const char* msg, ...);
 
 log_t* core_log();

--- a/src/core/mutex.c
+++ b/src/core/mutex.c
@@ -25,16 +25,22 @@
 
 #include <pthread.h>
 
+static log_t           _log   = LOG_T_INIT("core.mutex");
 static pthread_mutex_t _mutex = PTHREAD_MUTEX_INITIALIZER;
+
+log_t* core_mutex_log()
+{
+    return &_log;
+}
 
 int core_mutex_lock()
 {
-    gldebug("core.mutex.lock()");
+    mldebug("lock()");
     return pthread_mutex_lock(&_mutex);
 }
 
 int core_mutex_unlock()
 {
-    gldebug("core.mutex.unlock()");
+    mldebug("unlock()");
     return pthread_mutex_unlock(&_mutex);
 }

--- a/src/core/mutex.h
+++ b/src/core/mutex.h
@@ -21,6 +21,8 @@
 #ifndef __dnsjit_core_mutex_h
 #define __dnsjit_core_mutex_h
 
+#include "core/log.h"
+
 #include "core/mutex.hh"
 
 #endif

--- a/src/core/mutex.hh
+++ b/src/core/mutex.hh
@@ -18,5 +18,8 @@
  * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+//Lua:require("dnsjit.core.log")
+log_t* core_mutex_log();
+
 int core_mutex_lock();
 int core_mutex_unlock();

--- a/src/core/mutex.lua
+++ b/src/core/mutex.lua
@@ -30,12 +30,21 @@ module(...,package.seeall)
 require("dnsjit.core.mutex_h")
 local C = require("ffi").C
 
+Mutex = {}
+
+-- Return the Log object to control logging of this module.
+function Mutex.log()
+    return C.core_mutex_log()
+end
+
 -- Lock the global shared mutex
-function lock()
+function Mutex.lock()
     return C.core_mutex_lock()
 end
 
 -- Unlock the global shared mutex
-function unlock()
+function Mutex.unlock()
     return C.core_mutex_unlock()
 end
+
+return Mutex

--- a/src/core/query.hh
+++ b/src/core/query.hh
@@ -18,10 +18,10 @@
  * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-//lua:require("dnsjit.core.log_h")
+//lua:require("dnsjit.core.log")
 //lua:require("dnsjit.core.timespec_h")
 typedef struct query {
-    log_t log;
+    log_t _log;
 
     unsigned short is_udp : 1;
     unsigned short is_tcp : 1;
@@ -73,6 +73,7 @@ typedef struct query {
     size_t additionals;
 } query_t;
 
+log_t*   query_log();
 query_t* query_new();
 void query_free(query_t* self);
 int query_init(query_t* self);

--- a/src/core/query.lua
+++ b/src/core/query.lua
@@ -30,7 +30,6 @@
 module(...,package.seeall)
 
 local ch = require("dnsjit.core.chelpers")
-local log = require("dnsjit.core.log")
 require("dnsjit.core.query_h")
 local ffi = require("ffi")
 local C = ffi.C
@@ -46,19 +45,24 @@ function Query.new(o)
         error("is not query_t")
     end
     ffi.gc(o, C.query_free)
-    local log = log.new(o.log)
-    log:debug("new()")
     return setmetatable({
         _ = o,
-        log = log,
     }, {__index = Query})
+end
+
+-- Return the Log object to control logging of this instance or module.
+function Query:log()
+    if self == nil then
+        return C.query_log()
+    end
+    return self._._log
 end
 
 -- Return the
 -- .I query_t
 -- C structure bound to this object.
 function Query:struct()
-    self.log:debug("struct()")
+    self._._log:debug("struct()")
     return self._
 end
 

--- a/src/core/receiver.c
+++ b/src/core/receiver.c
@@ -21,15 +21,12 @@
 #include "config.h"
 
 #include "core/receiver.h"
-#include "core/log.h"
 
 int receiver_call(receiver_t recv, void* robj, query_t* q)
 {
     if (!recv) {
         return 1;
     }
-
-    gldebug("receiver_call %p(%p, %p)", recv, robj, q);
 
     return recv(robj, q);
 }

--- a/src/filter/lua.c
+++ b/src/filter/lua.c
@@ -25,10 +25,16 @@
 #include <lualib.h>
 #include <lauxlib.h>
 
+static log_t        _log      = LOG_T_INIT("filter.lua");
 static filter_lua_t _defaults = {
-    LOG_T_INIT,
+    LOG_T_INIT_OBJ("filter.lua"),
     0, 0, 0, 0
 };
+
+log_t* filter_lua_log()
+{
+    return &_log;
+}
 
 int filter_lua_init(filter_lua_t* self)
 {
@@ -36,9 +42,8 @@ int filter_lua_init(filter_lua_t* self)
         return 1;
     }
 
-    ldebug("init %p", self);
-
     *self = _defaults;
+    ldebug("init", self);
 
     if (!(self->L = luaL_newstate())) {
         return 1;

--- a/src/filter/lua.hh
+++ b/src/filter/lua.hh
@@ -21,16 +21,17 @@
 #if 0
 typedef struct {} lua_State;
 #endif
-//lua:require("dnsjit.core.log_h")
+//lua:require("dnsjit.core.log")
 //lua:require("dnsjit.core.receiver_h")
 typedef struct filter_lua {
-    log_t      log;
+    log_t      _log;
     lua_State* L;
     receiver_t recv;
     void*      robj;
     size_t     args;
 } filter_lua_t;
 
+log_t* filter_lua_log();
 int filter_lua_init(filter_lua_t* self);
 int filter_lua_destroy(filter_lua_t* self);
 int filter_lua_func(filter_lua_t* self, const char* bc, size_t len);

--- a/src/filter/lua.lua
+++ b/src/filter/lua.lua
@@ -32,7 +32,6 @@
 module(...,package.seeall)
 
 local ch = require("dnsjit.core.chelpers")
-local log = require("dnsjit.core.log")
 local query = require("dnsjit.core.query")
 require("dnsjit.filter.lua_h")
 local ffi = require("ffi")
@@ -66,13 +65,18 @@ local Lua = {}
 -- Create a new Lua filter.
 function Lua.new()
     local o = struct.new()
-    local log = log.new(o.log)
-    log:debug("new()")
     return setmetatable({
         _ = o,
-        log = log,
         ishandler = false,
     }, {__index = Lua})
+end
+
+-- Return the Log object to control logging of this instance or module.
+function Lua:log()
+    if self == nil then
+        return C.filter_lua_log()
+    end
+    return self._._log
 end
 
 -- Set the function to call on each receive, this function runs in it's own
@@ -106,7 +110,7 @@ function Lua:receive()
     if self.ishandler then
         error("is handler")
     end
-    self.log:debug("receive()")
+    self._._log:debug("receive()")
     return C.filter_lua_receiver(), self._
 end
 
@@ -115,7 +119,7 @@ function Lua:receiver(o)
     if self.ishandler then
         error("is handler")
     end
-    self.log:debug("receiver()")
+    self._._log:debug("receiver()")
     self._.recv, self._.robj = o:receive()
     self._receiver = o
 end

--- a/src/filter/roundrobin.c
+++ b/src/filter/roundrobin.c
@@ -22,9 +22,15 @@
 
 #include "filter/roundrobin.h"
 
+static log_t               _log      = LOG_T_INIT("filter.roundrobin");
 static filter_roundrobin_t _defaults = {
-    LOG_T_INIT, 0, 0
+    LOG_T_INIT_OBJ("filter.roundrobin"), 0, 0
 };
+
+log_t* filter_roundrobin_log()
+{
+    return &_log;
+}
 
 int filter_roundrobin_init(filter_roundrobin_t* self)
 {

--- a/src/filter/roundrobin.hh
+++ b/src/filter/roundrobin.hh
@@ -18,7 +18,7 @@
  * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-//lua:require("dnsjit.core.log_h")
+//lua:require("dnsjit.core.log")
 //lua:require("dnsjit.core.receiver_h")
 typedef struct filter_roundrobin_recv filter_roundrobin_recv_t;
 struct filter_roundrobin_recv {
@@ -27,11 +27,12 @@ struct filter_roundrobin_recv {
     void*                     robj;
 };
 typedef struct filter_roundrobin {
-    log_t                     log;
+    log_t                     _log;
     filter_roundrobin_recv_t* recv_list;
     filter_roundrobin_recv_t* recv;
 } filter_roundrobin_t;
 
+log_t* filter_roundrobin_log();
 int filter_roundrobin_init(filter_roundrobin_t* self);
 int filter_roundrobin_destroy(filter_roundrobin_t* self);
 int filter_roundrobin_add(filter_roundrobin_t* self, receiver_t recv, void* robj);

--- a/src/filter/roundrobin.lua
+++ b/src/filter/roundrobin.lua
@@ -27,7 +27,6 @@
 -- Filter to pass queries to others in a round robin fashion.
 module(...,package.seeall)
 
-local log = require("dnsjit.core.log")
 require("dnsjit.filter.roundrobin_h")
 local ffi = require("ffi")
 local C = ffi.C
@@ -60,24 +59,29 @@ local Roundrobin = {}
 -- Create a new Roundrobin filter.
 function Roundrobin.new()
     local o = struct.new()
-    local log = log.new(o.log)
-    log:debug("new()")
     return setmetatable({
         _ = o,
-        log = log,
         receivers = {},
     }, {__index = Roundrobin})
 end
 
+-- Return the Log object to control logging of this instance or module.
+function Roundrobin:log()
+    if self == nil then
+        return C.filter_roundrobin_log()
+    end
+    return self._._log
+end
+
 function Roundrobin:receive()
-    self.log:debug("receive()")
+    self._._log:debug("receive()")
     return C.filter_roundrobin_receiver(), self._
 end
 
 -- Set the receiver to pass queries to, this can be called multiple times to
 -- set addtional receivers.
 function Roundrobin:receiver(o)
-    self.log:debug("receiver()")
+    self._._log:debug("receiver()")
     local recv, robj
     recv, robj = o:receive()
     local ret = C.filter_roundrobin_add(self._, recv, robj)

--- a/src/filter/thread.hh
+++ b/src/filter/thread.hh
@@ -22,24 +22,25 @@
 typedef struct {} pthread_t;
 typedef struct {} sllq_t;
 #endif
-//lua:require("dnsjit.core.log_h")
+//lua:require("dnsjit.core.log")
 //lua:require("dnsjit.core.receiver_h")
 typedef struct thread {
-    log_t          log;
+    log_t          _log;
     unsigned short have_id : 1;
     unsigned short my_queues : 1;
     pthread_t*     id;
     sllq_t*        qin;
     receiver_t     recv;
     void*          robj;
-} thread_t;
+} filter_thread_t;
 
-int thread_init(thread_t* self);
-int thread_destroy(thread_t* self);
-int thread_create(thread_t* self, const char* bc, size_t len);
-int thread_stop(thread_t* self);
-int thread_join(thread_t* self);
-receiver_t thread_receiver();
+log_t* filter_thread_log();
+int filter_thread_init(filter_thread_t* self);
+int filter_thread_destroy(filter_thread_t* self);
+int filter_thread_create(filter_thread_t* self, const char* bc, size_t len);
+int filter_thread_stop(filter_thread_t* self);
+int filter_thread_join(filter_thread_t* self);
+receiver_t filter_thread_receiver();
 
-query_t* thread_recv(thread_t* self);
-int thread_send(thread_t* self, query_t* q);
+query_t* filter_thread_recv(filter_thread_t* self);
+int filter_thread_send(filter_thread_t* self, query_t* q);

--- a/src/filter/timing.c
+++ b/src/filter/timing.c
@@ -25,11 +25,17 @@
 #include <time.h>
 #include <sys/time.h>
 
+static log_t           _log      = LOG_T_INIT("filter.timing");
 static filter_timing_t _defaults = {
-    LOG_T_INIT, 0, 0,
+    LOG_T_INIT_OBJ("filter.timing"), 0, 0,
     TIMING_MODE_KEEP, 0, 0, 0.0,
     { 0, 0 }, { 0, 0 }, { 0, 0 }, { 0, 0 }
 };
+
+log_t* filter_timing_log()
+{
+    return &_log;
+}
 
 int filter_timing_init(filter_timing_t* self)
 {

--- a/src/filter/timing.hh
+++ b/src/filter/timing.hh
@@ -18,11 +18,11 @@
  * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-//lua:require("dnsjit.core.log_h")
+//lua:require("dnsjit.core.log")
 //lua:require("dnsjit.core.receiver_h")
 //lua:require("dnsjit.core.timespec_h")
 typedef struct filter_timing {
-    log_t      log;
+    log_t      _log;
     receiver_t recv;
     void*      robj;
 
@@ -43,6 +43,7 @@ typedef struct filter_timing {
 
 } filter_timing_t;
 
+log_t* filter_timing_log();
 int filter_timing_init(filter_timing_t* self);
 int filter_timing_destroy(filter_timing_t* self);
 

--- a/src/filter/timing.lua
+++ b/src/filter/timing.lua
@@ -26,7 +26,6 @@
 -- packets arrived or to delay processing.
 module(...,package.seeall)
 
-local log = require("dnsjit.core.log")
 require("dnsjit.filter.timing_h")
 local ffi = require("ffi")
 local C = ffi.C
@@ -59,12 +58,17 @@ local Timing = {}
 -- Create a new Timing filter.
 function Timing.new()
     local o = struct.new()
-    local log = log.new(o.log)
-    log:debug("new()")
     return setmetatable({
         _ = o,
-        log = log,
     }, {__index = Timing})
+end
+
+-- Return the Log object to control logging of this instance or module.
+function Timing:log()
+    if self == nil then
+        return C.filter_timing_log()
+    end
+    return self._._log
 end
 
 -- Set the timing mode to keep the timing between packets.
@@ -100,13 +104,13 @@ function Timing:best_effort()
 end
 
 function Timing:receive()
-    self.log:debug("receive()")
+    self._._log:debug("receive()")
     return C.filter_timing_receiver(), self._
 end
 
 -- Set the receiver to pass queries to.
 function Timing:receiver(o)
-    self.log:debug("receiver()")
+    self._._log:debug("receiver()")
     self._.recv, self._.robj = o:receive()
     self._receiver = o
 end

--- a/src/gen-manpage.lua
+++ b/src/gen-manpage.lua
@@ -41,6 +41,9 @@ for line in io.lines(arg[1]) do
                     print(".SH SYNOPSIS")
                     sh_syn = true
                 end
+                if line == "." then
+                    line = ""
+                end
                 print(line)
                 n2 = n
                 n, line = next(doc, n)
@@ -51,6 +54,9 @@ for line in io.lines(arg[1]) do
                     if not sh_desc then
                         print(".SH DESCRIPTION")
                         sh_desc = true
+                    end
+                    if line == "." then
+                        line = ""
                     end
                     print(line)
                     n, line = next(doc, n)
@@ -75,6 +81,9 @@ for line in io.lines(arg[1]) do
                 print(".B "..line:sub(10))
             end
             for _, line in pairs(doc) do
+                if line == "." then
+                    line = ""
+                end
                 print(line)
             end
         end

--- a/src/input/lua.lua
+++ b/src/input/lua.lua
@@ -30,37 +30,45 @@ module(...,package.seeall)
 
 local ch = require("dnsjit.core.chelpers")
 local log = require("dnsjit.core.log")
-require("dnsjit.core.log_h")
 require("dnsjit.core.receiver_h")
 local ffi = require("ffi")
 local C = ffi.C
 
 local Lua = {}
+local module_log = log.new("input.lua")
 
 -- Create a new Lua input.
 function Lua.new()
-    local o = ffi.new("log_t")
-    local log = log.new(o)
-    log:debug("new()")
-    return setmetatable({
+    local self = setmetatable({
         _recv = nil,
         _robj = nil,
         _receiver = nil,
-        _log = o,
-        log = log,
-    }, {__index = Lua})
+        _log = log.new("input.lua", module_log),
+    }, { __index = Lua })
+
+    self._log:debug("new()")
+
+    return self
+end
+
+-- Return the Log object to control logging of this instance or module.
+function Lua:log()
+    if self == nil then
+        return module_log
+    end
+    return self._log
 end
 
 -- Set the receiver to pass queries to.
 function Lua:receiver(o)
-    self.log:debug("receiver()")
+    self._log:debug("receiver()")
     self._recv, self._robj = o:receive()
     self._receiver = o
 end
 
 -- Send a query to the receiver.
 function Lua:send(q)
-    self.log:debug("send()")
+    self._log:debug("send()")
     return ch.z2n(C.receiver_call(self._recv, self._robj, q:struct()))
 end
 

--- a/src/input/pcap.c
+++ b/src/input/pcap.c
@@ -25,6 +25,21 @@
 
 #include "omg-dns/omg_dns.h"
 
+static log_t        _log      = LOG_T_INIT("input.pcap");
+static input_pcap_t _defaults = {
+    LOG_T_INIT_OBJ("input.pcap"),
+    0, 0,
+    0, 0, 0,
+    { 0, 0 }, { 0, 0 },
+    0, 0, 0, 0,
+    PCAP_THREAD_OK
+};
+
+log_t* input_pcap_log()
+{
+    return &_log;
+}
+
 static void _udp(u_char* user, const pcap_thread_packet_t* packet, const u_char* payload, size_t length)
 {
     input_pcap_t*               self = (input_pcap_t*)user;
@@ -186,24 +201,15 @@ static void _tcp(u_char* user, const pcap_thread_packet_t* packet, const u_char*
     self->recv(self->robj, q);
 }
 
-static input_pcap_t _defaults = {
-    LOG_T_INIT,
-    0, 0,
-    0, 0, 0,
-    { 0, 0 }, { 0, 0 },
-    0, 0, 0, 0,
-    PCAP_THREAD_OK
-};
-
 int input_pcap_init(input_pcap_t* self)
 {
     if (!self) {
         return 1;
     }
 
-    ldebug("init %p", self);
-
     *self = _defaults;
+
+    ldebug("init");
 
     if (!(self->pt = pcap_thread_create())) {
         return 1;

--- a/src/input/pcap.hh
+++ b/src/input/pcap.hh
@@ -42,11 +42,11 @@ int pcap_thread_set_filter_optimize(pcap_thread_t* pcap_thread, const int filter
 uint32_t pcap_thread_filter_netmask(const pcap_thread_t* pcap_thread);
 int pcap_thread_set_filter_netmask(pcap_thread_t* pcap_thread, const uint32_t filter_netmask);
 #endif
-//lua:require("dnsjit.core.log_h")
+//lua:require("dnsjit.core.log")
 //lua:require("dnsjit.core.receiver_h")
 //lua:require("dnsjit.core.timespec_h")
 typedef struct input_pcap {
-    log_t          log;
+    log_t          _log;
     unsigned short setup_ok : 1;
     unsigned short only_queries : 1;
     pcap_thread_t* pt;
@@ -57,6 +57,7 @@ typedef struct input_pcap {
     int            err;
 } input_pcap_t;
 
+log_t* input_pcap_log();
 int input_pcap_init(input_pcap_t* self);
 int input_pcap_destroy(input_pcap_t* self);
 int input_pcap_open(input_pcap_t* self, const char* device);

--- a/src/input/pcap.lua
+++ b/src/input/pcap.lua
@@ -27,7 +27,6 @@
 module(...,package.seeall)
 
 local ch = require("dnsjit.core.chelpers")
-local log = require("dnsjit.core.log")
 require("dnsjit.input.pcap_h")
 local ffi = require("ffi")
 local C = ffi.C
@@ -60,18 +59,23 @@ local Pcap = {}
 -- Create a new Pcap input.
 function Pcap.new()
     local o = struct.new()
-    local log = log.new(o.log)
-    log:debug("new()")
     return setmetatable({
         _ = o,
         _receiver = nil,
-        log = log,
     }, {__index = Pcap})
+end
+
+-- Return the Log object to control logging of this instance or module.
+function Pcap:log()
+    if self == nil then
+        return C.input_pcap_log()
+    end
+    return self._._log
 end
 
 -- Set the receiver to pass queries to.
 function Pcap:receiver(o)
-    self.log:debug("receiver()")
+    self._._log:debug("receiver()")
     self._.recv, self._.robj = o:receive()
     self._receiver = o
 end

--- a/src/lib/getopt.lua
+++ b/src/lib/getopt.lua
@@ -60,7 +60,10 @@
 -- is not already defined.
 module(...,package.seeall)
 
+local log = require("dnsjit.core.log")
+
 Getopt = {}
+local module_log = log.new("lib.getopt")
 
 -- Create a new Getopt object.
 -- .I args
@@ -71,7 +74,10 @@ function Getopt.new(args)
     local self = setmetatable({
         opt = {},
         s2l = {},
+        _log = log.new("lib.getopt", module_log),
     }, { __index = Getopt })
+
+    self._log:debug("new()")
 
     for k, v in pairs(args) do
         local short, long, default, help, extensions = unpack(v)
@@ -79,6 +85,14 @@ function Getopt.new(args)
     end
 
     return self
+end
+
+-- Return the Log object to control logging of this instance or module.
+function Getopt:log()
+    if self == nil then
+        return module_log
+    end
+    return self._log
 end
 
 -- Add an option.

--- a/src/lib/parseconf.lua
+++ b/src/lib/parseconf.lua
@@ -50,11 +50,30 @@
 --   multi config; on one line;
 module(...,package.seeall)
 
+local log = require("dnsjit.core.log")
+
 Parseconf = {}
+local module_log = log.new("lib.parseconf")
 
 -- Create a new Parseconf object.
 function Parseconf.new()
-    return setmetatable({ conf = {}, cf = {} }, { __index = Parseconf })
+    local self = setmetatable({
+        conf = {},
+        cf = {},
+        _log = log.new("lib.parseconf", module_log),
+    }, { __index = Parseconf })
+
+    self._log:debug("new()")
+
+    return self
+end
+
+-- Return the Log object to control logging of this instance or module.
+function Parseconf:log()
+    if self == nil then
+        return module_log
+    end
+    return self._log
 end
 
 -- Set a function to call when config

--- a/src/output/cpool.c
+++ b/src/output/cpool.c
@@ -22,10 +22,16 @@
 
 #include "output/cpool.h"
 
+static log_t          _log      = LOG_T_INIT("output.cpool");
 static output_cpool_t _defaults = {
-    LOG_T_INIT,
+    LOG_T_INIT_OBJ("output.cpool"),
     0
 };
+
+log_t* output_cpool_log()
+{
+    return &_log;
+}
 
 int output_cpool_init(output_cpool_t* self, const char* host, const char* port)
 {
@@ -40,6 +46,7 @@ int output_cpool_init(output_cpool_t* self, const char* host, const char* port)
     if (!(self->p = client_pool_new(host, port))) {
         lfatal("oom");
     }
+    self->p->_log = &self->_log;
 
     return 0;
 }
@@ -55,13 +62,6 @@ int output_cpool_destroy(output_cpool_t* self)
     client_pool_free(self->p);
 
     return 0;
-}
-
-void output_cpool_updatelog(output_cpool_t* self)
-{
-    if (self && self->p) {
-        self->p->log = self->log;
-    }
 }
 
 size_t output_cpool_max_clients(output_cpool_t* self)

--- a/src/output/cpool.hh
+++ b/src/output/cpool.hh
@@ -21,16 +21,16 @@
 #if 0
 typedef struct {} client_pool_t;
 #endif
-//lua:require("dnsjit.core.log_h")
+//lua:require("dnsjit.core.log")
 //lua:require("dnsjit.core.receiver_h")
 typedef struct output_cpool {
-    log_t          log;
+    log_t          _log;
     client_pool_t* p;
 } output_cpool_t;
 
+log_t* output_cpool_log();
 int output_cpool_init(output_cpool_t* self, const char* host, const char* port);
 int output_cpool_destroy(output_cpool_t* self);
-void output_cpool_updatelog(output_cpool_t* self);
 size_t output_cpool_max_clients(output_cpool_t* self);
 int output_cpool_set_max_clients(output_cpool_t* self, size_t max_clients);
 double output_cpool_client_ttl(output_cpool_t* self);

--- a/src/output/cpool.lua
+++ b/src/output/cpool.lua
@@ -34,7 +34,6 @@
 module(...,package.seeall)
 
 local ch = require("dnsjit.core.chelpers")
-local log = require("dnsjit.core.log")
 require("dnsjit.output.cpool_h")
 local ffi = require("ffi")
 local C = ffi.C
@@ -67,16 +66,17 @@ local Cpool = {}
 -- Create a new Cpool output.
 function Cpool.new(host, port)
     local o = struct.new(host, port)
-    local log = log.new(o.log)
-    log:cb(function ()
-        C.output_cpool_updatelog(o)
-    end)
-    log:debug("new()")
-    C.output_cpool_updatelog(o)
     return setmetatable({
         _ = o,
-        log = log,
     }, {__index = Cpool})
+end
+
+-- Return the Log object to control logging of this instance or module.
+function Cpool:log()
+    if self == nil then
+        return C.output_cpool_log()
+    end
+    return self._._log
 end
 
 -- Set the maximum clients to emulate, if
@@ -173,7 +173,7 @@ function Cpool:receive()
     if self.ishandler then
         error("is handler")
     end
-    self.log:debug("receive()")
+    self._._log:debug("receive()")
     return C.output_cpool_receiver(), self._
 end
 

--- a/src/output/cpool/client_pool.h
+++ b/src/output/cpool/client_pool.h
@@ -84,7 +84,7 @@ struct client_pool {
 
     client_pool_sendas_t sendas;
 
-    log_t log;
+    log_t* _log;
 };
 
 client_pool_t* client_pool_new(const char* host, const char* port);

--- a/src/output/null.h
+++ b/src/output/null.h
@@ -18,7 +18,6 @@
  * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "core/log.h"
 #include "core/receiver.h"
 
 #ifndef __dnsjit_output_null_h

--- a/src/output/null.hh
+++ b/src/output/null.hh
@@ -18,10 +18,8 @@
  * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-//lua:require("dnsjit.core.log_h")
 //lua:require("dnsjit.core.receiver_h")
 typedef struct output_null {
-    log_t  log;
     size_t pkts;
 } output_null_t;
 

--- a/src/output/null.lua
+++ b/src/output/null.lua
@@ -23,7 +23,6 @@
 -- Output module for those that doesn't really like queries.
 module(...,package.seeall)
 
-local log = require("dnsjit.core.log")
 require("dnsjit.output.null_h")
 local ffi = require("ffi")
 local C = ffi.C
@@ -48,16 +47,12 @@ local Null = {}
 -- Create a new Null output.
 function Null.new()
     local o = struct.new()
-    local log = log.new(o.log)
-    log:debug("new()")
     return setmetatable({
         _ = o,
-        log = log,
     }, {__index = Null})
 end
 
 function Null:receive()
-    self.log:debug("receive()")
     return C.output_null_receiver(), self._
 end
 


### PR DESCRIPTION
- Fix #5: Logging can now be configured globally, module wise or just for one object instance
- Rearrange Makefile to better see Lua headers, sources and documentation only sources
- `gen-manpage.lua`: Lines with `-- .` are converted into an empty line, for adding spaces between sections more easily.