### PR TITLE
Logging, cpool and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ set and may be changed or removed.
 
 The following Lua module categories exists:
 - `dnsjit.core`: Core modules for handling things like logging, DNS messages and receiver/receive functionality.
+- `dnsjit.lib`: Various Lua libraries or C library bindings.
 - `dnsjit.input`: Input modules used to read DNS messages in various ways.
 - `dnsjit.filter`: Filter modules to process or manipulate DNS messages.
 - `dnsjit.output`: Output modules used to display DNS message, export to various formats or replay them against other targets.
@@ -60,6 +61,7 @@ access them, after building you can do:
 ```shell
 man src/dnsjit.1
 man src/dnsjit.core.3
+man src/dnsjit.lib.3
 man src/dnsjit.input.3
 man src/dnsjit.filter.3
 man src/dnsjit.output.3

--- a/examples/replay.lua
+++ b/examples/replay.lua
@@ -14,6 +14,8 @@ local output = require("dnsjit.output.cpool").new(host, port)
 input:only_queries(true)
 input:open_offline(pcap)
 
+output:skip_reply(true)
+
 input:receiver(output)
 
 output:start()

--- a/src/dnsjit.1in
+++ b/src/dnsjit.1in
@@ -57,6 +57,9 @@ dnsjit.core
 Core modules for handling things like logging, DNS messages and
 receiver/receive functionality.
 .TP
+dnsjit.lib
+Various Lua libraries or C library bindings.
+.TP
 dnsjit.input
 Input modules used to read DNS messages in various ways.
 .TP
@@ -88,6 +91,7 @@ See more examples in the
 directory.
 .SH SEE ALSO
 .BR dnsjit.core (3),
+.BR dnsjit.lib (3),
 .BR dnsjit.input (3),
 .BR dnsjit.filter (3),
 .BR dnsjit.output (3)

--- a/src/filter/lua.c
+++ b/src/filter/lua.c
@@ -43,7 +43,8 @@ int filter_lua_init(filter_lua_t* self)
     }
 
     *self = _defaults;
-    ldebug("init", self);
+
+    ldebug("init");
 
     if (!(self->L = luaL_newstate())) {
         return 1;
@@ -65,7 +66,7 @@ int filter_lua_destroy(filter_lua_t* self)
         return 1;
     }
 
-    ldebug("destroy %p", self);
+    ldebug("destroy");
 
     lua_close(self->L);
 
@@ -78,7 +79,7 @@ int filter_lua_func(filter_lua_t* self, const char* bc, size_t len)
         return 1;
     }
 
-    ldebug("func %p %p %lu", self, bc, len);
+    ldebug("func %p %lu", bc, len);
 
     if (self->recv) {
         ldebug("func recv %p %p", self->recv, self->robj);

--- a/src/filter/roundrobin.c
+++ b/src/filter/roundrobin.c
@@ -38,9 +38,9 @@ int filter_roundrobin_init(filter_roundrobin_t* self)
         return 1;
     }
 
-    ldebug("init %p", self);
-
     *self = _defaults;
+
+    ldebug("init");
 
     return 0;
 }
@@ -52,7 +52,7 @@ int filter_roundrobin_destroy(filter_roundrobin_t* self)
         return 1;
     }
 
-    ldebug("destroy %p", self);
+    ldebug("destroy");
 
     while ((r = self->recv_list)) {
         self->recv_list = r->next;
@@ -69,7 +69,7 @@ int filter_roundrobin_add(filter_roundrobin_t* self, receiver_t recv, void* robj
         return 1;
     }
 
-    ldebug("add %p %p %p", self, recv, robj);
+    ldebug("add recv %p obj %p", recv, robj);
 
     if (!(r = malloc(sizeof(filter_roundrobin_recv_t)))) {
         return 1;

--- a/src/filter/thread.c
+++ b/src/filter/thread.c
@@ -47,9 +47,9 @@ int filter_thread_init(filter_thread_t* self)
         return 1;
     }
 
-    ldebug("new %p", self);
-
     *self = _defaults;
+
+    ldebug("init");
 
     return 0;
 }
@@ -65,7 +65,7 @@ int filter_thread_destroy(filter_thread_t* self)
         return 1;
     }
 
-    ldebug("destroy %p", self);
+    ldebug("destroy");
 
     if (self->have_id) {
         filter_thread_stop(self);
@@ -131,7 +131,7 @@ int filter_thread_create(filter_thread_t* self, const char* bc, size_t len)
         return 1;
     }
 
-    ldebug("create %p %p %lu", self, bc, len);
+    ldebug("create %p %lu", bc, len);
 
     if (!self->id) {
         if (!(self->id = malloc(sizeof(pthread_t)))) {
@@ -159,7 +159,7 @@ int filter_thread_create(filter_thread_t* self, const char* bc, size_t len)
     ctx->recv = self->recv;
     ctx->robj = self->robj;
 
-    ldebug("create %p qin %p", self, self->qin);
+    ldebug("create qin %p", self->qin);
 
     if (pthread_create(self->id, 0, _thread, (void*)ctx)) {
         free(ctx->bc);
@@ -168,7 +168,7 @@ int filter_thread_create(filter_thread_t* self, const char* bc, size_t len)
     }
     self->have_id = 1;
 
-    ldebug("create %p id %lu", self, *self->id);
+    ldebug("create id %lu", *self->id);
 
     return 0;
 }
@@ -179,7 +179,7 @@ int filter_thread_join(filter_thread_t* self)
         return 1;
     }
 
-    ldebug("join %p %lu", self, *self->id);
+    ldebug("join %lu", *self->id);
 
     if (pthread_join(*self->id, 0)) {
         return 1;
@@ -198,7 +198,7 @@ int filter_thread_stop(filter_thread_t* self)
         return 1;
     }
 
-    ldebug("stop %p", self);
+    ldebug("stop");
 
     err = SLLQ_EAGAIN;
     while (err == SLLQ_EAGAIN || err == SLLQ_ETIMEDOUT || err == SLLQ_FULL) {
@@ -214,7 +214,7 @@ int filter_thread_stop(filter_thread_t* self)
         err = sllq_push(self->qin, (void*)&_stop, &ts);
     }
 
-    ldebug("stopped %p", self);
+    ldebug("stopped");
 
     return 0;
 }
@@ -231,7 +231,7 @@ static int _receive(void* robj, query_t* q)
         return 1;
     }
 
-    ldebug("push %p q %p copy %p", self, q, copy);
+    ldebug("push q %p copy %p", q, copy);
 
     err = SLLQ_EAGAIN;
     while (err == SLLQ_EAGAIN || err == SLLQ_ETIMEDOUT || err == SLLQ_FULL) {
@@ -249,7 +249,7 @@ static int _receive(void* robj, query_t* q)
         err = sllq_push(self->qin, (void*)copy, &ts);
     }
 
-    ldebug("pushed %p q %p", self, q);
+    ldebug("pushed q %p", q);
 
     query_free(q);
     return 0;
@@ -270,7 +270,7 @@ query_t* filter_thread_recv(filter_thread_t* self)
         return 0;
     }
 
-    ldebug("recv %p", self);
+    ldebug("recv");
 
     err = SLLQ_EAGAIN;
     while (err == SLLQ_EAGAIN || err == SLLQ_ETIMEDOUT || err == SLLQ_EMPTY) {
@@ -287,11 +287,11 @@ query_t* filter_thread_recv(filter_thread_t* self)
     }
 
     if (q == &_stop) {
-        ldebug("recv %p stop", self);
+        ldebug("recv stop");
         return 0;
     }
 
-    ldebug("recv %p q %p", self, q);
+    ldebug("recv q %p", q);
     return q;
 }
 
@@ -307,7 +307,7 @@ int filter_thread_send(filter_thread_t* self, query_t* q)
         return 1;
     }
 
-    ldebug("send %p q %p copy %p", self, q, copy);
+    ldebug("send q %p copy %p", q, copy);
     self->recv(self->robj, copy);
 
     return 0;

--- a/src/filter/timing.c
+++ b/src/filter/timing.c
@@ -43,9 +43,9 @@ int filter_timing_init(filter_timing_t* self)
         return 1;
     }
 
-    ldebug("init %p", self);
-
     *self = _defaults;
+
+    ldebug("init");
 
     return 0;
 }
@@ -56,7 +56,7 @@ int filter_timing_destroy(filter_timing_t* self)
         return 1;
     }
 
-    ldebug("destroy %p", self);
+    ldebug("destroy");
 
     return 0;
 }

--- a/src/input/pcap.c
+++ b/src/input/pcap.c
@@ -235,7 +235,7 @@ int input_pcap_destroy(input_pcap_t* self)
         return 1;
     }
 
-    ldebug("destroy %p", self);
+    ldebug("destroy");
 
     pcap_thread_free(self->pt);
 
@@ -248,7 +248,7 @@ int input_pcap_open(input_pcap_t* self, const char* device)
         return 1;
     }
 
-    ldebug("open %p %s", self, device);
+    ldebug("open %s", device);
 
     if ((self->err = pcap_thread_open(self->pt, device, (void*)self)) != PCAP_THREAD_OK) {
         return 1;
@@ -263,7 +263,7 @@ int input_pcap_open_offline(input_pcap_t* self, const char* file)
         return 1;
     }
 
-    ldebug("open_offline %p %s", self, file);
+    ldebug("open_offline %s", file);
 
     if ((self->err = pcap_thread_open_offline(self->pt, file, (void*)self)) != PCAP_THREAD_OK) {
         return 1;
@@ -279,7 +279,7 @@ int input_pcap_run(input_pcap_t* self)
         return 1;
     }
 
-    ldebug("run %p", self);
+    ldebug("run");
 
     clock_gettime(CLOCK_MONOTONIC, &ts);
     if ((self->err = pcap_thread_run(self->pt)) != PCAP_THREAD_OK) {
@@ -301,7 +301,7 @@ int input_pcap_next(input_pcap_t* self)
         return 1;
     }
 
-    ldebug("next %p", self);
+    ldebug("next");
 
     if ((self->err = pcap_thread_next(self->pt)) != PCAP_THREAD_OK) {
         return 1;

--- a/src/lib.lua
+++ b/src/lib.lua
@@ -17,10 +17,11 @@
 -- along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
 
 -- dnsjit.lib
--- Various helpful libraries
+-- Various Lua libraries or C library bindings
 module(...,package.seeall)
 
 error("This should not be included, only here for documentation generation")
 
--- dnsjit.lib.getopt (3)
+-- dnsjit.lib.getopt (3),
+-- dnsjit.lib.parseconf (3)
 return

--- a/src/lib/getopt.lua
+++ b/src/lib/getopt.lua
@@ -23,7 +23,9 @@
 --       { nil, "host", "localhost", "Set host", "?" },
 --       { "p", nil, 53, "Set port", "?" },
 --   })
+-- .
 --   local left = getopt:parse()
+-- .
 --   print("host", getopt:val("host"))
 --   print("port", getopt:val("p"))
 --

--- a/src/lib/parseconf.lua
+++ b/src/lib/parseconf.lua
@@ -19,10 +19,13 @@
 -- dnsjit.lib.parseconf
 -- Parse simple config files
 --   local conf = require("dnsjit.lib.parseconf").new()
+-- .
 --   conf:func("config_name", function(k,...)
 --       print(k,...)
 --   end)
+-- .
 --   conf:parse(file)
+-- .
 --   print(conf:val("another_config_name"))
 --
 -- This module parses simple config files that are based on the config

--- a/src/output/cpool.c
+++ b/src/output/cpool.c
@@ -33,17 +33,17 @@ log_t* output_cpool_log()
     return &_log;
 }
 
-int output_cpool_init(output_cpool_t* self, const char* host, const char* port)
+int output_cpool_init(output_cpool_t* self, const char* host, const char* port, size_t queue_size)
 {
     if (!self || !host || !port) {
         return 1;
     }
 
-    ldebug("init %p %s %s", self, host, port);
-
     *self = _defaults;
 
-    if (!(self->p = client_pool_new(host, port))) {
+    ldebug("init %s %s %lu", host, port, queue_size);
+
+    if (!(self->p = client_pool_new(host, port, queue_size))) {
         lfatal("oom");
     }
     self->p->_log = &self->_log;
@@ -57,7 +57,7 @@ int output_cpool_destroy(output_cpool_t* self)
         return 1;
     }
 
-    ldebug("destroy %p", self);
+    ldebug("destroy");
 
     client_pool_free(self->p);
 
@@ -79,7 +79,7 @@ int output_cpool_set_max_clients(output_cpool_t* self, size_t max_clients)
         return 1;
     }
 
-    ldebug("max_clients %p %lu", self, max_clients);
+    ldebug("max_clients %lu", max_clients);
 
     self->p->max_clients = max_clients;
 
@@ -101,7 +101,7 @@ int output_cpool_set_client_ttl(output_cpool_t* self, double client_ttl)
         return 1;
     }
 
-    ldebug("client_ttl %p %f", self, client_ttl);
+    ldebug("client_ttl %f", client_ttl);
 
     self->p->client_ttl = client_ttl;
 
@@ -123,7 +123,7 @@ int output_cpool_set_max_reuse_clients(output_cpool_t* self, size_t max_reuse_cl
         return 1;
     }
 
-    ldebug("max_reuse_clients %p %lu", self, max_reuse_clients);
+    ldebug("max_reuse_clients %lu", max_reuse_clients);
 
     self->p->max_reuse_clients = max_reuse_clients;
 
@@ -145,7 +145,7 @@ int output_cpool_set_skip_reply(output_cpool_t* self, int skip_reply)
         return 1;
     }
 
-    ldebug("skip_reply %p %lu", self, skip_reply);
+    ldebug("skip_reply %lu", skip_reply);
 
     self->p->client_skip_reply = skip_reply ? 1 : 0;
 
@@ -178,7 +178,7 @@ int output_cpool_set_sendas_original(output_cpool_t* self)
         return 1;
     }
 
-    ldebug("sendas original %p", self);
+    ldebug("sendas original");
 
     self->p->sendas = CLIENT_POOL_SENDAS_ORIGINAL;
 
@@ -191,7 +191,7 @@ int output_cpool_set_sendas_udp(output_cpool_t* self)
         return 1;
     }
 
-    ldebug("sendas udp %p", self);
+    ldebug("sendas udp");
 
     self->p->sendas = CLIENT_POOL_SENDAS_ORIGINAL;
 
@@ -204,7 +204,7 @@ int output_cpool_set_sendas_tcp(output_cpool_t* self)
         return 1;
     }
 
-    ldebug("sendas tcp %p", self);
+    ldebug("sendas tcp");
 
     self->p->sendas = CLIENT_POOL_SENDAS_ORIGINAL;
 
@@ -226,7 +226,7 @@ int output_cpool_set_dry_run(output_cpool_t* self, int dry_run)
         return 1;
     }
 
-    ldebug("dry_run %p %lu", self, dry_run);
+    ldebug("dry_run %lu", dry_run);
 
     self->p->dry_run = dry_run ? 1 : 0;
 

--- a/src/output/cpool.hh
+++ b/src/output/cpool.hh
@@ -29,7 +29,7 @@ typedef struct output_cpool {
 } output_cpool_t;
 
 log_t* output_cpool_log();
-int output_cpool_init(output_cpool_t* self, const char* host, const char* port);
+int output_cpool_init(output_cpool_t* self, const char* host, const char* port, size_t queue_size);
 int output_cpool_destroy(output_cpool_t* self);
 size_t output_cpool_max_clients(output_cpool_t* self);
 int output_cpool_set_max_clients(output_cpool_t* self, size_t max_clients);

--- a/src/output/cpool.lua
+++ b/src/output/cpool.lua
@@ -47,13 +47,13 @@ local mt = {
         end
     end,
     __index = {
-        new = function(host, port)
+        new = function(host, port, queue_size)
             local self = struct()
             if not self then
                 error("oom")
             end
             if ffi.istype(type, self) then
-                C.output_cpool_init(self, host, port)
+                C.output_cpool_init(self, host, port, queue_size)
                 return self
             end
         end
@@ -63,9 +63,16 @@ struct = ffi.metatype(type, mt)
 
 local Cpool = {}
 
--- Create a new Cpool output.
-function Cpool.new(host, port)
-    local o = struct.new(host, port)
+-- Create a new Cpool output for the target
+-- .I host
+-- and
+-- .I port
+-- with an optional queue size.
+function Cpool.new(host, port, queue_size)
+    if queue_size == nil then
+        queue_size = 0
+    end
+    local o = struct.new(host, port, queue_size)
     return setmetatable({
         _ = o,
     }, {__index = Cpool})

--- a/src/output/cpool/client.c
+++ b/src/output/cpool/client.c
@@ -37,7 +37,7 @@
 static void client_shutdown(struct ev_loop* loop, ev_io* w, int revents)
 {
     client_t* client;
-    char      buf[512];
+    char      buf[4 * 1024];
 
     /* TODO: Check revents for EV_ERROR */
 
@@ -58,7 +58,7 @@ static void client_read(struct ev_loop* loop, ev_io* w, int revents)
 {
     client_t* client;
     ssize_t   nrecv;
-    char      buf[64 * 1024];
+    char      buf[4 * 1024];
 
     /* TODO: Check revents for EV_ERROR */
 

--- a/src/output/cpool/client_pool.h
+++ b/src/output/cpool/client_pool.h
@@ -87,7 +87,7 @@ struct client_pool {
     log_t* _log;
 };
 
-client_pool_t* client_pool_new(const char* host, const char* port);
+client_pool_t* client_pool_new(const char* host, const char* port, size_t queue_size);
 void client_pool_free(client_pool_t* client_pool);
 int client_pool_start(client_pool_t* client_pool);
 int client_pool_stop(client_pool_t* client_pool);


### PR DESCRIPTION
- Fix debug logging, remove `self` pointer output
- `dnsjit.output.cpool`:
  - Add SLLQ queue size to `new`, optional value
  - Remove static settings, send as UDP and skip replies
  - Changed buffers in client shutdown and read
- Add reference to `dnsjit.lib` in README and `dnsjit (1)`
- `dnsjit.lib`: Add reference to `parseconf`
- `dnsjit.lib.getopt` and `dnsjit.lib.parseconf`: Add spacing to synopsis