### PR TITLE
Source and query tracking

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -31,7 +31,7 @@ EXTRA_DIST = gen-manpage.lua dnsjit.1in
 bin_PROGRAMS = dnsjit
 
 dnsjit_SOURCES = dnsjit.c \
-    core/log.c core/mutex.c core/query.c core/receiver.c \
+    core/log.c core/mutex.c core/query.c core/receiver.c core/tracking.c \
     input/pcap.c \
 	filter/lua.c filter/roundrobin.c filter/thread.c filter/timing.c \
     output/cpool.c output/null.c \
@@ -40,7 +40,7 @@ dnsjit_SOURCES = dnsjit.c \
     sllq/sllq.c \
 	output/cpool/client_pool.c output/cpool/client.c
 dist_dnsjit_SOURCES = \
-    core/log.h core/mutex.h core/query.h core/receiver.h core/timespec.h \
+    core/log.h core/mutex.h core/query.h core/receiver.h core/timespec.h core/tracking.h \
     input/pcap.h \
 	filter/lua.h filter/roundrobin.h filter/thread.h filter/timing.h \
     output/cpool.h output/null.h \
@@ -52,24 +52,24 @@ dnsjit_LDADD = $(PTHREAD_LIBS) $(luajit_LIBS)
 
 # Lua headers
 dist_dnsjit_SOURCES += \
-	core/log.hh core/mutex.hh core/query.hh core/receiver.hh core/timespec.hh \
+	core/log.hh core/mutex.hh core/query.hh core/receiver.hh core/timespec.hh core/tracking.hh \
     input/pcap.hh \
 	filter/lua.hh filter/roundrobin.hh filter/thread.hh filter/timing.hh \
     output/cpool.hh output/null.hh
 lua_hobjects = \
-	core/log.luaho core/mutex.luaho core/query.luaho core/receiver.luaho core/timespec.luaho \
+	core/log.luaho core/mutex.luaho core/query.luaho core/receiver.luaho core/timespec.luaho core/tracking.luaho \
     input/pcap.luaho \
 	filter/lua.luaho filter/roundrobin.luaho filter/thread.luaho filter/timing.luaho \
     output/cpool.luaho output/null.luaho
 # Lua sources
 dist_dnsjit_SOURCES += \
-	core/chelpers.lua core/log.lua core/mutex.lua core/query.lua \
+	core/chelpers.lua core/log.lua core/mutex.lua core/query.lua core/tracking.lua \
 	lib/getopt.lua lib/parseconf.lua \
     input/lua.lua input/pcap.lua \
 	filter/lua.lua filter/roundrobin.lua filter/thread.lua filter/timing.lua \
     output/cpool.lua output/null.lua
 lua_objects = \
-	core/chelpers.luao core/log.luao core/mutex.luao core/query.luao \
+	core/chelpers.luao core/log.luao core/mutex.luao core/query.luao core/tracking.luao \
 	lib/getopt.luao lib/parseconf.luao \
     input/lua.luao input/pcap.luao \
 	filter/lua.luao filter/roundrobin.luao filter/thread.luao filter/timing.luao \
@@ -88,7 +88,7 @@ CLEANFILES += $(lua_hobjects) $(lua_objects)
 man1_MANS = dnsjit.1
 CLEANFILES += $(man1_MANS)
 
-man3_MANS = dnsjit.core.3 dnsjit.core.chelpers.3 dnsjit.core.log.3 dnsjit.core.mutex.3 dnsjit.core.query.3 dnsjit.core.receiver.3 dnsjit.core.timespec.3 \
+man3_MANS = dnsjit.core.3 dnsjit.core.chelpers.3 dnsjit.core.log.3 dnsjit.core.mutex.3 dnsjit.core.query.3 dnsjit.core.receiver.3 dnsjit.core.timespec.3 dnsjit.core.tracking.3 \
     dnsjit.lib.3 dnsjit.lib.getopt.3 dnsjit.lib.parseconf.3 \
     dnsjit.input.3 dnsjit.input.lua.3 dnsjit.input.pcap.3 \
 	dnsjit.filter.3 dnsjit.filter.lua.3 dnsjit.filter.roundrobin.3 dnsjit.filter.thread.3 dnsjit.filter.timing.3 \
@@ -142,6 +142,9 @@ dnsjit.core.receiver.3in: core/receiver.lua gen-manpage.lua
 
 dnsjit.core.timespec.3in: core/timespec.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/timespec.lua" > "$@"
+
+dnsjit.core.tracking.3in: core/tracking.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/tracking.lua" > "$@"
 
 
 dnsjit.lib.3in: lib.lua gen-manpage.lua

--- a/src/core.lua
+++ b/src/core.lua
@@ -40,5 +40,6 @@ error("This should not be included, only here for documentation generation")
 -- dnsjit.core.mutex (3),
 -- dnsjit.core.query (3),
 -- dnsjit.core.receiver (3),
--- dnsjit.core.timespec (3)
+-- dnsjit.core.timespec (3),
+-- dnsjit.core.tracking (3)
 return

--- a/src/core/query.c
+++ b/src/core/query.c
@@ -61,6 +61,7 @@ typedef struct _query {
 static log_t   _log      = LOG_T_INIT("core.query");
 static query_t _defaults = {
     LOG_T_INIT_OBJ("core.query"),
+    0, 0,
     0, 0, 0, 0,
     0, 0, { 0, 0 },
     "", 0, 0,

--- a/src/core/query.hh
+++ b/src/core/query.hh
@@ -23,6 +23,8 @@
 typedef struct query {
     log_t _log;
 
+    uint64_t sid, qid;
+
     unsigned short is_udp : 1;
     unsigned short is_tcp : 1;
     unsigned short is_ipv6 : 1;

--- a/src/core/query.lua
+++ b/src/core/query.lua
@@ -86,6 +86,28 @@ function Query:dst()
     return ffi.string(C.query_dst(self._))
 end
 
+-- Return or set the source ID, used to track the unique source of the
+-- query.
+-- See also
+-- .BR dnsjit.core.tracking (3).
+function Query:sid(sid)
+    if sid == nil then
+        return self._.sid
+    end
+    self._.sid = sid
+end
+
+-- Return or set the query ID, used to track the unique query from a
+-- source.
+-- See also
+-- .BR dnsjit.core.tracking (3).
+function Query:qid(qid)
+    if qid == nil then
+        return self._.qid
+    end
+    self._.qid = qid
+end
+
 -- Return the source port.
 function Query:sport()
     return self._.sport
@@ -302,4 +324,5 @@ function Query:rr_ttl()
     return C.query_rr_ttl(self._)
 end
 
+-- dnsjit.core.tracking (3)
 return Query

--- a/src/core/tracking.c
+++ b/src/core/tracking.c
@@ -18,11 +18,36 @@
  * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
+
+#include "core/tracking.h"
 #include "core/log.h"
 
-#ifndef __dnsjit_core_mutex_h
-#define __dnsjit_core_mutex_h
+#include <pthread.h>
 
-#include "core/mutex.hh"
+static log_t           _log   = LOG_T_INIT("core.tracking");
+static pthread_mutex_t _mutex = PTHREAD_MUTEX_INITIALIZER;
+static uint64_t        _sid   = 1;
 
-#endif
+log_t* core_tracking_log()
+{
+    return &_log;
+}
+
+uint64_t core_tracking_new_sid()
+{
+    uint64_t sid;
+
+    if (pthread_mutex_lock(&_mutex)) {
+        return 0;
+    }
+    if (!_sid) {
+        /* 0 is error */
+        _sid++;
+    }
+    sid = _sid++;
+    if (pthread_mutex_unlock(&_mutex)) {
+        return 0;
+    }
+    return sid;
+}

--- a/src/core/tracking.h
+++ b/src/core/tracking.h
@@ -20,9 +20,11 @@
 
 #include "core/log.h"
 
-#ifndef __dnsjit_core_mutex_h
-#define __dnsjit_core_mutex_h
+#ifndef __dnsjit_core_tracking_h
+#define __dnsjit_core_tracking_h
 
-#include "core/mutex.hh"
+#include <stdint.h>
+
+#include "core/tracking.hh"
 
 #endif

--- a/src/core/tracking.hh
+++ b/src/core/tracking.hh
@@ -18,11 +18,7 @@
  * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "core/log.h"
+//Lua:require("dnsjit.core.log")
+log_t* core_tracking_log();
 
-#ifndef __dnsjit_core_mutex_h
-#define __dnsjit_core_mutex_h
-
-#include "core/mutex.hh"
-
-#endif
+uint64_t core_tracking_new_sid();

--- a/src/core/tracking.lua
+++ b/src/core/tracking.lua
@@ -1,0 +1,53 @@
+-- Copyright (c) 2018, OARC, Inc.
+-- All rights reserved.
+--
+-- This file is part of dnsjit.
+--
+-- dnsjit is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- dnsjit is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+
+-- dnsjit.core.tracking
+-- Core functions for tracking input sources
+--   local tracking = require("dnsjit.core.tracking")
+--   local source_id = tracking.new_sid()
+--
+-- Provide a thread safe way of getting an unique ID for an input source,
+-- used together with Query ID
+-- .I qid
+-- to track input sources and queries along the process chain.
+module(...,package.seeall)
+
+require("dnsjit.core.tracking_h")
+local C = require("ffi").C
+
+Tracking = {}
+
+-- Return the Log object to control logging of this module.
+function Tracking.log()
+    return C.core_tracking_log()
+end
+
+-- Return a new source ID, used for tracking queries.
+-- This function is thread safe and uses mutex to keep the ID unique.
+-- See also
+-- .BR dnsjit.core.query (3)
+-- functions
+-- .B sid()
+-- and
+-- .BR qid() .
+function Tracking.new_sid()
+    return C.core_tracking_new_sid()
+end
+
+-- dnsjit.core.query (3)
+return Tracking

--- a/src/input/pcap.hh
+++ b/src/input/pcap.hh
@@ -55,6 +55,8 @@ typedef struct input_pcap {
     timespec_t     ts, te;
     size_t         pkts, drop, ignore, queries;
     int            err;
+    uint64_t       sid;
+    uint64_t       qid;
 } input_pcap_t;
 
 log_t* input_pcap_log();


### PR DESCRIPTION
- Fix #6: Add `dnsjit.core.tracking` to track input sources
- `dnsjit.core.query`: Add source id `sid` and query id `qid`
- `dnsjit.input.pcap`: Use `dnsjit.core.tracking` to get a unique source ID for each module instance and keep an own query ID for each query created
- `dnsjit.core.mutex`: Fix include, project headers should be included outside header defines