### PR TITLE
Multicopy

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -33,7 +33,7 @@ bin_PROGRAMS = dnsjit
 dnsjit_SOURCES = dnsjit.c \
     core/log.c core/mutex.c core/query.c core/receiver.c core/tracking.c \
     input/pcap.c \
-	filter/lua.c filter/roundrobin.c filter/thread.c filter/timing.c \
+	filter/lua.c filter/multicopy.c filter/roundrobin.c filter/thread.c filter/timing.c \
     output/cpool.c output/null.c \
     omg-dns/omg_dns.c \
     pcap-thread/pcap_thread.c \
@@ -42,7 +42,7 @@ dnsjit_SOURCES = dnsjit.c \
 dist_dnsjit_SOURCES = \
     core/log.h core/mutex.h core/query.h core/receiver.h core/timespec.h core/tracking.h \
     input/pcap.h \
-	filter/lua.h filter/roundrobin.h filter/thread.h filter/timing.h \
+	filter/lua.h filter/multicopy.h filter/roundrobin.h filter/thread.h filter/timing.h \
     output/cpool.h output/null.h \
     omg-dns/omg_dns.h \
     pcap-thread/pcap_thread.h \
@@ -54,25 +54,25 @@ dnsjit_LDADD = $(PTHREAD_LIBS) $(luajit_LIBS)
 dist_dnsjit_SOURCES += \
 	core/log.hh core/mutex.hh core/query.hh core/receiver.hh core/timespec.hh core/tracking.hh \
     input/pcap.hh \
-	filter/lua.hh filter/roundrobin.hh filter/thread.hh filter/timing.hh \
+	filter/lua.hh filter/multicopy.hh filter/roundrobin.hh filter/thread.hh filter/timing.hh \
     output/cpool.hh output/null.hh
 lua_hobjects = \
 	core/log.luaho core/mutex.luaho core/query.luaho core/receiver.luaho core/timespec.luaho core/tracking.luaho \
     input/pcap.luaho \
-	filter/lua.luaho filter/roundrobin.luaho filter/thread.luaho filter/timing.luaho \
+	filter/lua.luaho filter/multicopy.luaho filter/roundrobin.luaho filter/thread.luaho filter/timing.luaho \
     output/cpool.luaho output/null.luaho
 # Lua sources
 dist_dnsjit_SOURCES += \
 	core/chelpers.lua core/log.lua core/mutex.lua core/query.lua core/tracking.lua \
 	lib/getopt.lua lib/parseconf.lua \
     input/lua.lua input/pcap.lua \
-	filter/lua.lua filter/roundrobin.lua filter/thread.lua filter/timing.lua \
+	filter/lua.lua filter/multicopy.lua filter/roundrobin.lua filter/thread.lua filter/timing.lua \
     output/cpool.lua output/null.lua
 lua_objects = \
 	core/chelpers.luao core/log.luao core/mutex.luao core/query.luao core/tracking.luao \
 	lib/getopt.luao lib/parseconf.luao \
     input/lua.luao input/pcap.luao \
-	filter/lua.luao filter/roundrobin.luao filter/thread.luao filter/timing.luao \
+	filter/lua.luao filter/multicopy.luao filter/roundrobin.luao filter/thread.luao filter/timing.luao \
     output/cpool.luao output/null.luao
 # Documentation only sources
 dist_dnsjit_SOURCES += \
@@ -91,7 +91,7 @@ CLEANFILES += $(man1_MANS)
 man3_MANS = dnsjit.core.3 dnsjit.core.chelpers.3 dnsjit.core.log.3 dnsjit.core.mutex.3 dnsjit.core.query.3 dnsjit.core.receiver.3 dnsjit.core.timespec.3 dnsjit.core.tracking.3 \
     dnsjit.lib.3 dnsjit.lib.getopt.3 dnsjit.lib.parseconf.3 \
     dnsjit.input.3 dnsjit.input.lua.3 dnsjit.input.pcap.3 \
-	dnsjit.filter.3 dnsjit.filter.lua.3 dnsjit.filter.roundrobin.3 dnsjit.filter.thread.3 dnsjit.filter.timing.3 \
+	dnsjit.filter.3 dnsjit.filter.lua.3 dnsjit.filter.multicopy.3 dnsjit.filter.roundrobin.3 dnsjit.filter.thread.3 dnsjit.filter.timing.3 \
 	dnsjit.output.3 dnsjit.output.cpool.3 dnsjit.output.null.3
 CLEANFILES += *.3in $(man3_MANS)
 
@@ -172,6 +172,9 @@ dnsjit.filter.3in: filter.lua gen-manpage.lua
 
 dnsjit.filter.lua.3in: filter/lua.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/filter/lua.lua" > "$@"
+
+dnsjit.filter.multicopy.3in: filter/multicopy.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/filter/multicopy.lua" > "$@"
 
 dnsjit.filter.roundrobin.3in: filter/roundrobin.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/filter/roundrobin.lua" > "$@"

--- a/src/filter.lua
+++ b/src/filter.lua
@@ -25,6 +25,7 @@ module(...,package.seeall)
 error("This should not be included, only here for documentation generation")
 
 -- dnsjit.filter.lua (3),
+-- dnsjit.filter.multicopy (3),
 -- dnsjit.filter.roundrobin (3),
 -- dnsjit.filter.thread (3),
 -- dnsjit.filter.timing (3)

--- a/src/filter/multicopy.c
+++ b/src/filter/multicopy.c
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "filter/multicopy.h"
+
+static log_t              _log      = LOG_T_INIT("filter.multicopy");
+static filter_multicopy_t _defaults = {
+    LOG_T_INIT_OBJ("filter.multicopy"), 0
+};
+
+log_t* filter_multicopy_log()
+{
+    return &_log;
+}
+
+int filter_multicopy_init(filter_multicopy_t* self)
+{
+    if (!self) {
+        return 1;
+    }
+
+    *self = _defaults;
+
+    ldebug("init");
+
+    return 0;
+}
+
+int filter_multicopy_destroy(filter_multicopy_t* self)
+{
+    filter_multicopy_recv_t* r;
+    if (!self) {
+        return 1;
+    }
+
+    ldebug("destroy");
+
+    while ((r = self->recv_list)) {
+        self->recv_list = r->next;
+        free(r);
+    }
+
+    return 0;
+}
+
+int filter_multicopy_add(filter_multicopy_t* self, receiver_t recv, void* robj)
+{
+    filter_multicopy_recv_t* r;
+    if (!self) {
+        return 1;
+    }
+
+    ldebug("add recv %p obj %p", recv, robj);
+
+    if (!(r = malloc(sizeof(filter_multicopy_recv_t)))) {
+        return 1;
+    }
+
+    r->next         = self->recv_list;
+    r->recv         = recv;
+    r->robj         = robj;
+    self->recv_list = r;
+
+    return 0;
+}
+
+static int _receive(void* robj, query_t* q)
+{
+    filter_multicopy_t*      self = (filter_multicopy_t*)robj;
+    filter_multicopy_recv_t* r;
+    query_t*                 copy;
+
+    if (!self || !q || !self->recv_list) {
+        query_free(q);
+        return 1;
+    }
+
+    for (r = self->recv_list; r; r = r->next) {
+        if ((copy = query_copy(q))) {
+            r->recv(r->robj, copy);
+        }
+    }
+    query_free(q);
+
+    return 0;
+}
+
+receiver_t filter_multicopy_receiver()
+{
+    return _receive;
+}

--- a/src/filter/multicopy.h
+++ b/src/filter/multicopy.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "core/log.h"
+#include "core/receiver.h"
+
+#ifndef __dnsjit_filter_multicopy_h
+#define __dnsjit_filter_multicopy_h
+
+#include "filter/multicopy.hh"
+
+#endif

--- a/src/filter/multicopy.hh
+++ b/src/filter/multicopy.hh
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//lua:require("dnsjit.core.log")
+//lua:require("dnsjit.core.receiver_h")
+typedef struct filter_multicopy_recv filter_multicopy_recv_t;
+struct filter_multicopy_recv {
+    filter_multicopy_recv_t* next;
+    receiver_t               recv;
+    void*                    robj;
+};
+typedef struct filter_multicopy {
+    log_t                    _log;
+    filter_multicopy_recv_t* recv_list;
+} filter_multicopy_t;
+
+log_t* filter_multicopy_log();
+int filter_multicopy_init(filter_multicopy_t* self);
+int filter_multicopy_destroy(filter_multicopy_t* self);
+int filter_multicopy_add(filter_multicopy_t* self, receiver_t recv, void* robj);
+
+receiver_t filter_multicopy_receiver();

--- a/src/filter/multicopy.lua
+++ b/src/filter/multicopy.lua
@@ -1,0 +1,97 @@
+-- Copyright (c) 2018, OARC, Inc.
+-- All rights reserved.
+--
+-- This file is part of dnsjit.
+--
+-- dnsjit is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- dnsjit is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+
+-- dnsjit.filter.multicopy
+-- Pass a copy of the query to all receivers
+--   local filter = require("dnsjit.filter.multicopy").new()
+-- .
+--   filter.receiver(...)
+--   filter.receiver(...)
+--   filter.receiver(...)
+-- .
+--   input.receiver(filter)
+--
+-- Filter to pass copy of queries to all registered receivers.
+module(...,package.seeall)
+
+require("dnsjit.filter.multicopy_h")
+local ffi = require("ffi")
+local C = ffi.C
+
+local type = "filter_multicopy_t"
+local struct
+local mt = {
+    __gc = function(self)
+        if ffi.istype(type, self) then
+            C.filter_multicopy_destroy(self)
+        end
+    end,
+    __index = {
+        new = function()
+            local self = struct()
+            if not self then
+                error("oom")
+            end
+            if ffi.istype(type, self) then
+                C.filter_multicopy_init(self)
+                return self
+            end
+        end
+    }
+}
+struct = ffi.metatype(type, mt)
+
+local Multicopy = {}
+
+-- Create a new Multicopy filter.
+function Multicopy.new()
+    local o = struct.new()
+    return setmetatable({
+        _ = o,
+        receivers = {},
+    }, {__index = Multicopy})
+end
+
+-- Return the Log object to control logging of this instance or module.
+function Multicopy:log()
+    if self == nil then
+        return C.filter_multicopy_log()
+    end
+    return self._._log
+end
+
+function Multicopy:receive()
+    self._._log:debug("receive()")
+    return C.filter_multicopy_receiver(), self._
+end
+
+-- Set the receiver to pass queries to, this can be called multiple times to
+-- set addtional receivers.
+function Multicopy:receiver(o)
+    self._._log:debug("receiver()")
+    local recv, robj
+    recv, robj = o:receive()
+    local ret = C.filter_multicopy_add(self._, recv, robj)
+    if ret == 0 then
+        table.insert(self.receivers, o)
+        return
+    end
+    return ret
+end
+
+return Multicopy


### PR DESCRIPTION
- Fix #9: Add `dnsjit.filter.multicopy`, a filter to pass copies of queries to all registered receivers