### PR TITLE
Object naming in modules, query `parse()`

### DIFF
--- a/examples/dumpdns.lua
+++ b/examples/dumpdns.lua
@@ -10,30 +10,30 @@ local input = require("dnsjit.input.pcap").new()
 local output = require("dnsjit.filter.lua").new()
 
 output:func(function(filter, query)
-    print(query:src()..":"..query:sport().." -> "..query:dst()..":"..query:dport())
+    print(query:src()..":"..query.sport.." -> "..query:dst()..":"..query.dport)
     if not query:parse() then
-        local n = query:questions()
+        local n = query.questions
         while n > 0 and query:rr_next() == 0 do
             if query:rr_ok() == 1 then
                 print("  qd:", query:rr_class(), query:rr_type(), query:rr_label())
             end
             n = n - 1
         end
-        n = query:answers()
+        n = query.answers
         while n > 0 and query:rr_next() == 0 do
             if query:rr_ok() == 1 then
                 print("  an:", query:rr_class(), query:rr_type(), query:rr_ttl(), query:rr_label())
             end
             n = n - 1
         end
-        n = query:authorities()
+        n = query.authorities
         while n > 0 and query:rr_next() == 0 do
             if query:rr_ok() == 1 then
                 print("  ns:", query:rr_class(), query:rr_type(), query:rr_ttl(), query:rr_label())
             end
             n = n - 1
         end
-        n = query:additionals()
+        n = query.additionals
         while n > 0 and query:rr_next() == 0 do
             if query:rr_ok() == 1 then
                 print("  ar:", query:rr_class(), query:rr_type(), query:rr_ttl(), query:rr_label())

--- a/examples/filter_rcode.lua
+++ b/examples/filter_rcode.lua
@@ -14,8 +14,8 @@ output:push(tonumber(rcode))
 output:func(function(filter, query, args)
     local rcode = unpack(args, 0)
     query:parse()
-    if query:rcode() == rcode then
-        print(query:id(), query:src().." -> "..query:dst())
+    if query.have_rcode == 1 and query.rcode == rcode then
+        print(query.id, query:src().." -> "..query:dst())
     end
 end)
 

--- a/src/core/query.c
+++ b/src/core/query.c
@@ -250,6 +250,37 @@ int core_query_parse(core_query_t* self)
         if (omg_dns_parse(&_self->dns, (const u_char*)(self->raw ? self->raw : self->small), self->len)) {
             return 2;
         }
+
+        self->have_id      = _self->dns.have_id;
+        self->have_qr      = _self->dns.have_qr;
+        self->have_opcode  = _self->dns.have_opcode;
+        self->have_aa      = _self->dns.have_aa;
+        self->have_tc      = _self->dns.have_tc;
+        self->have_rd      = _self->dns.have_rd;
+        self->have_ra      = _self->dns.have_ra;
+        self->have_z       = _self->dns.have_z;
+        self->have_ad      = _self->dns.have_ad;
+        self->have_cd      = _self->dns.have_cd;
+        self->have_rcode   = _self->dns.have_rcode;
+        self->have_qdcount = _self->dns.have_qdcount;
+        self->have_ancount = _self->dns.have_ancount;
+        self->have_nscount = _self->dns.have_nscount;
+        self->have_arcount = _self->dns.have_arcount;
+        self->id           = _self->dns.id;
+        self->qr           = _self->dns.qr;
+        self->opcode       = _self->dns.opcode;
+        self->aa           = _self->dns.aa;
+        self->tc           = _self->dns.tc;
+        self->rd           = _self->dns.rd;
+        self->ra           = _self->dns.ra;
+        self->z            = _self->dns.z;
+        self->ad           = _self->dns.ad;
+        self->cd           = _self->dns.cd;
+        self->rcode        = _self->dns.rcode;
+        self->qdcount      = _self->dns.qdcount;
+        self->ancount      = _self->dns.ancount;
+        self->nscount      = _self->dns.nscount;
+        self->arcount      = _self->dns.arcount;
     } else if (self->len > _self->dns.bytes_parsed) {
         if (omg_dns_parse_body(&_self->dns, (const u_char*)(self->raw ? self->raw : self->small) + _self->dns.bytes_parsed, self->len - _self->dns.bytes_parsed)) {
             return 2;

--- a/src/core/query.lua
+++ b/src/core/query.lua
@@ -20,13 +20,129 @@
 -- Container of a DNS message and related capturing information
 --   local query = require("dnsjit.core.query")
 --   local q = query.new()
---   print(q:src(), q:dst(), q:id())
+--   print(q:src(), q:dst(), q.id, q.rcode)
 --
 -- The core object that is passed between receiver and receivee and describes
 -- a DNS message, how it was captured or generated.
--- .LP
--- .B NOTE
--- it is not common to create this object, it is received from other modules.
+-- .SS Attributes
+-- .TP
+-- sid
+-- Source ID, used to track the unique source of the query.
+-- See also
+-- .BR dnsjit.core.tracking (3).
+-- .TP
+-- qid
+-- Query ID, used to track the unique query from a source.
+-- See also
+-- .BR dnsjit.core.tracking (3).
+-- .TP
+-- sport
+-- Source port.
+-- .TP
+-- dport
+-- Destination port.
+-- .TP
+-- have_id
+-- Set if there is a DNS ID.
+-- .TP
+-- have_qr
+-- Set if there is a QR flag.
+-- .TP
+-- have_opcode
+-- Set if there is an OPCODE.
+-- .TP
+-- have_aa
+-- Set if there is a AA flag.
+-- .TP
+-- have_tc
+-- Set if there is a TC flag.
+-- .TP
+-- have_rd
+-- Set if there is a RD flag.
+-- .TP
+-- have_ra
+-- Set if there is a RA flag.
+-- .TP
+-- have_z
+-- Set if there is a Z flag.
+-- .TP
+-- have_ad
+-- Set if there is a AD flag.
+-- .TP
+-- have_cd
+-- Set if there is a CD flag.
+-- .TP
+-- have_rcode
+-- Set if there is a RCODE.
+-- .TP
+-- have_qdcount
+-- Set if there is an QDCOUNT.
+-- .TP
+-- have_ancount
+-- Set if there is an ANCOUNT.
+-- .TP
+-- have_nscount
+-- Set if there is a NSCOUNT.
+-- .TP
+-- have_arcount
+-- Set if there is an ARCOUNT.
+-- .TP
+-- id
+-- The DNS ID.
+-- .TP
+-- qr
+-- The QR flag.
+-- .TP
+-- opcode
+-- The OPCODE.
+-- .TP
+-- aa
+-- The AA flag.
+-- .TP
+-- tc
+-- The TC flag.
+-- .TP
+-- rd
+-- The RD flag.
+-- .TP
+-- ra
+-- The RA flag.
+-- .TP
+-- z
+-- The Z flag.
+-- .TP
+-- ad
+-- The AD flag.
+-- .TP
+-- cd
+-- The CD flag.
+-- .TP
+-- rcode
+-- The RCODE.
+-- .TP
+-- qdcount
+-- The QDCOUNT.
+-- .TP
+-- ancount
+-- The ANCOUNT.
+-- .TP
+-- nscount
+-- The NSCOUNT.
+-- .TP
+-- arcount
+-- The ARCOUNT.
+-- .TP
+-- questions
+-- The actual number of questions found.
+-- .TP
+-- answers
+-- The actual number of answers found.
+-- .TP
+-- authorities
+-- The actual number of authorities found.
+-- .TP
+-- additionals
+-- The actual number of additionals found.
 module(...,package.seeall)
 
 local ch = require("dnsjit.core.chelpers")
@@ -34,20 +150,18 @@ require("dnsjit.core.query_h")
 local ffi = require("ffi")
 local C = ffi.C
 
+local t_name = "core_query_t"
+local core_query_t
 local Query = {}
 
 -- Create a new query or bind an existing
 -- .IR core_query_t .
-function Query.new(o)
-    if o == nil then
-        o = C.core_query_new()
-    elseif not ffi.istype("core_query_t", o) then
-        error("is not core_query_t")
+function Query.new(self)
+    if not ffi.istype(t_name, self) then
+        self = C.core_query_new()
     end
-    ffi.gc(o, C.core_query_free)
-    return setmetatable({
-        _ = o,
-    }, {__index = Query})
+    ffi.gc(self, C.core_query_free)
+    return self
 end
 
 -- Return the Log object to control logging of this instance or module.
@@ -55,254 +169,44 @@ function Query:log()
     if self == nil then
         return C.core_query_log()
     end
-    return self._._log
-end
-
--- Return the
--- .I core_query_t
--- C structure bound to this object.
-function Query:struct()
-    self._._log:debug("struct()")
-    return self._
+    return self._log
 end
 
 -- Parse the DNS headers or the query.
 function Query:parse_header()
-    return ch.z2n(C.core_query_parse_header(self._))
+    return ch.z2n(C.core_query_parse_header(self))
 end
 
 -- Parse the full DNS message or just the body if the header was already parsed.
 function Query:parse()
-    return ch.z2n(C.core_query_parse(self._))
+    return ch.z2n(C.core_query_parse(self))
 end
 
 -- Return the IP source as a string.
 function Query:src()
-    return ffi.string(C.core_query_src(self._))
+    return ffi.string(C.core_query_src(self))
 end
 
 -- Return the IP destination as a string.
 function Query:dst()
-    return ffi.string(C.core_query_dst(self._))
-end
-
--- Return or set the source ID, used to track the unique source of the
--- query.
--- See also
--- .BR dnsjit.core.tracking (3).
-function Query:sid(sid)
-    if sid == nil then
-        return self._.sid
-    end
-    self._.sid = sid
-end
-
--- Return or set the query ID, used to track the unique query from a
--- source.
--- See also
--- .BR dnsjit.core.tracking (3).
-function Query:qid(qid)
-    if qid == nil then
-        return self._.qid
-    end
-    self._.qid = qid
-end
-
--- Return the source port.
-function Query:sport()
-    return self._.sport
-end
-
--- Return the destination port.
-function Query:dport()
-    return self._.dport
-end
-
--- Return true if there is a DNS ID.
-function Query:have_id()
-    return ch.i2b(self._.have_id)
-end
-
--- Return true if there is a QR flag.
-function Query:have_qr()
-    return ch.i2b(self._.have_qr)
-end
-
--- Return true if there is an OPCODE.
-function Query:have_opcode()
-    return ch.i2b(self._.have_opcode)
-end
-
--- Return true if there is a AA flag.
-function Query:have_aa()
-    return ch.i2b(self._.have_aa)
-end
-
--- Return true if there is a TC flag.
-function Query:have_tc()
-    return ch.i2b(self._.have_tc)
-end
-
--- Return true if there is a RD flag.
-function Query:have_rd()
-    return ch.i2b(self._.have_rd)
-end
-
--- Return true if there is a RA flag.
-function Query:have_ra()
-    return ch.i2b(self._.have_ra)
-end
-
--- Return true if there is a Z flag.
-function Query:have_z()
-    return ch.i2b(self._.have_z)
-end
-
--- Return true if there is a AD flag.
-function Query:have_ad()
-    return ch.i2b(self._.have_ad)
-end
-
--- Return true if there is a CD flag.
-function Query:have_cd()
-    return ch.i2b(self._.have_cd)
-end
-
--- Return true if there is a RCODE.
-function Query:have_rcode()
-    return ch.i2b(self._.have_rcode)
-end
-
--- Return true if there is an QDCOUNT.
-function Query:have_qdcount()
-    return ch.i2b(self._.have_qdcount)
-end
-
--- Return true if there is an ANCOUNT.
-function Query:have_ancount()
-    return ch.i2b(self._.have_ancount)
-end
-
--- Return true if there is a NSCOUNT.
-function Query:have_nscount()
-    return ch.i2b(self._.have_nscount)
-end
-
--- Return true if there is an ARCOUNT.
-function Query:have_arcount()
-    return ch.i2b(self._.have_arcount)
-end
-
--- Return the DNS ID.
-function Query:id()
-    return self._.id
-end
-
--- Return the QR flag.
-function Query:qr()
-    return self._.qr
-end
-
--- Return the OPCODE.
-function Query:opcode()
-    return self._.opcode
-end
-
--- Return the AA flag.
-function Query:aa()
-    return self._.aa
-end
-
--- Return the TC flag.
-function Query:tc()
-    return self._.tc
-end
-
--- Return the RD flag.
-function Query:rd()
-    return self._.rd
-end
-
--- Return the RA flag.
-function Query:ra()
-    return self._.ra
-end
-
--- Return the Z flag.
-function Query:z()
-    return self._.z
-end
-
--- Return the AD flag.
-function Query:ad()
-    return self._.ad
-end
-
--- Return the CD flag.
-function Query:cd()
-    return self._.cd
-end
-
--- Return the RCODE.
-function Query:rcode()
-    return self._.rcode
-end
-
--- Return the QDCOUNT.
-function Query:qdcount()
-    return self._.qdcount
-end
-
--- Return the ANCOUNT.
-function Query:ancount()
-    return self._.ancount
-end
-
--- Return the NSCOUNT.
-function Query:nscount()
-    return self._.nscount
-end
-
--- Return the ARCOUNT.
-function Query:arcount()
-    return self._.arcount
-end
-
--- Return the actual number of questions found.
-function Query:questions()
-    return self._.questions
-end
-
--- Return the actual number of answers found.
-function Query:answers()
-    return self._.answers
-end
-
--- Return the actual number of authorities found.
-function Query:authorities()
-    return self._.authorities
-end
-
--- Return the actual number of additionals found.
-function Query:additionals()
-    return self._.additionals
+    return ffi.string(C.core_query_dst(self))
 end
 
 -- Start walking the resource record(s) (RR) found or continue with the next,
 -- returns integer > 0 on error or end of RRs.
 function Query:rr_next()
-    return C.core_query_rr_next(self._)
+    return C.core_query_rr_next(self)
 end
 
 -- Check if the RR at the current position was parsed successfully or not,
 -- return 1 if successful.
 function Query:rr_ok()
-    return C.core_query_rr_ok(self._)
+    return C.core_query_rr_ok(self)
 end
 
 -- Return the FQDN of the current RR or an empty string on error.
 function Query:rr_label()
-    local ptr = C.core_query_rr_label(self._)
+    local ptr = C.core_query_rr_label(self)
     if ptr == nil then
         return ""
     end
@@ -311,18 +215,20 @@ end
 
 -- Return an integer with the RR type.
 function Query:rr_type()
-    return C.core_query_rr_type(self._)
+    return C.core_query_rr_type(self)
 end
 
 -- Return an integer with the RR class.
 function Query:rr_class()
-    return C.core_query_rr_class(self._)
+    return C.core_query_rr_class(self)
 end
 
 -- Return an integer with the RR TTL.
 function Query:rr_ttl()
-    return C.core_query_rr_ttl(self._)
+    return C.core_query_rr_ttl(self)
 end
+
+core_query_t = ffi.metatype(t_name, { __index = Query })
 
 -- dnsjit.core.tracking (3)
 return Query

--- a/src/input/lua.lua
+++ b/src/input/lua.lua
@@ -31,11 +31,12 @@ module(...,package.seeall)
 local ch = require("dnsjit.core.chelpers")
 local log = require("dnsjit.core.log")
 require("dnsjit.core.receiver_h")
+require("dnsjit.core.query_h")
 local ffi = require("ffi")
 local C = ffi.C
 
-local Lua = {}
 local module_log = log.new("input.lua")
+local Lua = {}
 
 -- Create a new Lua input.
 function Lua.new()
@@ -67,9 +68,10 @@ function Lua:receiver(o)
 end
 
 -- Send a query to the receiver.
-function Lua:send(q)
+function Lua:send(query)
     self._log:debug("send()")
-    return ch.z2n(C.receiver_call(self._recv, self._robj, q:struct()))
+    local q = C.core_query_copy(query)
+    return ch.z2n(C.receiver_call(self._recv, self._robj, q))
 end
 
 -- dnsjit.core.query (3)

--- a/src/lib/getopt.lua
+++ b/src/lib/getopt.lua
@@ -64,8 +64,8 @@ module(...,package.seeall)
 
 local log = require("dnsjit.core.log")
 
-Getopt = {}
 local module_log = log.new("lib.getopt")
+Getopt = {}
 
 -- Create a new Getopt object.
 -- .I args

--- a/src/lib/parseconf.lua
+++ b/src/lib/parseconf.lua
@@ -55,8 +55,8 @@ module(...,package.seeall)
 
 local log = require("dnsjit.core.log")
 
-Parseconf = {}
 local module_log = log.new("lib.parseconf")
+Parseconf = {}
 
 -- Create a new Parseconf object.
 function Parseconf.new()

--- a/src/output/null.lua
+++ b/src/output/null.lua
@@ -27,38 +27,25 @@ require("dnsjit.output.null_h")
 local ffi = require("ffi")
 local C = ffi.C
 
-local type = "output_null_t"
-local struct
-local mt = {
-    __index = {
-        new = function()
-            local self = struct()
-            if not self then
-                error("oom")
-            end
-            return self
-        end
-    }
-}
-struct = ffi.metatype(type, mt)
-
+local t_name = "output_null_t"
+local output_null_t = ffi.typeof(t_name)
 local Null = {}
 
 -- Create a new Null output.
 function Null.new()
-    local o = struct.new()
-    return setmetatable({
-        _ = o,
-    }, {__index = Null})
+    local self = {
+        obj = output_null_t(),
+    }
+    return setmetatable(self, { __index = Null })
 end
 
 function Null:receive()
-    return C.output_null_receiver(), self._
+    return C.output_null_receiver(), self.obj
 end
 
 -- Return the number of queries we sent into the void.
 function Null:packets()
-    return tonumber(self._.pkts)
+    return tonumber(self.obj.pkts)
 end
 
 return Null


### PR DESCRIPTION
- Use same naming of module locals
  - `local t_name=""`: the C structure name for the module as string (example `core_log_t`)
  - `local <t_name>=...`: the __ctype__ _used_ for creating an object, set either with `ffi.typeof()` or `ffi.metatype()`
  - `self.obj`: the C structure if wrapping inside a Lua object
- `core.query`:
  - Rework into a pure C structure object, a lot of values are not attributes instead of functions
  - Fix bug where DNS header values was not copied