### PR TITLE
Inner local, query, thread

### DIFF
--- a/src/core/receiver.lua
+++ b/src/core/receiver.lua
@@ -20,7 +20,7 @@
 -- Receiver data structure definition
 --   require("dnsjit.core.receiver_h")
 --   local C = require("ffi").C
---   C.core_receiver_call(recv_c_function_ptr, recv_c_function_data, query:struct()
+--   C.core_receiver_call(recv_c_function_ptr, recv_c_function_data, query)
 --
 -- Receiver and receive interfaces and data structure definitions used by
 -- input, filter and output modules to pass query objects for processing.

--- a/src/filter/lua.lua
+++ b/src/filter/lua.lua
@@ -140,9 +140,8 @@ function Lua:send(query)
     if not self.ishandler then
         error("not handler")
     end
-    -- TODO: test replace with ffi.gc(q:struct(), nil)
-    local q = C.core_query_copy(query)
-    return ch.z2n(C.receiver_call(self._recv, self._robj, q))
+    -- TODO: test replace with ffi.gc(query, nil)
+    return ch.z2n(C.receiver_call(self._recv, self._robj, C.core_query_copy(query)))
 end
 
 -- dnsjit.filter.thread (3)

--- a/src/filter/thread.lua
+++ b/src/filter/thread.lua
@@ -167,13 +167,13 @@ function Thread:recv()
 end
 
 -- Called in the thread function to send the query to the next receiver.
-function Thread:send(q)
+function Thread:send(query)
     if not self.inthread then
         error("only usable within a thread context")
     end
     self.obj._log:debug("send()")
-    -- TODO: test replace with ffi.gc(q:struct(), nil)
-    return ch.z2n(C.filter_thread_send(self.obj, q:struct()))
+    -- TODO: test replace with ffi.gc(query, nil)
+    return ch.z2n(C.filter_thread_send(self.obj, C.core_query_copy(query)))
 end
 
 -- dnsjit.filter.lua (3)

--- a/src/input/lua.lua
+++ b/src/input/lua.lua
@@ -70,8 +70,7 @@ end
 -- Send a query to the receiver.
 function Lua:send(query)
     self._log:debug("send()")
-    local q = C.core_query_copy(query)
-    return ch.z2n(C.receiver_call(self._recv, self._robj, q))
+    return ch.z2n(C.receiver_call(self._recv, self._robj, C.core_query_copy(query)))
 end
 
 -- dnsjit.core.query (3)

--- a/src/lib/getopt.lua
+++ b/src/lib/getopt.lua
@@ -172,9 +172,9 @@ end
 
 -- Print the usage.
 function Getopt:usage()
-    local arg
     print("Usage:")
     for k, v in pairs(self.opt) do
+        local arg
         if v.type == "string" then
             arg = " \""..v.default.."\""
         elseif v.type == "number" and not v.counter then

--- a/src/lib/parseconf.lua
+++ b/src/lib/parseconf.lua
@@ -120,14 +120,14 @@ end
 
 -- Parse the given file.
 function Parseconf:file(fn)
-    local ln, l, c, e, m
+    local ln, l
     ln = 1
     for l in io.lines(fn) do
-        c = l:find("#")
+        local c = l:find("#")
         if c then
             l = l:sub(1, c - 1)
         end
-        e, m = pcall(self.line, self, l)
+        local e, m = pcall(self.line, self, l)
         if e == false then
             error("parse error in "..fn.."["..ln.."]: "..m)
         end
@@ -137,13 +137,13 @@ end
 
 -- Parse the given line.
 function Parseconf:line(l)
-    local n, p, v, va, c, ws, n, eol
+    local n
     n = 1
     while n <= l:len() do
-        c = nil
-        va = {}
+        local c = nil
+        local va = {}
         while true do
-            p, v = self:part(l, n)
+            local p, v = self:part(l, n)
             if not p then
                 error("invalid config at character "..n..": "..l:sub(n))
             end
@@ -153,7 +153,7 @@ function Parseconf:line(l)
                 table.insert(va, v)
             end
             n = n + p:len()
-            ws, eol = self:next(l, n)
+            local ws, eol = self:next(l, n)
             if ws == true then
                 if eol then
                     n = n + eol:len()


### PR DESCRIPTION
- Move local variables to the most inner loop they exist in
- Remove reference to `query:struct()`
- `filter.thread`: Use query copy in `send()`