### PR TITLE
Tracking queries

### DIFF
--- a/src/core/query.c
+++ b/src/core/query.c
@@ -61,7 +61,7 @@ typedef struct _query {
 static core_log_t   _log      = LOG_T_INIT("core.query");
 static core_query_t _defaults = {
     LOG_T_INIT_OBJ("core.query"),
-    0, 0,
+    0, 0, 0,
     0, 0, 0, 0,
     0, 0, { 0, 0 },
     "", 0, 0,

--- a/src/core/query.hh
+++ b/src/core/query.hh
@@ -23,7 +23,7 @@
 typedef struct core_query {
     core_log_t _log;
 
-    uint64_t sid, qid;
+    uint64_t src_id, qr_id, dst_id;
 
     unsigned short is_udp : 1;
     unsigned short is_tcp : 1;

--- a/src/core/query.lua
+++ b/src/core/query.lua
@@ -26,13 +26,21 @@
 -- a DNS message, how it was captured or generated.
 -- .SS Attributes
 -- .TP
--- sid
--- Source ID, used to track the unique source of the query.
+-- src_id
+-- Source ID, used to track the query through the input, filter and output
+-- modules.
 -- See also
 -- .BR dnsjit.core.tracking (3).
 -- .TP
--- qid
--- Query ID, used to track the unique query from a source.
+-- qr_id
+-- Query/Response ID, used to track the query through the input, filter
+-- and output modules.
+-- See also
+-- .BR dnsjit.core.tracking (3).
+-- .TP
+-- dst_id
+-- Destination ID, used to track the query through the input, filter
+-- and output modules.
 -- See also
 -- .BR dnsjit.core.tracking (3).
 -- .TP

--- a/src/core/tracking.c
+++ b/src/core/tracking.c
@@ -25,29 +25,69 @@
 
 #include <pthread.h>
 
-static core_log_t      _log   = LOG_T_INIT("core.tracking");
-static pthread_mutex_t _mutex = PTHREAD_MUTEX_INITIALIZER;
-static uint64_t        _sid   = 1;
+static core_log_t      _log          = LOG_T_INIT("core.tracking");
+static pthread_mutex_t _src_id_mutex = PTHREAD_MUTEX_INITIALIZER;
+static uint64_t        _src_id       = 1;
+static pthread_mutex_t _qr_id_mutex  = PTHREAD_MUTEX_INITIALIZER;
+static uint64_t        _qr_id        = 1;
+static pthread_mutex_t _dst_id_mutex = PTHREAD_MUTEX_INITIALIZER;
+static uint64_t        _dst_id       = 1;
 
 core_log_t* core_tracking_log()
 {
     return &_log;
 }
 
-uint64_t core_tracking_new_sid()
+uint64_t core_tracking_src_id()
 {
-    uint64_t sid;
+    uint64_t src_id;
 
-    if (pthread_mutex_lock(&_mutex)) {
+    if (pthread_mutex_lock(&_src_id_mutex)) {
         return 0;
     }
-    if (!_sid) {
+    if (!_src_id) {
         /* 0 is error */
-        _sid++;
+        _src_id++;
     }
-    sid = _sid++;
-    if (pthread_mutex_unlock(&_mutex)) {
+    src_id = _src_id++;
+    if (pthread_mutex_unlock(&_src_id_mutex)) {
         return 0;
     }
-    return sid;
+    return src_id;
+}
+
+uint64_t core_tracking_qr_id()
+{
+    uint64_t qr_id;
+
+    if (pthread_mutex_lock(&_qr_id_mutex)) {
+        return 0;
+    }
+    if (!_qr_id) {
+        /* 0 is error */
+        _qr_id++;
+    }
+    qr_id = _qr_id++;
+    if (pthread_mutex_unlock(&_qr_id_mutex)) {
+        return 0;
+    }
+    return qr_id;
+}
+
+uint64_t core_tracking_dst_id()
+{
+    uint64_t dst_id;
+
+    if (pthread_mutex_lock(&_dst_id_mutex)) {
+        return 0;
+    }
+    if (!_dst_id) {
+        /* 0 is error */
+        _dst_id++;
+    }
+    dst_id = _dst_id++;
+    if (pthread_mutex_unlock(&_dst_id_mutex)) {
+        return 0;
+    }
+    return dst_id;
 }

--- a/src/core/tracking.hh
+++ b/src/core/tracking.hh
@@ -21,4 +21,6 @@
 //Lua:require("dnsjit.core.log")
 core_log_t* core_tracking_log();
 
-uint64_t core_tracking_new_sid();
+uint64_t core_tracking_src_id();
+uint64_t core_tracking_qr_id();
+uint64_t core_tracking_dst_id();

--- a/src/core/tracking.lua
+++ b/src/core/tracking.lua
@@ -19,7 +19,7 @@
 -- dnsjit.core.tracking
 -- Core functions for tracking input sources
 --   local tracking = require("dnsjit.core.tracking")
---   local source_id = tracking.new_sid()
+--   local source_id = tracking.src_id()
 --
 -- Provide a thread safe way of getting an unique ID for an input source,
 -- used together with Query ID
@@ -41,12 +41,42 @@ end
 -- This function is thread safe and uses mutex to keep the ID unique.
 -- See also
 -- .BR dnsjit.core.query (3)
--- functions
--- .B sid()
+-- attributes
+-- .BR src_id ,
+-- .B qr_id
 -- and
--- .BR qid() .
-function Tracking.new_sid()
-    return C.core_tracking_new_sid()
+-- .BR dst_id .
+function Tracking.src_id()
+    return C.core_tracking_src_id()
+end
+
+-- Return a new query ID, used for tracking queries.
+-- This function is thread safe and uses mutex to keep the ID unique.
+-- .B NOTE
+-- usually the input modules keeps an own unique query ID and does not use
+-- this function.
+-- See also
+-- .BR dnsjit.core.query (3)
+-- attributes
+-- .BR src_id ,
+-- .B qr_id
+-- and
+-- .BR dst_id .
+function Tracking.qr_id()
+    return C.core_tracking_qr_id()
+end
+
+-- Return a new destination ID, used for tracking queries.
+-- This function is thread safe and uses mutex to keep the ID unique.
+-- See also
+-- .BR dnsjit.core.query (3)
+-- attributes
+-- .BR src_id ,
+-- .B qr_id
+-- and
+-- .BR dst_id .
+function Tracking.dst_id()
+    return C.core_tracking_dst_id()
 end
 
 -- dnsjit.core.query (3)

--- a/src/input/pcap.c
+++ b/src/input/pcap.c
@@ -68,12 +68,12 @@ static void _udp(u_char* user, const pcap_thread_packet_t* packet, const u_char*
         self->drop++;
         return;
     }
-    q->sid = self->sid;
-    if (!self->qid) {
+    q->src_id = self->src_id;
+    if (!self->qr_id) {
         /* 0 is error */
-        self->qid++;
+        self->qr_id++;
     }
-    q->qid = self->qid++;
+    q->qr_id = self->qr_id++;
     if (packet->have_iphdr) {
         if (core_query_set_src(q, AF_INET, &packet->iphdr.ip_src, sizeof(packet->iphdr.ip_src))
             || core_query_set_dst(q, AF_INET, &packet->iphdr.ip_dst, sizeof(packet->iphdr.ip_dst))) {
@@ -160,12 +160,12 @@ static void _tcp(u_char* user, const pcap_thread_packet_t* packet, const u_char*
         self->drop++;
         return;
     }
-    q->sid = self->sid;
-    if (!self->qid) {
+    q->src_id = self->src_id;
+    if (!self->qr_id) {
         /* 0 is error */
-        self->qid++;
+        self->qr_id++;
     }
-    q->qid = self->qid++;
+    q->qr_id = self->qr_id++;
     if (packet->have_iphdr) {
         if (core_query_set_src(q, AF_INET, &packet->iphdr.ip_src, sizeof(packet->iphdr.ip_src))
             || core_query_set_dst(q, AF_INET, &packet->iphdr.ip_dst, sizeof(packet->iphdr.ip_dst))) {
@@ -221,8 +221,8 @@ int input_pcap_init(input_pcap_t* self)
         return 1;
     }
 
-    *self     = _defaults;
-    self->sid = core_tracking_new_sid();
+    *self        = _defaults;
+    self->src_id = core_tracking_src_id();
 
     ldebug("init");
 

--- a/src/input/pcap.hh
+++ b/src/input/pcap.hh
@@ -55,8 +55,8 @@ typedef struct input_pcap {
     core_timespec_t ts, te;
     size_t          pkts, drop, ignore, queries;
     int             err;
-    uint64_t        sid;
-    uint64_t        qid;
+    uint64_t        src_id;
+    uint64_t        qr_id;
 } input_pcap_t;
 
 core_log_t* input_pcap_log();


### PR DESCRIPTION
- Rename Source ID `sid` to `src_id`
- Rename Query ID `qid` to `qr_id`
- `core.tracking`: Add unique thread safe counter for query/response `qr_id` and destination `dst_id`
- `core.query`: Add destination ID