### PR TITLE
Responses, fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,11 @@ local input = require("dnsjit.input.pcap").new()
 local output = require("dnsjit.filter.lua").new()
 
 output:func(function(filter, query)
-    print(query:id())
+    query:parse()
+    print(query.id)
 end)
 
 input:open_offline("file.pcap")
-input:only_queries(true)
 input:receiver(output)
 input:run()
 ```

--- a/src/core/query.c
+++ b/src/core/query.c
@@ -337,7 +337,7 @@ const char* core_query_rr_label(core_query_t* self)
     }
 
     label = _self->label_buf;
-    left  = sizeof(_self->label) - 1;
+    left  = sizeof(_self->label_buf) - 1;
 
     if (omg_dns_rr_labels(&_self->rr[_self->at_rr])) {
         size_t l    = _self->rr_label_idx[_self->at_rr];
@@ -539,6 +539,25 @@ int core_query_set_parsed_header(core_query_t* self, omg_dns_t dns)
     self->ancount      = dns.ancount;
     self->nscount      = dns.nscount;
     self->arcount      = dns.arcount;
+
+    return 0;
+}
+
+int core_query_copy_addr(core_query_t* self, core_query_t* from)
+{
+    _query_t* _self = (_query_t*)self;
+    _query_t* _from = (_query_t*)from;
+
+    if (!_self || !_from) {
+        return 1;
+    }
+
+    _self->af     = _from->af;
+    _self->src    = _from->src;
+    _self->dst    = _from->dst;
+    self->is_ipv6 = from->is_ipv6;
+    self->sport   = from->sport;
+    self->dport   = from->dport;
 
     return 0;
 }

--- a/src/core/query.hh
+++ b/src/core/query.hh
@@ -92,3 +92,5 @@ const char* core_query_rr_label(core_query_t* self);
 uint16_t core_query_rr_type(core_query_t* self);
 uint16_t core_query_rr_class(core_query_t* self);
 uint32_t core_query_rr_ttl(core_query_t* self);
+
+int core_query_copy_addr(core_query_t* self, core_query_t* from);

--- a/src/filter/timing.c
+++ b/src/filter/timing.c
@@ -67,8 +67,8 @@ static int _receive(void* robj, core_query_t* q)
     struct timespec  now  = { 0, 0 };
     struct timeval   last_packet, ts;
     struct timespec  last_time;
-    struct timespec  last_realtime;
-    struct timespec  last_time_queue;
+    //struct timespec  last_realtime;
+    struct timespec last_time_queue;
 
     if (!self || !q || !self->recv) {
         core_query_free(q);
@@ -218,7 +218,7 @@ static int _receive(void* robj, core_query_t* q)
             clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &sleep_to, 0);
         }
 #elif HAVE_NANOSLEEP
-#define SAVE_REALTIME 1
+        //#define SAVE_REALTIME 1
         /* sleep_to will be relative, need to check against now - last_time */
         if (self->mode != TIMING_MODE_BEST_EFFORT
             && (sleep_to.tv_sec < (now.tv_sec - self->last_time.sec)
@@ -245,17 +245,17 @@ static int _receive(void* robj, core_query_t* q)
     }
     self->last_time.sec  = last_time.tv_sec;
     self->last_time.nsec = last_time.tv_nsec;
-#ifdef SAVE_REALTIME
-    if (clock_gettime(CLOCK_REALTIME, &last_realtime)) {
-        lfatal("clock_gettime()");
-        // self->last_realtime.tv_sec  = 0;
-        // self->last_realtime.tv_nsec = 0;
-        // self->last_time.tv_sec      = 0;
-        // self->last_time.tv_nsec     = 0;
-    }
-#endif
-    self->last_realtime.sec  = last_realtime.tv_sec;
-    self->last_realtime.nsec = last_realtime.tv_nsec;
+    // #ifdef SAVE_REALTIME
+    //     if (clock_gettime(CLOCK_REALTIME, &last_realtime)) {
+    //         lfatal("clock_gettime()");
+    //         // self->last_realtime.tv_sec  = 0;
+    //         // self->last_realtime.tv_nsec = 0;
+    //         // self->last_time.tv_sec      = 0;
+    //         // self->last_time.tv_nsec     = 0;
+    //     }
+    // #endif
+    //     self->last_realtime.sec  = last_realtime.tv_sec;
+    //     self->last_realtime.nsec = last_realtime.tv_nsec;
 
     self->last_packet = q->ts;
 

--- a/src/output/cpool.hh
+++ b/src/output/cpool.hh
@@ -24,8 +24,10 @@ typedef struct {} client_pool_t;
 //lua:require("dnsjit.core.log")
 //lua:require("dnsjit.core.receiver_h")
 typedef struct output_cpool {
-    core_log_t     _log;
-    client_pool_t* p;
+    core_log_t      _log;
+    client_pool_t*  p;
+    core_receiver_t recv;
+    void*           robj;
 } output_cpool_t;
 
 core_log_t* output_cpool_log();

--- a/src/output/cpool.lua
+++ b/src/output/cpool.lua
@@ -52,6 +52,7 @@ function Cpool.new(host, port, queue_size)
         queue_size = 0
     end
     local self = {
+        _receiver = nil,
         obj = output_cpool_t(),
     }
     C.output_cpool_init(self.obj, host, port, queue_size)
@@ -155,6 +156,13 @@ end
 -- Stop the processing of queries.
 function Cpool:stop()
     return ch.z2n(C.output_cpool_stop(self.obj))
+end
+
+-- Set the receiver to pass queries and responses to.
+function Cpool:receiver(o)
+    self.obj._log:debug("receiver()")
+    self.obj.recv, self.obj.robj = o:receive()
+    self._receiver = o
 end
 
 function Cpool:receive()

--- a/src/output/cpool/client.h
+++ b/src/output/cpool/client.h
@@ -61,6 +61,7 @@ struct client {
     unsigned short is_dgram : 1;
     unsigned short is_stream : 1;
     unsigned short sent_length : 1;
+    unsigned short always_read : 1;
 
     ev_tstamp start;
     client_t* next;
@@ -81,6 +82,11 @@ struct client {
     socklen_t               to_addrlen;
     struct sockaddr_storage from_addr;
     socklen_t               from_addrlen;
+
+    size_t   recvbuf_size;
+    char*    recvbuf;
+    ssize_t  nrecv;
+    uint64_t dst_id;
 };
 
 client_t* client_new(core_query_t* query, client_callback_t callback);
@@ -101,6 +107,8 @@ int client_set_prev(client_t* client, client_t* prev);
 int client_set_start(client_t* client, ev_tstamp start);
 int client_set_skip_reply(client_t* client);
 core_query_t* client_release_query(client_t* client);
+
+int client_set_recvbuf_size(client_t* client, size_t recvbuf_size);
 
 int client_connect(client_t* client, int ipproto, const struct sockaddr* addr, socklen_t addlen, struct ev_loop* loop);
 int client_send(client_t* client, struct ev_loop* loop);

--- a/src/output/cpool/client_pool.h
+++ b/src/output/cpool/client_pool.h
@@ -50,6 +50,8 @@ enum client_pool_state {
     CLIENT_POOL_ERROR
 };
 
+typedef void (*client_pool_client_read_t)(void*, const client_t*);
+
 typedef struct client_pool client_pool_t;
 struct client_pool {
     client_pool_t* next;
@@ -58,6 +60,7 @@ struct client_pool {
     unsigned short is_stopping : 1;
     unsigned short client_skip_reply : 1;
     unsigned short dry_run : 1;
+    unsigned short client_always_read : 1;
 
     client_pool_state_t state;
     pthread_t           thread_id;
@@ -85,6 +88,10 @@ struct client_pool {
     client_pool_sendas_t sendas;
 
     core_log_t* _log;
+
+    size_t                    client_recvbuf_size;
+    client_pool_client_read_t client_read;
+    void*                     client_read_ctx;
 };
 
 client_pool_t* client_pool_new(const char* host, const char* port, size_t queue_size);


### PR DESCRIPTION
- Update README example for the changes made to `core.query`
- `core.query`:
  - CID 263046: Fix buffer overrun in RR label handling
  - Add `core_query_copy_addr()` to copy source/destination information from another query
- `filter.timing`:
  - CID 260362: Disable last real time, not used
- `output/cpool/client`:
  - Add static buffer for non-important reads
  - Add `client_set_recvbuf_size()` to allocate a per client receiver buffer
  - Add `always_read` option to enable the receiving of data to always be on
  - Use `core.tracking` destination ID `dst_id` and set the IDs in the query being processed
- `output/cpool/client_pool`:
  - Add `client_recvbuf_size` to set the receive buffer for new clients
  - Add `client_always_read` option to set for new clients
  - Add `client_pool_client_read_t` callback used when clients receives data
  - Clear and free clients on reuse list when stopping
- `output.cpool`:
  - Fix `sendas` functions, all were setting it to original
  - Add receiver functionality to pass queries and responses
- `example/replay.lua`:
  - Use `lib.getopt`
  - Add `-v` to increase verbosity
  - Add `-R` to wait for responses and display both query and responses