### PR TITLE
Timing

### DIFF
--- a/src/core/timespec.hh
+++ b/src/core/timespec.hh
@@ -19,6 +19,6 @@
  */
 
 typedef struct core_timespec {
-    uint64_t sec;
-    uint64_t nsec;
+    int64_t sec;
+    int64_t nsec;
 } core_timespec_t;

--- a/src/filter/timing.c
+++ b/src/filter/timing.c
@@ -24,12 +24,24 @@
 
 #include <time.h>
 #include <sys/time.h>
+#include <errno.h>
+
+#define N1e9 1000000000
+
+typedef struct _filter_timing {
+    filter_timing_t pub;
+
+    struct timespec diff;
+    core_timespec_t last_pkthdr_ts;
+    struct timespec last_ts;
+    int (*timing_callback)(filter_timing_t*, core_query_t*);
+    struct timespec mod_ts;
+} _filter_timing_t;
 
 static core_log_t      _log      = LOG_T_INIT("filter.timing");
 static filter_timing_t _defaults = {
     LOG_T_INIT_OBJ("filter.timing"), 0, 0,
     TIMING_MODE_KEEP, 0, 0, 0.0,
-    { 0, 0 }, { 0, 0 }, { 0, 0 }, { 0, 0 }
 };
 
 core_log_t* filter_timing_log()
@@ -37,239 +49,366 @@ core_log_t* filter_timing_log()
     return &_log;
 }
 
-int filter_timing_init(filter_timing_t* self)
+static int _keep(filter_timing_t* self, core_query_t* q)
 {
-    if (!self) {
-        return 1;
+    _filter_timing_t* _self = (_filter_timing_t*)self;
+#if HAVE_CLOCK_NANOSLEEP
+    struct timespec to = {
+        _self->diff.tv_sec + q->ts.sec,
+        _self->diff.tv_nsec + q->ts.nsec
+    };
+    int ret = EINTR;
+
+    if (to.tv_nsec >= N1e9) {
+        to.tv_sec += 1;
+        to.tv_nsec -= N1e9;
+    } else if (to.tv_nsec < 0) {
+        to.tv_sec -= 1;
+        to.tv_nsec += N1e9;
     }
 
-    *self = _defaults;
-
-    ldebug("init");
-
-    return 0;
-}
-
-int filter_timing_destroy(filter_timing_t* self)
-{
-    if (!self) {
-        return 1;
-    }
-
-    ldebug("destroy");
-
-    return 0;
-}
-
-static int _receive(void* robj, core_query_t* q)
-{
-    filter_timing_t* self = (filter_timing_t*)robj;
-    struct timespec  now  = { 0, 0 };
-    struct timeval   last_packet, ts;
-    struct timespec  last_time;
-    //struct timespec  last_realtime;
-    struct timespec last_time_queue;
-
-    if (!self || !q || !self->recv) {
-        core_query_free(q);
-        return 1;
-    }
-
-    ts.tv_sec  = q->ts.sec;
-    ts.tv_usec = q->ts.nsec / 1000;
-
-    last_packet.tv_sec  = self->last_packet.sec;
-    last_packet.tv_usec = self->last_packet.nsec / 1000;
-
-    ldebug("pkthdr.ts %lu.%06lu", ts.tv_sec, ts.tv_usec);
-    ldebug("last_packet %lu.%06lu", last_packet.tv_sec, last_packet.tv_usec);
-
-    if (clock_gettime(CLOCK_MONOTONIC, &now)) {
-        lfatal("clock_gettime()");
-    }
-
-    if ((self->last_time_queue.sec || self->last_time_queue.nsec)
-        && last_packet.tv_sec
-        && (self->last_time.sec || self->last_time.nsec)
-        && timercmp(&ts, &last_packet, >)) {
-        struct timespec pdiff = { 0, 0 };
-        struct timeval  diff;
-        struct timespec sleep_to;
-
-        if (now.tv_sec > self->last_time_queue.sec)
-            pdiff.tv_sec = now.tv_sec - self->last_time_queue.sec;
-        if (now.tv_nsec > self->last_time_queue.nsec)
-            pdiff.tv_nsec = now.tv_nsec - self->last_time_queue.nsec;
-
-        if (self->last_time_queue.sec > self->last_time.sec)
-            pdiff.tv_sec += self->last_time_queue.sec - self->last_time.sec;
-        if (self->last_time_queue.nsec > self->last_time.nsec)
-            pdiff.tv_nsec += self->last_time_queue.nsec - self->last_time.nsec;
-
-        if (pdiff.tv_nsec > 999999999) {
-            pdiff.tv_sec += pdiff.tv_nsec / 1000000000;
-            pdiff.tv_nsec %= 1000000000;
+    while (ret) {
+        ldebug("keep mode, sleep to %ld.%ld", to.tv_sec, to.tv_nsec);
+        ret = clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &to, 0);
+        if (ret && ret != EINTR) {
+            lfatal("clock_nanosleep(%ld.%ld) %d", to.tv_sec, to.tv_nsec, ret);
         }
+    }
+#elif HAVE_NANOSLEEP
+    struct timespec diff = {
+        q->ts.sec - _self->last_pkthdr_ts.sec,
+        q->ts.nsec - _self->last_pkthdr_ts.nsec
+    };
+    int ret = EINTR;
 
-        ldebug("process diff %lu.%09lu", pdiff.tv_sec, pdiff.tv_nsec);
+    if (diff.tv_nsec >= N1e9) {
+        diff.tv_sec += 1;
+        diff.tv_nsec -= N1e9;
+    } else if (diff.tv_nsec < 0) {
+        diff.tv_sec -= 1;
+        diff.tv_nsec += N1e9;
+    }
 
-        timersub(&ts, &last_packet, &diff);
-
-        ldebug("diff %lu.%06lu", diff.tv_sec, diff.tv_usec);
-
-        if (self->mode == TIMING_MODE_MULTIPLY) {
-            diff.tv_sec  = (long)((float)diff.tv_sec * self->mul);
-            diff.tv_usec = (long)((float)diff.tv_usec * self->mul);
-            if (diff.tv_sec < 0 || diff.tv_usec < 0) {
-                diff.tv_sec  = 0;
-                diff.tv_usec = 0;
+    if (diff.tv_sec > -1 && diff.tv_nsec > -1) {
+        while (ret) {
+            ldebug("keep mode, sleep for %ld.%ld", diff.tv_sec, diff.tv_nsec);
+            if ((ret = nanosleep(&diff, &diff))) {
+                ret = errno;
+                if (ret != EINTR) {
+                    lfatal("nanosleep(%ld.%ld) %d", diff.tv_sec, diff.tv_nsec, ret);
+                }
             }
         }
+    }
+
+    _self->last_pkthdr_ts = q->ts;
+#endif
+
+    self->recv(self->robj, q);
+
+    return 0;
+}
+
+static int _increase(filter_timing_t* self, core_query_t* q)
+{
+    _filter_timing_t* _self = (_filter_timing_t*)self;
+    struct timespec   diff  = {
+        q->ts.sec - _self->last_pkthdr_ts.sec,
+        q->ts.nsec - _self->last_pkthdr_ts.nsec
+    };
+    int ret = EINTR;
+
+    if (diff.tv_nsec >= N1e9) {
+        diff.tv_sec += 1;
+        diff.tv_nsec -= N1e9;
+    } else if (diff.tv_nsec < 0) {
+        diff.tv_sec -= 1;
+        diff.tv_nsec += N1e9;
+    }
+
+    diff.tv_sec += _self->mod_ts.tv_sec;
+    diff.tv_nsec += _self->mod_ts.tv_nsec;
+    if (diff.tv_nsec >= N1e9) {
+        diff.tv_sec += 1;
+        diff.tv_nsec -= N1e9;
+    }
+
+    if (diff.tv_sec > -1 && diff.tv_nsec > -1) {
+#if HAVE_CLOCK_NANOSLEEP
+        struct timespec to = {
+            _self->last_ts.tv_sec + diff.tv_sec,
+            _self->last_ts.tv_nsec + diff.tv_nsec
+        };
+
+        if (to.tv_nsec >= N1e9) {
+            to.tv_sec += 1;
+            to.tv_nsec -= N1e9;
+        } else if (to.tv_nsec < 0) {
+            to.tv_sec -= 1;
+            to.tv_nsec += N1e9;
+        }
+
+        while (ret) {
+            ldebug("increase mode, sleep to %ld.%ld", to.tv_sec, to.tv_nsec);
+            ret = clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &to, 0);
+            if (ret && ret != EINTR) {
+                lfatal("clock_nanosleep(%ld.%ld) %d", to.tv_sec, to.tv_nsec, ret);
+            }
+        }
+#elif HAVE_NANOSLEEP
+        while (ret) {
+            ldebug("increase mode, sleep for %ld.%ld", diff.tv_sec, diff.tv_nsec);
+            if ((ret = nanosleep(&diff, &diff))) {
+                ret = errno;
+                if (ret != EINTR) {
+                    lfatal("nanosleep(%ld.%ld) %d", diff.tv_sec, diff.tv_nsec, ret);
+                }
+            }
+        }
+#endif
+    }
+
+    _self->last_pkthdr_ts = q->ts;
 
 #if HAVE_CLOCK_NANOSLEEP
-        /* absolute time */
-        sleep_to.tv_sec  = self->last_time.sec;
-        sleep_to.tv_nsec = self->last_time.nsec;
+    if (clock_gettime(CLOCK_MONOTONIC, &_self->last_ts)) {
+        lfatal("clock_gettime()");
+    }
+#endif
+
+    self->recv(self->robj, q);
+
+    return 0;
+}
+
+static int _reduce(filter_timing_t* self, core_query_t* q)
+{
+    _filter_timing_t* _self = (_filter_timing_t*)self;
+    struct timespec   diff  = {
+        q->ts.sec - _self->last_pkthdr_ts.sec,
+        q->ts.nsec - _self->last_pkthdr_ts.nsec
+    };
+    int ret = EINTR;
+
+    if (diff.tv_nsec >= N1e9) {
+        diff.tv_sec += 1;
+        diff.tv_nsec -= N1e9;
+    } else if (diff.tv_nsec < 0) {
+        diff.tv_sec -= 1;
+        diff.tv_nsec += N1e9;
+    }
+
+    diff.tv_sec -= _self->mod_ts.tv_sec;
+    diff.tv_nsec -= _self->mod_ts.tv_nsec;
+    if (diff.tv_nsec < 0) {
+        diff.tv_sec -= 1;
+        diff.tv_nsec += N1e9;
+    }
+
+    if (diff.tv_sec > -1 && diff.tv_nsec > -1) {
+#if HAVE_CLOCK_NANOSLEEP
+        struct timespec to = {
+            _self->last_ts.tv_sec + diff.tv_sec,
+            _self->last_ts.tv_nsec + diff.tv_nsec
+        };
+
+        if (to.tv_nsec >= N1e9) {
+            to.tv_sec += 1;
+            to.tv_nsec -= N1e9;
+        } else if (to.tv_nsec < 0) {
+            to.tv_sec -= 1;
+            to.tv_nsec += N1e9;
+        }
+
+        while (ret) {
+            ldebug("reduce mode, sleep to %ld.%ld", to.tv_sec, to.tv_nsec);
+            ret = clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &to, 0);
+            if (ret && ret != EINTR) {
+                lfatal("clock_nanosleep(%ld.%ld) %d", to.tv_sec, to.tv_nsec, ret);
+            }
+        }
 #elif HAVE_NANOSLEEP
-        /* relative time */
-        sleep_to.tv_sec  = 0;
-        sleep_to.tv_nsec = 0;
+        while (ret) {
+            ldebug("reduce mode, sleep for %ld.%ld", diff.tv_sec, diff.tv_nsec);
+            if ((ret = nanosleep(&diff, &diff))) {
+                ret = errno;
+                if (ret != EINTR) {
+                    lfatal("nanosleep(%ld.%ld) %d", diff.tv_sec, diff.tv_nsec, ret);
+                }
+            }
+        }
+#endif
+    }
+
+    _self->last_pkthdr_ts = q->ts;
+
+#if HAVE_CLOCK_NANOSLEEP
+    if (clock_gettime(CLOCK_MONOTONIC, &_self->last_ts)) {
+        lfatal("clock_gettime()");
+    }
+#endif
+
+    self->recv(self->robj, q);
+
+    return 0;
+}
+
+static int _multiply(filter_timing_t* self, core_query_t* q)
+{
+    _filter_timing_t* _self = (_filter_timing_t*)self;
+    struct timespec   diff  = {
+        q->ts.sec - _self->last_pkthdr_ts.sec,
+        q->ts.nsec - _self->last_pkthdr_ts.nsec
+    };
+    int ret = EINTR;
+
+    if (diff.tv_nsec >= N1e9) {
+        diff.tv_sec += 1;
+        diff.tv_nsec -= N1e9;
+    } else if (diff.tv_nsec < 0) {
+        diff.tv_sec -= 1;
+        diff.tv_nsec += N1e9;
+    }
+
+    diff.tv_sec  = (time_t)((float)diff.tv_sec * self->mul);
+    diff.tv_nsec = (long)((float)diff.tv_nsec * self->mul);
+    if (diff.tv_nsec >= N1e9) {
+        diff.tv_sec += diff.tv_nsec / N1e9;
+        diff.tv_nsec %= N1e9;
+    }
+
+    if (diff.tv_sec > -1 && diff.tv_nsec > -1) {
+#if HAVE_CLOCK_NANOSLEEP
+        struct timespec to = {
+            _self->last_ts.tv_sec + diff.tv_sec,
+            _self->last_ts.tv_nsec + diff.tv_nsec
+        };
+
+        if (to.tv_nsec >= N1e9) {
+            to.tv_sec += 1;
+            to.tv_nsec -= N1e9;
+        } else if (to.tv_nsec < 0) {
+            to.tv_sec -= 1;
+            to.tv_nsec += N1e9;
+        }
+
+        while (ret) {
+            ldebug("multiply mode, sleep to %ld.%ld", to.tv_sec, to.tv_nsec);
+            ret = clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &to, 0);
+            if (ret && ret != EINTR) {
+                lfatal("clock_nanosleep(%ld.%ld) %d", to.tv_sec, to.tv_nsec, ret);
+            }
+        }
+#elif HAVE_NANOSLEEP
+        while (ret) {
+            ldebug("multiply mode, sleep for %ld.%ld", diff.tv_sec, diff.tv_nsec);
+            if ((ret = nanosleep(&diff, &diff))) {
+                ret = errno;
+                if (ret != EINTR) {
+                    lfatal("nanosleep(%ld.%ld) %d", diff.tv_sec, diff.tv_nsec, ret);
+                }
+            }
+        }
+#endif
+    }
+
+    _self->last_pkthdr_ts = q->ts;
+
+#if HAVE_CLOCK_NANOSLEEP
+    if (clock_gettime(CLOCK_MONOTONIC, &_self->last_ts)) {
+        lfatal("clock_gettime()");
+    }
+#endif
+
+    self->recv(self->robj, q);
+
+    return 0;
+}
+
+static int _init(filter_timing_t* self, core_query_t* q)
+{
+    _filter_timing_t* _self = (_filter_timing_t*)self;
+
+#if HAVE_CLOCK_NANOSLEEP
+    if (clock_gettime(CLOCK_MONOTONIC, &_self->last_ts)) {
+        lfatal("clock_gettime()");
+    }
+    _self->diff = _self->last_ts;
+    _self->diff.tv_sec -= q->ts.sec;
+    _self->diff.tv_nsec -= q->ts.nsec;
+    ldebug("init with clock_nanosleep() now is %ld.%ld, diff of first pkt %ld.%ld",
+        _self->last_ts.tv_sec, _self->last_ts.tv_nsec,
+        _self->diff.tv_sec, _self->diff.tv_nsec);
+#elif HAVE_NANOSLEEP
+    ldebug("init with nanosleep()");
 #else
 #error "No clock_nanosleep() or nanosleep(), can not continue"
 #endif
 
-        sleep_to.tv_nsec += diff.tv_usec * 1000;
-        if (sleep_to.tv_nsec > 999999999) {
-            sleep_to.tv_sec += sleep_to.tv_nsec / 1000000000;
-            sleep_to.tv_nsec %= 1000000000;
-        }
-        sleep_to.tv_sec += diff.tv_sec;
+    _self->last_pkthdr_ts = q->ts;
 
-        if (pdiff.tv_sec) {
-            if (sleep_to.tv_sec > pdiff.tv_sec)
-                sleep_to.tv_sec -= pdiff.tv_sec;
-            else
-                sleep_to.tv_sec = 0;
-        }
-        if (pdiff.tv_nsec) {
-            if (sleep_to.tv_nsec >= pdiff.tv_nsec)
-                sleep_to.tv_nsec -= pdiff.tv_nsec;
-            else if (sleep_to.tv_sec) {
-                sleep_to.tv_sec -= 1;
-                sleep_to.tv_nsec += 1000000000 - pdiff.tv_nsec;
-            } else
-                sleep_to.tv_nsec = 0;
-        }
-
-        switch (self->mode) {
-        case TIMING_MODE_INCREASE:
-            sleep_to.tv_nsec += self->inc;
-            break;
-
-        case TIMING_MODE_REDUCE: {
-            unsigned long int nsec = self->red;
-
-            if (nsec > 999999999) {
-                unsigned long int sec = nsec / 1000000000;
-                if (sleep_to.tv_sec > sec)
-                    sleep_to.tv_sec -= sec;
-                else
-                    sleep_to.tv_sec = 0;
-                nsec %= 1000000000;
-            }
-            if (nsec) {
-                if (sleep_to.tv_nsec >= nsec)
-                    sleep_to.tv_nsec -= nsec;
-                else if (sleep_to.tv_sec) {
-                    sleep_to.tv_sec -= 1;
-                    sleep_to.tv_nsec += 1000000000 - nsec;
-                } else
-                    sleep_to.tv_nsec = 0;
-            }
-        } break;
-
-        default:
-            break;
-        }
-
-        if (sleep_to.tv_nsec > 999999999) {
-            sleep_to.tv_sec += sleep_to.tv_nsec / 1000000000;
-            sleep_to.tv_nsec %= 1000000000;
-        }
-
-        ldebug("last %lu.%09lu", self->last_time.sec, self->last_time.nsec);
-        ldebug("now %lu.%09lu", now.tv_sec, now.tv_nsec);
-        ldebug("sleep_to %lu.%09lu", sleep_to.tv_sec, sleep_to.tv_nsec);
-
-#if HAVE_CLOCK_NANOSLEEP
-        if (self->mode != TIMING_MODE_BEST_EFFORT
-            && (sleep_to.tv_sec < now.tv_sec
-                   || (sleep_to.tv_sec == now.tv_sec && sleep_to.tv_nsec < now.tv_nsec))) {
-            ldebug("Unable to keep up with timings (process cost %lu.%09lu, packet diff %lu.%06lu, now %lu.%09lu, sleep to %lu.%09lu)",
-                pdiff.tv_sec, pdiff.tv_nsec,
-                diff.tv_sec, diff.tv_usec,
-                now.tv_sec, now.tv_nsec,
-                sleep_to.tv_sec, sleep_to.tv_nsec);
-            sleep_to.tv_sec  = 0;
-            sleep_to.tv_nsec = 0;
-        }
-
-        if (sleep_to.tv_sec || sleep_to.tv_nsec) {
-            clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &sleep_to, 0);
-        }
-#elif HAVE_NANOSLEEP
-        //#define SAVE_REALTIME 1
-        /* sleep_to will be relative, need to check against now - last_time */
-        if (self->mode != TIMING_MODE_BEST_EFFORT
-            && (sleep_to.tv_sec < (now.tv_sec - self->last_time.sec)
-                   || (sleep_to.tv_sec == (now.tv_sec - self->last_time.sec) && sleep_to.tv_nsec < (now.tv_nsec - self->last_time.nsec)))) {
-            ldebug("Unable to keep up with timings (process cost %lu.%09lu, packet diff %lu.%06lu, now %lu.%09lu, sleep to %lu.%09lu)",
-                pdiff.tv_sec, pdiff.tv_nsec,
-                diff.tv_sec, diff.tv_usec,
-                now.tv_sec, now.tv_nsec,
-                self->last_time.sec + sleep_to.tv_sec, self->last_time.nsec + sleep_to.tv_nsec);
-            sleep_to.tv_sec  = 0;
-            sleep_to.tv_nsec = 0;
-        }
-
-        if (sleep_to.tv_sec || sleep_to.tv_nsec) {
-            nanosleep(&sleep_to, 0);
-        }
-#endif
+    switch (self->mode) {
+    case TIMING_MODE_KEEP:
+        ldebug("init mode keep");
+        _self->timing_callback = _keep;
+        break;
+    case TIMING_MODE_INCREASE:
+        _self->timing_callback = _increase;
+        _self->mod_ts.tv_sec   = self->inc / N1e9;
+        _self->mod_ts.tv_nsec  = self->inc % N1e9;
+        ldebug("init mode increase by %ld.%ld", _self->mod_ts.tv_sec, _self->mod_ts.tv_nsec);
+        break;
+    case TIMING_MODE_REDUCE:
+        _self->timing_callback = _reduce;
+        _self->mod_ts.tv_sec   = self->red / N1e9;
+        _self->mod_ts.tv_nsec  = self->red % N1e9;
+        ldebug("init mode reduce by %ld.%ld", _self->mod_ts.tv_sec, _self->mod_ts.tv_nsec);
+        break;
+    case TIMING_MODE_MULTIPLY:
+        _self->timing_callback = _multiply;
+        ldebug("init mode multiply by %f", self->mul);
+        break;
+    default:
+        lfatal("invalid timing mode %d", self->mode);
+        return 1;
     }
-
-    if (clock_gettime(CLOCK_MONOTONIC, &last_time)) {
-        lfatal("clock_gettime()");
-        // self->last_time.tv_sec  = 0;
-        // self->last_time.tv_nsec = 0;
-    }
-    self->last_time.sec  = last_time.tv_sec;
-    self->last_time.nsec = last_time.tv_nsec;
-    // #ifdef SAVE_REALTIME
-    //     if (clock_gettime(CLOCK_REALTIME, &last_realtime)) {
-    //         lfatal("clock_gettime()");
-    //         // self->last_realtime.tv_sec  = 0;
-    //         // self->last_realtime.tv_nsec = 0;
-    //         // self->last_time.tv_sec      = 0;
-    //         // self->last_time.tv_nsec     = 0;
-    //     }
-    // #endif
-    //     self->last_realtime.sec  = last_realtime.tv_sec;
-    //     self->last_realtime.nsec = last_realtime.tv_nsec;
-
-    self->last_packet = q->ts;
 
     self->recv(self->robj, q);
 
-    if (clock_gettime(CLOCK_MONOTONIC, &last_time_queue)) {
-        lfatal("clock_gettime()");
-        // self->last_time_queue.tv_sec  = 0;
-        // self->last_time_queue.tv_nsec = 0;
-    }
-    self->last_time_queue.sec  = last_time_queue.tv_sec;
-    self->last_time_queue.nsec = last_time_queue.tv_nsec;
-
     return 0;
+}
+
+filter_timing_t* filter_timing_new()
+{
+    filter_timing_t*  self  = malloc(sizeof(_filter_timing_t));
+    _filter_timing_t* _self = (_filter_timing_t*)self;
+
+    if (self) {
+        *self                  = _defaults;
+        _self->timing_callback = _init;
+
+        ldebug("new");
+    }
+
+    return self;
+}
+
+void filter_timing_free(filter_timing_t* self)
+{
+    ldebug("free");
+    free(self);
+}
+
+static int _receive(void* robj, core_query_t* q)
+{
+    _filter_timing_t* _self = (_filter_timing_t*)robj;
+
+    if (!_self || !q || !_self->pub.recv) {
+        core_query_free(q);
+        return 1;
+    }
+
+    return _self->timing_callback((filter_timing_t*)_self, q);
 }
 
 core_receiver_t filter_timing_receiver()

--- a/src/filter/timing.hh
+++ b/src/filter/timing.hh
@@ -27,24 +27,17 @@ typedef struct filter_timing {
     void*           robj;
 
     enum {
-        TIMING_MODE_KEEP        = 0,
-        TIMING_MODE_INCREASE    = 1,
-        TIMING_MODE_REDUCE      = 2,
-        TIMING_MODE_MULTIPLY    = 3,
-        TIMING_MODE_BEST_EFFORT = 4
+        TIMING_MODE_KEEP     = 0,
+        TIMING_MODE_INCREASE = 1,
+        TIMING_MODE_REDUCE   = 2,
+        TIMING_MODE_MULTIPLY = 3
     } mode;
     size_t inc, red;
     float  mul;
-
-    core_timespec_t last_packet;
-    core_timespec_t last_time;
-    core_timespec_t last_realtime;
-    core_timespec_t last_time_queue;
-
 } filter_timing_t;
 
-core_log_t* filter_timing_log();
-int filter_timing_init(filter_timing_t* self);
-int filter_timing_destroy(filter_timing_t* self);
+core_log_t*      filter_timing_log();
+filter_timing_t* filter_timing_new();
+void filter_timing_free(filter_timing_t* self);
 
 core_receiver_t filter_timing_receiver();

--- a/src/filter/timing.lua
+++ b/src/filter/timing.lua
@@ -30,18 +30,15 @@ require("dnsjit.filter.timing_h")
 local ffi = require("ffi")
 local C = ffi.C
 
-local t_name = "filter_timing_t"
-local filter_timing_t = ffi.typeof(t_name)
 local Timing = {}
 
 -- Create a new Timing filter.
 function Timing.new()
     local self = {
         _receiver = nil,
-        obj = filter_timing_t(),
+        obj = C.filter_timing_new(),
     }
-    C.filter_timing_init(self.obj)
-    ffi.gc(self.obj, C.filter_timing_destroy)
+    ffi.gc(self.obj, C.filter_timing_free)
     return setmetatable(self, { __index = Timing })
 end
 
@@ -77,12 +74,6 @@ end
 function Timing:multiply(factor)
     self.obj.mode = "TIMING_MODE_MULTIPLY"
     self.obj.mul = factor
-end
-
--- Set the timing mode to keep the timing between packets but ignore any
--- issues in doing so.
-function Timing:best_effort()
-    self.obj.mode = "TIMING_MODE_BEST_EFFORT"
 end
 
 function Timing:receive()


### PR DESCRIPTION
- `core.timespec`: Is now a signed value
- `filter.timing`:
  - Add private structure and use new/free instead of init/destroy
  - Rework timing code, based on DNS-OARC/drool#99
  - Remove `best_effort` mode, same as `keep` now