### PR TITLE
Fixes

### DIFF
--- a/src/core/log.h
+++ b/src/core/log.h
@@ -38,6 +38,34 @@
 
 #include "core/log.hh"
 
+#ifdef DNSJIT_NO_LOGGING
+
+#define ldebug(msg...)
+#define linfo(msg...)
+#define lnotice(msg...)
+#define lwarning(msg...)
+#define lcritical(msg...)
+
+#define lpdebug(msg...)
+#define lpinfo(msg...)
+#define lpnotice(msg...)
+#define lpwarning(msg...)
+#define lpcritical(msg...)
+
+#define mldebug(msg...)
+#define mlinfo(msg...)
+#define mlnotice(msg...)
+#define mlwarning(msg...)
+#define mlcritical(msg...)
+
+#define gldebug(msg...)
+#define glinfo(msg...)
+#define glnotice(msg...)
+#define glwarning(msg...)
+#define glcritical(msg...)
+
+#else
+
 #define ldebug(msg...) core_log_debug(&self->_log, __FILE__, __LINE__, msg)
 #define linfo(msg...) core_log_info(&self->_log, __FILE__, __LINE__, msg)
 #define lnotice(msg...) core_log_notice(&self->_log, __FILE__, __LINE__, msg)
@@ -64,6 +92,13 @@
 #define glnotice(msg...) core_log_notice(0, __FILE__, __LINE__, msg)
 #define glwarning(msg...) core_log_warning(0, __FILE__, __LINE__, msg)
 #define glcritical(msg...) core_log_critical(0, __FILE__, __LINE__, msg)
+#define glfatal(msg...) core_log_fatal(0, __FILE__, __LINE__, msg)
+
+#endif
+
+#define lfatal(msg...) core_log_fatal(&self->_log, __FILE__, __LINE__, msg)
+#define lpfatal(msg...) core_log_fatal(self->_log, __FILE__, __LINE__, msg)
+#define mlfatal(msg...) core_log_fatal(&_log, __FILE__, __LINE__, msg)
 #define glfatal(msg...) core_log_fatal(0, __FILE__, __LINE__, msg)
 
 #endif

--- a/src/core/log.lua
+++ b/src/core/log.lua
@@ -347,7 +347,7 @@ function Log.debug(self, ...)
 end
 
 -- Generate an info message.
-function Log:info(format, ...)
+function Log.info(self, ...)
     local format
     if not ffi.istype(t_name, self) then
         format = self
@@ -405,7 +405,7 @@ function Log:info(format, ...)
 end
 
 -- Generate a notice message.
-function Log:notice(format, ...)
+function Log.notice(self, ...)
     local format
     if not ffi.istype(t_name, self) then
         format = self
@@ -463,7 +463,7 @@ function Log:notice(format, ...)
 end
 
 -- Generate a warning message.
-function Log:warning(format, ...)
+function Log.warning(self, ...)
     local format
     if not ffi.istype(t_name, self) then
         format = self
@@ -521,7 +521,7 @@ function Log:warning(format, ...)
 end
 
 -- Generate a critical message.
-function Log:critical(format, ...)
+function Log.critical(self, ...)
     local format
     if not ffi.istype(t_name, self) then
         format = self
@@ -562,7 +562,7 @@ function Log:critical(format, ...)
 end
 
 -- Generate a fatal message.
-function Log:fatal(format, ...)
+function Log.fatal(self, ...)
     local format
     if not ffi.istype(t_name, self) then
         format = self

--- a/src/core/query.c
+++ b/src/core/query.c
@@ -25,6 +25,7 @@
 #include <string.h>
 #include <arpa/inet.h>
 #include <sys/socket.h>
+#include <pthread.h>
 
 #if INET_ADDRSTRLEN > INET6_ADDRSTRLEN
 #define NTOP_BUFSIZE INET_ADDRSTRLEN
@@ -32,95 +33,108 @@
 #define NTOP_BUFSIZE INET6_ADDRSTRLEN
 #endif
 
-#define NUM_LABELS 512
-#define NUM_RRS 128
+#define NUM_LABELS 128
+#define NUM_RRS 64
 
-typedef struct _query {
-    core_query_t pub;
-
-    int                     af;
-    struct sockaddr_storage src;
-    struct sockaddr_storage dst;
-    char                    ntop_buf[NTOP_BUFSIZE];
-
-    omg_dns_t dns;
-
-    unsigned short parsed : 1;
-    size_t         rr_idx;
-    omg_dns_rr_t   rr[NUM_RRS];
-    int            rr_ret[NUM_RRS];
-    size_t         rr_label_idx[NUM_RRS];
+typedef struct _parse {
+    size_t       rr_idx;
+    omg_dns_rr_t rr[NUM_RRS];
+    int          rr_ret[NUM_RRS];
+    size_t       rr_label_idx[NUM_RRS];
 
     size_t          label_idx;
     omg_dns_label_t label[NUM_LABELS];
 
     int  at_rr;
     char label_buf[512];
+} _parse_t;
+
+typedef struct _query {
+    core_query_t  pub;
+    core_query_t* next;
+
+    int                     af;
+    struct sockaddr_storage src;
+    struct sockaddr_storage dst;
+    char*                   ntop_buf;
+
+    omg_dns_t dns;
+
+    _parse_t* parsed;
 } _query_t;
 
-static core_log_t   _log      = LOG_T_INIT("core.query");
-static core_query_t _defaults = {
-    LOG_T_INIT_OBJ("core.query"),
-    0, 0, 0,
-    0, 0, 0, 0,
-    0, 0, { 0, 0 },
-    "", 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0
-};
-static omg_dns_t _omg_dns_defaults = OMG_DNS_T_INIT;
+static core_log_t      _log            = LOG_T_INIT("core.query");
+static core_query_t*   _freelist       = 0;
+static size_t          _numfree        = 0;
+static pthread_mutex_t _freelist_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+#define MAX_FREE (128 * 1024)
+
+#define _self ((_query_t*)self)
 
 core_log_t* core_query_log()
 {
     return &_log;
 }
 
-static int _label_callback(const omg_dns_label_t* label, void* context)
+static int _label_callback(const omg_dns_label_t* label, void* self)
 {
-    _query_t* _self = (_query_t*)context;
-
-    if (!_self || _self->label_idx == NUM_LABELS)
+    if (!_self || _self->parsed->label_idx == NUM_LABELS)
         return OMG_DNS_ENOMEM;
 
-    _self->label[_self->label_idx] = *label;
-    _self->label_idx++;
+    _self->parsed->label[_self->parsed->label_idx] = *label;
+    _self->parsed->label_idx++;
 
     return OMG_DNS_OK;
 }
 
-static int _rr_callback(int ret, const omg_dns_rr_t* rr, void* context)
+static int _rr_callback(int ret, const omg_dns_rr_t* rr, void* self)
 {
-    _query_t* _self = (_query_t*)context;
-
-    if (!_self || _self->rr_idx == NUM_RRS)
+    if (!_self || _self->parsed->rr_idx == NUM_RRS)
         return OMG_DNS_ENOMEM;
 
-    _self->rr_ret[_self->rr_idx] = ret;
+    _self->parsed->rr_ret[_self->parsed->rr_idx] = ret;
     if (rr)
-        _self->rr[_self->rr_idx] = *rr;
-    _self->rr_idx++;
-    if (_self->rr_idx != NUM_RRS)
-        _self->rr_label_idx[_self->rr_idx] = _self->label_idx;
+        _self->parsed->rr[_self->parsed->rr_idx] = *rr;
+    _self->parsed->rr_idx++;
+    if (_self->parsed->rr_idx != NUM_RRS)
+        _self->parsed->rr_label_idx[_self->parsed->rr_idx] = _self->parsed->label_idx;
 
     return OMG_DNS_OK;
 }
 
 core_query_t* core_query_new()
 {
-    core_query_t* self  = malloc(sizeof(_query_t));
-    _query_t*     _self = (_query_t*)self;
+    core_query_t* self;
+
+    if (pthread_mutex_lock(&_freelist_mutex)) {
+        self            = malloc(sizeof(_query_t));
+        _self->parsed   = 0;
+        _self->ntop_buf = 0;
+        self->raw       = 0;
+    } else {
+        if (_freelist) {
+            self      = _freelist;
+            _freelist = _self->next;
+            _numfree--;
+            pthread_mutex_unlock(&_freelist_mutex);
+        } else {
+            pthread_mutex_unlock(&_freelist_mutex);
+            self            = malloc(sizeof(_query_t));
+            _self->parsed   = 0;
+            _self->ntop_buf = 0;
+            self->raw       = 0;
+        }
+    }
 
     if (self) {
-        *self         = _defaults;
-        _self->af     = AF_UNSPEC;
-        _self->dns    = _omg_dns_defaults;
-        _self->parsed = 0;
-
-        ldebug("new");
-
-        omg_dns_set_rr_callback(&_self->dns, _rr_callback, (void*)_self);
-        omg_dns_set_label_callback(&_self->dns, _label_callback, (void*)_self);
+        char*  raw  = self->raw;
+        size_t rlen = self->rlen;
+        memset(self, 0, sizeof(core_query_t));
+        self->raw  = raw;
+        self->rlen = rlen;
+        memset(&_self->dns, 0, sizeof(omg_dns_t));
+        _self->af = AF_UNSPEC;
     }
 
     return self;
@@ -128,11 +142,26 @@ core_query_t* core_query_new()
 
 void core_query_free(core_query_t* self)
 {
-    ldebug("free");
-
     if (self) {
-        free(self->raw);
-        free(self);
+        if (pthread_mutex_lock(&_freelist_mutex)) {
+            free(_self->ntop_buf);
+            free(_self->parsed);
+            free(self->raw);
+            free(self);
+        } else {
+            if (_numfree < MAX_FREE) {
+                _self->next = _freelist;
+                _freelist   = self;
+                _numfree++;
+                pthread_mutex_unlock(&_freelist_mutex);
+            } else {
+                pthread_mutex_unlock(&_freelist_mutex);
+                free(_self->ntop_buf);
+                free(_self->parsed);
+                free(self->raw);
+                free(self);
+            }
+        }
     }
 }
 
@@ -142,18 +171,20 @@ int core_query_set_raw(core_query_t* self, const char* raw, size_t len)
         return 1;
     }
 
-    ldebug("set raw %p %lu", raw, len);
-
-    if (self->raw) {
-        free(self->raw);
-        self->raw      = 0;
-        self->len      = 0;
-        self->have_raw = 0;
-    }
     if (len > sizeof(self->small)) {
-        if (!(self->raw = malloc(len))) {
-            return 1;
+        if (!self->raw) {
+            if (!(self->raw = malloc(len))) {
+                return 1;
+            }
+            self->rlen = len;
+        } else if (len > self->rlen) {
+            free(self->raw);
+            if (!(self->raw = malloc(len))) {
+                return 1;
+            }
+            self->rlen = len;
         }
+
         memcpy(self->raw, raw, len);
     } else {
         memcpy(self->small, raw, len);
@@ -164,37 +195,32 @@ int core_query_set_raw(core_query_t* self, const char* raw, size_t len)
     return 0;
 }
 
+#define _copy ((_query_t*)copy)
+
 core_query_t* core_query_copy(core_query_t* self)
 {
-    core_query_t* q = core_query_new();
+    core_query_t* copy = core_query_new();
 
-    ldebug("copy %p", q);
+    if (copy) {
+        memcpy(copy, self, sizeof(_query_t));
+        copy->have_raw = 0;
+        copy->raw      = 0;
+        copy->len      = 0;
 
-    if (q) {
-        _query_t* _q = (_query_t*)q;
-        *_q          = *(_query_t*)self;
-        q->have_raw  = 0;
-        q->raw       = 0;
-        q->len       = 0;
+        _copy->ntop_buf = 0;
+        _copy->parsed   = 0;
 
-        if (!_q->parsed) {
-            omg_dns_set_rr_callback(&_q->dns, _rr_callback, (void*)_q);
-            omg_dns_set_label_callback(&_q->dns, _label_callback, (void*)_q);
-        }
-
-        if (self->have_raw && core_query_set_raw(q, core_query_raw(self), self->len)) {
-            core_query_free(q);
+        if (self->have_raw && core_query_set_raw(copy, core_query_raw(self), self->len)) {
+            core_query_free(copy);
             return 0;
         }
     }
 
-    return q;
+    return copy;
 }
 
 int core_query_parse_header(core_query_t* self)
 {
-    _query_t* _self = (_query_t*)self;
-
     if (!_self || !self->have_raw || _self->dns.have_header) {
         return 1;
     }
@@ -239,14 +265,20 @@ int core_query_parse_header(core_query_t* self)
 
 int core_query_parse(core_query_t* self)
 {
-    _query_t* _self = (_query_t*)self;
-
     if (!_self || !self->have_raw || _self->parsed || _self->dns.have_body) {
         return 1;
     }
 
-    _self->rr_idx    = 0;
-    _self->label_idx = 0;
+    if (!(_self->parsed = malloc(sizeof(_parse_t)))) {
+        return 1;
+    }
+
+    _self->parsed->rr_idx    = 0;
+    _self->parsed->label_idx = 0;
+
+    omg_dns_set_rr_callback(&_self->dns, _rr_callback, (void*)_self);
+    omg_dns_set_label_callback(&_self->dns, _label_callback, (void*)_self);
+
     if (!_self->dns.have_header) {
         if (omg_dns_parse(&_self->dns, (const u_char*)(self->raw ? self->raw : self->small), self->len)) {
             return 2;
@@ -287,9 +319,8 @@ int core_query_parse(core_query_t* self)
             return 2;
         }
     }
-    _self->parsed       = 1;
-    _self->at_rr        = -1;
-    _self->label_buf[0] = 0;
+    _self->parsed->at_rr        = -1;
+    _self->parsed->label_buf[0] = 0;
 
     self->questions   = _self->dns.questions;
     self->answers     = _self->dns.answers;
@@ -301,85 +332,80 @@ int core_query_parse(core_query_t* self)
 
 int core_query_rr_next(core_query_t* self)
 {
-    _query_t* _self = (_query_t*)self;
-
     if (!_self || !_self->parsed) {
         return 1;
     }
 
-    if (_self->at_rr < 0) {
-        _self->at_rr = 0;
-    } else if (_self->at_rr < _self->rr_idx) {
-        _self->at_rr++;
+    if (_self->parsed->at_rr < 0) {
+        _self->parsed->at_rr = 0;
+    } else if (_self->parsed->at_rr < _self->parsed->rr_idx) {
+        _self->parsed->at_rr++;
     }
 
-    return _self->at_rr < _self->rr_idx ? 0 : 1;
+    return _self->parsed->at_rr < _self->parsed->rr_idx ? 0 : 1;
 }
 
 int core_query_rr_ok(core_query_t* self)
 {
-    _query_t* _self = (_query_t*)self;
-
-    if (!_self || !_self->parsed || _self->at_rr < 0 || _self->at_rr >= _self->rr_idx) {
+    if (!_self || !_self->parsed || _self->parsed->at_rr < 0 || _self->parsed->at_rr >= _self->parsed->rr_idx) {
         return 0;
     }
 
-    return _self->rr_ret[_self->at_rr] == OMG_DNS_OK ? 1 : 0;
+    return _self->parsed->rr_ret[_self->parsed->at_rr] == OMG_DNS_OK ? 1 : 0;
 }
 
 const char* core_query_rr_label(core_query_t* self)
 {
-    _query_t* _self = (_query_t*)self;
-    char*     label;
-    size_t    left;
+    char*  label;
+    size_t left;
 
-    if (!_self || !_self->parsed || _self->at_rr < 0 || _self->at_rr >= _self->rr_idx || _self->rr_ret[_self->at_rr] != OMG_DNS_OK) {
+    if (!_self || !_self->parsed || _self->parsed->at_rr < 0 || _self->parsed->at_rr >= _self->parsed->rr_idx || _self->parsed->rr_ret[_self->parsed->at_rr] != OMG_DNS_OK) {
         return 0;
     }
 
-    label = _self->label_buf;
-    left  = sizeof(_self->label_buf) - 1;
+    label = _self->parsed->label_buf;
+    left  = sizeof(_self->parsed->label_buf) - 1;
 
-    if (omg_dns_rr_labels(&_self->rr[_self->at_rr])) {
-        size_t l    = _self->rr_label_idx[_self->at_rr];
+    if (omg_dns_rr_labels(&_self->parsed->rr[_self->parsed->at_rr])) {
+        size_t l    = _self->parsed->rr_label_idx[_self->parsed->at_rr];
         size_t loop = 0;
 
-        while (!omg_dns_label_is_end(&(_self->label[l]))) {
-            if (!omg_dns_label_is_complete(&(_self->label[l]))) {
-                ldebug("label %lu incomplete", l);
+        while (!omg_dns_label_is_end(&(_self->parsed->label[l]))) {
+            if (!omg_dns_label_is_complete(&(_self->parsed->label[l]))) {
+                mldebug("label %lu incomplete", l);
                 return 0;
             }
 
-            if (loop > _self->label_idx) {
-                ldebug("label %lu looped", l);
+            if (loop > _self->parsed->label_idx) {
+                mldebug("label %lu looped", l);
                 return 0;
             }
             loop++;
 
-            if (omg_dns_label_have_offset(&(_self->label[l]))) {
+            if (omg_dns_label_have_offset(&(_self->parsed->label[l]))) {
                 size_t l2;
 
-                for (l2 = 0; l2 < _self->label_idx; l2++) {
-                    if (omg_dns_label_have_dn(&(_self->label[l2]))
-                        && omg_dns_label_offset(&(_self->label[l2])) == omg_dns_label_offset(&(_self->label[l]))) {
+                for (l2 = 0; l2 < _self->parsed->label_idx; l2++) {
+                    if (omg_dns_label_have_dn(&(_self->parsed->label[l2]))
+                        && omg_dns_label_offset(&(_self->parsed->label[l2])) == omg_dns_label_offset(&(_self->parsed->label[l]))) {
                         l = l2;
                         break;
                     }
                 }
-                if (l2 < _self->label_idx) {
+                if (l2 < _self->parsed->label_idx) {
                     continue;
                 }
-                ldebug("label %lu offset missing", l);
+                mldebug("label %lu offset missing", l);
                 return 0;
-            } else if (omg_dns_label_have_extension_bits(&(_self->label[l]))) {
-                ldebug("label %lu is an extension", l);
+            } else if (omg_dns_label_have_extension_bits(&(_self->parsed->label[l]))) {
+                mldebug("label %lu is an extension", l);
                 return 0;
-            } else if (omg_dns_label_have_dn(&(_self->label[l]))) {
-                char*  dn    = (self->raw ? self->raw : self->small) + omg_dns_label_dn_offset(&(_self->label[l]));
-                size_t dnlen = omg_dns_label_length(&(_self->label[l]));
+            } else if (omg_dns_label_have_dn(&(_self->parsed->label[l]))) {
+                char*  dn    = (self->raw ? self->raw : self->small) + omg_dns_label_dn_offset(&(_self->parsed->label[l]));
+                size_t dnlen = omg_dns_label_length(&(_self->parsed->label[l]));
 
                 if ((dnlen + 1) > left) {
-                    ldebug("label %lu caused buffer overflow", l);
+                    mldebug("label %lu caused buffer overflow", l);
                     return 0;
                 }
                 memcpy(label, dn, dnlen);
@@ -392,54 +418,50 @@ const char* core_query_rr_label(core_query_t* self)
 
                 l++;
             } else {
-                ldebug("label %lu invalid", l);
+                mldebug("label %lu invalid", l);
                 return 0;
             }
         }
     }
 
     *label = 0;
-    return _self->label_buf;
+    return _self->parsed->label_buf;
 }
 
 uint16_t core_query_rr_type(core_query_t* self)
 {
-    _query_t* _self = (_query_t*)self;
-
-    if (!_self || !_self->parsed || _self->at_rr < 0 || _self->at_rr >= _self->rr_idx || _self->rr_ret[_self->at_rr] != OMG_DNS_OK) {
+    if (!_self || !_self->parsed || _self->parsed->at_rr < 0 || _self->parsed->at_rr >= _self->parsed->rr_idx || _self->parsed->rr_ret[_self->parsed->at_rr] != OMG_DNS_OK) {
         return 0;
     }
 
-    return _self->rr[_self->at_rr].type;
+    return _self->parsed->rr[_self->parsed->at_rr].type;
 }
 
 uint16_t core_query_rr_class(core_query_t* self)
 {
-    _query_t* _self = (_query_t*)self;
-
-    if (!_self || !_self->parsed || _self->at_rr < 0 || _self->at_rr >= _self->rr_idx || _self->rr_ret[_self->at_rr] != OMG_DNS_OK) {
+    if (!_self || !_self->parsed || _self->parsed->at_rr < 0 || _self->parsed->at_rr >= _self->parsed->rr_idx || _self->parsed->rr_ret[_self->parsed->at_rr] != OMG_DNS_OK) {
         return 0;
     }
 
-    return _self->rr[_self->at_rr].class;
+    return _self->parsed->rr[_self->parsed->at_rr].class;
 }
 
 uint32_t core_query_rr_ttl(core_query_t* self)
 {
-    _query_t* _self = (_query_t*)self;
-
-    if (!_self || !_self->parsed || _self->at_rr < 0 || _self->at_rr >= _self->rr_idx || _self->rr_ret[_self->at_rr] != OMG_DNS_OK) {
+    if (!_self || !_self->parsed || _self->parsed->at_rr < 0 || _self->parsed->at_rr >= _self->parsed->rr_idx || _self->parsed->rr_ret[_self->parsed->at_rr] != OMG_DNS_OK) {
         return 0;
     }
 
-    return _self->rr[_self->at_rr].ttl;
+    return _self->parsed->rr[_self->parsed->at_rr].ttl;
 }
 
 const char* core_query_src(core_query_t* self)
 {
-    _query_t* _self = (_query_t*)self;
-
     if (!_self || _self->af == AF_UNSPEC) {
+        return 0;
+    }
+
+    if (!_self->ntop_buf && !(_self->ntop_buf = malloc(NTOP_BUFSIZE))) {
         return 0;
     }
 
@@ -452,9 +474,11 @@ const char* core_query_src(core_query_t* self)
 
 const char* core_query_dst(core_query_t* self)
 {
-    _query_t* _self = (_query_t*)self;
-
     if (!_self || _self->af == AF_UNSPEC) {
+        return 0;
+    }
+
+    if (!_self->ntop_buf && !(_self->ntop_buf = malloc(NTOP_BUFSIZE))) {
         return 0;
     }
 
@@ -467,8 +491,6 @@ const char* core_query_dst(core_query_t* self)
 
 int core_query_set_src(core_query_t* self, int af, const void* addr, size_t len)
 {
-    _query_t* _self = (_query_t*)self;
-
     if (!_self || !addr || !len || len > sizeof(struct sockaddr_storage)) {
         return 1;
     }
@@ -485,8 +507,6 @@ int core_query_set_src(core_query_t* self, int af, const void* addr, size_t len)
 
 int core_query_set_dst(core_query_t* self, int af, const void* addr, size_t len)
 {
-    _query_t* _self = (_query_t*)self;
-
     if (!_self || !addr || !len || len > sizeof(struct sockaddr_storage)) {
         return 1;
     }
@@ -503,8 +523,6 @@ int core_query_set_dst(core_query_t* self, int af, const void* addr, size_t len)
 
 int core_query_set_parsed_header(core_query_t* self, omg_dns_t dns)
 {
-    _query_t* _self = (_query_t*)self;
-
     if (!_self || !self->have_raw || !dns.have_header || dns.have_body || dns.is_complete) {
         return 1;
     }
@@ -546,7 +564,6 @@ int core_query_set_parsed_header(core_query_t* self, omg_dns_t dns)
 
 int core_query_copy_addr(core_query_t* self, core_query_t* from)
 {
-    _query_t* _self = (_query_t*)self;
     _query_t* _from = (_query_t*)from;
 
     if (!_self || !_from) {

--- a/src/core/query.hh
+++ b/src/core/query.hh
@@ -21,8 +21,6 @@
 //lua:require("dnsjit.core.log")
 //lua:require("dnsjit.core.timespec_h")
 typedef struct core_query {
-    core_log_t _log;
-
     uint64_t src_id, qr_id, dst_id;
 
     unsigned short is_udp : 1;
@@ -33,9 +31,9 @@ typedef struct core_query {
     uint16_t        sport, dport;
     core_timespec_t ts;
 
-    char   small[64];
+    char   small[1500];
     char*  raw;
-    size_t len;
+    size_t rlen, len;
 
     unsigned short have_id : 1;
     unsigned short have_qr : 1;

--- a/src/lib/parseconf.lua
+++ b/src/lib/parseconf.lua
@@ -24,7 +24,7 @@
 --       print(k,...)
 --   end)
 -- .
---   conf:parse(file)
+--   conf:file(file)
 -- .
 --   print(conf:val("another_config_name"))
 --
@@ -96,13 +96,13 @@ function Parseconf:part(l, n)
     if p then
         return p, tonumber(p)
     end
-    p = l:match("^([^%s;]+)[%s;]", n)
-    if p then
-        return p, p
-    end
     p = l:match("^(\"[^\"]+\")[%s;]", n)
     if p then
         return p, p:sub(2, -2)
+    end
+    p = l:match("^([^%s;]+)[%s;]", n)
+    if p then
+        return p, p
     end
 end
 

--- a/src/output/cpool.c
+++ b/src/output/cpool.c
@@ -311,26 +311,18 @@ int output_cpool_stop(output_cpool_t* self)
 static int _receive(void* robj, core_query_t* q)
 {
     output_cpool_t* self = (output_cpool_t*)robj;
-    core_query_t*   copy;
 
     if (!self || !q || !self->p) {
         core_query_free(q);
         return 1;
     }
 
-    if (!(copy = core_query_copy(q))) {
-        core_query_free(q);
-        return 1;
-    }
-
-    if (client_pool_query(self->p, copy)) {
+    if (client_pool_query(self->p, q)) {
         ldebug("client_pool_query failed");
-        core_query_free(copy);
         core_query_free(q);
         return 1;
     }
 
-    core_query_free(q);
     return 0;
 }
 


### PR DESCRIPTION
- `core.log`:
  - Make it possible to turn off all logging at compile time with `DNSJIT_NO_LOGGING`
  - Fix logging functions in the Lua object
- `core.query`:
  - Remove object logging
  - Rework private object to reduce the size
  - Reduce number of labels and RRs parsed
  - Reuse objects using a thread safe free list
  - Keep `raw` buffer allocation between reuses
  - Increase `small` buffer to 1500 bytes
  - Drop parsed information between copies
- `lib.parseconf`:
  - Correct usage documentation
  - Fix matching of quoted strings
- `output.cpool`: Remove unneeded copying of query