### PR TITLE
Autoheader

### DIFF
--- a/src/dnsjit.c
+++ b/src/dnsjit.c
@@ -51,7 +51,16 @@ int main(int argc, char* argv[])
     sigset_t   set;
     pthread_t  sighthr;
 
-    fprintf(stderr, "<< " PACKAGE_NAME " v" PACKAGE_VERSION " " PACKAGE_URL " >>\n");
+#ifdef PACKAGE_NAME
+    fprintf(stderr, "<< " PACKAGE_NAME
+#ifdef PACKAGE_VERSION
+                    " v" PACKAGE_VERSION
+#endif
+#ifdef PACKAGE_URL
+                    " " PACKAGE_URL
+#endif
+                    " >>\n");
+#endif
 
     if (argc < 2) {
         fprintf(stderr, "usage: %s <file.lua> ...\n", argv[0]);


### PR DESCRIPTION
- Fix banner when autoconf `PACKAGE_` defines may not exist