### PR TITLE
Query Logging, v0.9.2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -17,7 +17,7 @@
 # along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
 
 AC_PREREQ(2.61)
-AC_INIT([dnsjit], [0.9.1], [admin@dns-oarc.net], [dnsjit], [https://github.com/DNS-OARC/dnsjit/issues])
+AC_INIT([dnsjit], [0.9.2], [admin@dns-oarc.net], [dnsjit], [https://github.com/DNS-OARC/dnsjit/issues])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
 AC_CONFIG_SRCDIR([src/dnsjit.c])
 AC_CONFIG_HEADER([src/config.h])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-dnsjit (0.9.1-1~unstable+1) unstable; urgency=low
+dnsjit (0.9.2-1~unstable+1) unstable; urgency=low
 
   * Initial changelog file
 

--- a/rpm/dnsjit.spec
+++ b/rpm/dnsjit.spec
@@ -1,5 +1,5 @@
 Name:           dnsjit
-Version:        0.9.1
+Version:        0.9.2
 Release:        1%{?dist}
 Summary:        Engine for capturing, parsing and replaying DNS
 Group:          Productivity/Networking/DNS/Utilities

--- a/src/core/query.lua
+++ b/src/core/query.lua
@@ -172,12 +172,9 @@ function Query.new(self)
     return self
 end
 
--- Return the Log object to control logging of this instance or module.
+-- Return the Log object to control logging of this module.
 function Query:log()
-    if self == nil then
-        return C.core_query_log()
-    end
-    return self._log
+    return C.core_query_log()
 end
 
 -- Parse the DNS headers or the query.


### PR DESCRIPTION
- `core.query`: Fix `log()`, do not attempt to return `_log` since it does not exist anymore
- Bump to v0.9.2