### PR TITLE
Input, objects, layers and more...

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **dnsjit** is a combination of parts taken from **dsc**, **dnscap**, **drool**,
 and put together around Lua to create a script-based engine for easy
-capturing, parsing and statistics gathering of DNS message while also
+capturing, parsing and statistics gathering of DNS messages while also
 providing facilities for replaying DNS traffic.
 
 One of the core functionality that **dnsjit** brings is to tie together C
@@ -99,8 +99,9 @@ local output = require("dnsjit.filter.lua").new()
 
 output:func(function(filter, packet)
     local dns = require("dnsjit.core.object.dns").new(packet)
-    dns:parse()
-    print(dns.id)
+    if dns:parse() == 0 then
+        print(dns.id)
+    end
 end)
 
 input:open_offline("file.pcap")

--- a/configure.ac
+++ b/configure.ac
@@ -37,6 +37,8 @@ AX_PTHREAD
 AX_PCAP_THREAD_PCAP
 AC_CHECK_LIB([ev], [ev_now], [], AC_MSG_ERROR([libev not found]))
 AC_CHECK_HEADER([ev.h], [AC_CHECK_HEADERS([ev.h])], [AC_CHECK_HEADER([libev/ev.h], [AC_CHECK_HEADERS([libev/ev.h])], [AC_MSG_ERROR([libev header not found])])])
+AC_CHECK_HEADERS([net/ethernet.h])
+AC_CHECK_HEADERS([net/ethertypes.h])
 AC_SEARCH_LIBS([clock_gettime],[rt])
 AC_CHECK_FUNCS([clock_nanosleep nanosleep])
 PKG_CHECK_MODULES([luajit], [luajit >= 2],,AC_MSG_ERROR([luajit v2+ not found]))
@@ -47,6 +49,8 @@ fi
 
 # Checks for sizes
 AC_CHECK_SIZEOF([void*])
+AC_CHECK_SIZEOF([uint64_t])
+AC_CHECK_SIZEOF([pthread_t])
 
 # Output Makefiles
 AC_CONFIG_FILES([

--- a/examples/dumpdns.lua
+++ b/examples/dumpdns.lua
@@ -10,6 +10,7 @@ local input = require("dnsjit.input.pcapthread").new()
 local output = require("dnsjit.filter.lua").new()
 
 output:func(function(filter, pkt)
+    require("dnsjit.core.object.packet")
     local dns
     if pkt:type() == "packet" then
         dns = require("dnsjit.core.object.dns").new(pkt)

--- a/examples/filter_rcode.lua
+++ b/examples/filter_rcode.lua
@@ -12,6 +12,7 @@ local output = require("dnsjit.filter.lua").new()
 
 output:push(tonumber(rcode))
 output:func(function(filter, pkt, args)
+    require("dnsjit.core.object.packet")
     local rcode = unpack(args, 0)
     local dns
     if pkt:type() == "packet" then

--- a/examples/replay.lua
+++ b/examples/replay.lua
@@ -37,6 +37,7 @@ input:open_offline(pcap)
 if getopt:val("responses") then
     local lua = require("dnsjit.filter.lua").new()
     lua:func(function(f, pkt)
+        require("dnsjit.core.object.packet")
         local dns
         if pkt:type() == "packet" then
             dns = require("dnsjit.core.object.dns").new(pkt)

--- a/examples/test_pcap_read.lua
+++ b/examples/test_pcap_read.lua
@@ -1,0 +1,69 @@
+#!/usr/bin/env dnsjit
+local pcap = arg[2]
+local num = arg[3]
+
+if pcap == nil then
+    print("usage: "..arg[1].." <pcap> [num times]")
+    return
+end
+
+inputs = { "fpcap", "mmpcap", "pcap", "pcapthread" }
+result = {}
+results = {}
+highest = nil
+
+if num == nil then
+    num = 10
+end
+
+for _, name in pairs(inputs) do
+    rt = 0.0
+    p = 0
+
+    print("run", name)
+    for n = 1, num do
+        o = require("dnsjit.output.null").new()
+        i = require("dnsjit.input."..name).new()
+        if name == "pcap" then
+            i:open_offline(pcap)
+            i:receiver(o)
+            i:dispatch()
+        elseif name == "pcapthread" then
+            i:open_offline(pcap)
+            i:receiver(o)
+            i:run()
+        else
+            i:open(pcap)
+            i:receiver(o)
+            i:run()
+        end
+
+        ss, sns = i:start_time()
+        es, ens = i:end_time()
+
+        if es > ss then
+            rt = rt + ((es - ss) - 1) + ((1000000000 - sns + ens)/1000000000)
+        elseif es == ss and ens > sns then
+            rt = rt + (ens - sns) / 1000000000
+        end
+
+        p = p + o:packets()
+    end
+
+    result[name] = {
+        rt = rt,
+        p = p
+    }
+    if highest == nil or rt > result[highest].rt then
+        highest = name
+    end
+    table.insert(results, name)
+end
+
+print("name", "runtime", "pps", "x", "pkts")
+print(highest, result[highest].rt, result[highest].p/result[highest].rt, 1.0, result[highest].p)
+for _, name in pairs(results) do
+    if name ~= highest then
+        print(name, result[name].rt, result[name].p/result[name].rt, result[highest].rt/result[name].rt, result[name].p)
+    end
+end

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -30,63 +30,30 @@ EXTRA_DIST = gen-manpage.lua dnsjit.1in
 
 bin_PROGRAMS = dnsjit
 
-dnsjit_SOURCES = dnsjit.c \
-  core/log.c core/mutex.c core/receiver.c core/tracking.c \
-  core/object/dns.c core/object/packet.c \
-  input/pcapthread.c input/zero.c \
-  filter/lua.c filter/split.c filter/timing.c \
-  output/cpool.c output/null.c \
-  output/cpool/client_pool.c output/cpool/client.c \
+dnsjit_SOURCES = dnsjit.c globals.c \
   omg-dns/omg_dns.c \
   pcap-thread/pcap_thread.c \
   sllq/sllq.c
-dist_dnsjit_SOURCES = \
-  core/log.h core/mutex.h core/object.h core/receiver.h core/timespec.h core/tracking.h \
-  core/object/dns.h core/object/packet.h \
-  input/pcapthread.h input/zero.h \
-  filter/lua.h filter/split.h filter/timing.h \
-  output/cpool.h output/null.h \
-  output/cpool/client_pool.h output/cpool/client.h \
+dist_dnsjit_SOURCES = core.lua lib.lua input.lua filter.lua output.lua \
   omg-dns/omg_dns.h \
   pcap-thread/pcap_thread.h \
   sllq/sllq.h
+lua_hobjects =
+lua_objects = core.luao lib.luao input.luao filter.luao output.luao
 dnsjit_LDADD = $(PTHREAD_LIBS) $(luajit_LIBS)
 
+# C source and headers
+dnsjit_SOURCES += core/log.c core/receiver.c core/object.c core/object/ip.c core/object/tcp.c core/object/pcap.c core/object/dns.c core/object/icmp6.c core/object/ieee802.c core/object/udp.c core/object/loop.c core/object/packet.c core/object/ip6.c core/object/gre.c core/object/linuxsll.c core/object/icmp.c core/object/null.c core/object/ether.c core/tracking.c core/mutex.c input/zero.c input/pcap.c input/fpcap.c input/mmpcap.c input/pcapthread.c filter/lua.c filter/split.c filter/thread.c filter/timing.c filter/coro.c filter/layer.c output/udpcli.c output/cpool.c output/cpool/client_pool.c output/cpool/client.c output/null.c
+dist_dnsjit_SOURCES += core/mutex.h core/receiver.h core/object.h core/log.h core/timespec.h core/tracking.h core/object/icmp.h core/object/ip.h core/object/loop.h core/object/dns.h core/object/ip6.h core/object/null.h core/object/tcp.h core/object/udp.h core/object/packet.h core/object/icmp6.h core/object/ether.h core/object/pcap.h core/object/ieee802.h core/object/linuxsll.h core/object/gre.h input/zero.h input/fpcap.h input/pcap.h input/mmpcap.h input/pcapthread.h filter/lua.h filter/split.h filter/layer.h filter/timing.h filter/thread.h filter/coro.h output/null.h output/cpool/client_pool.h output/cpool/client.h output/cpool.h output/udpcli.h
+
 # Lua headers
-dist_dnsjit_SOURCES += \
-  core/log.hh core/mutex.hh core/object.hh core/receiver.hh core/timespec.hh core/tracking.hh \
-  core/object/dns.hh core/object/packet.hh \
-  input/pcapthread.hh input/zero.hh \
-  filter/lua.hh filter/split.hh filter/timing.hh \
-  output/cpool.hh output/null.hh
-lua_hobjects = \
-  core/log.luaho core/mutex.luaho core/object.luaho core/receiver.luaho core/timespec.luaho core/tracking.luaho \
-  core/object/dns.luaho core/object/packet.luaho \
-  input/pcapthread.luaho input/zero.luaho \
-  filter/lua.luaho filter/split.luaho filter/timing.luaho \
-  output/cpool.luaho output/null.luaho
+dist_dnsjit_SOURCES += core/timespec.hh core/mutex.hh core/tracking.hh core/object/loop.hh core/object/gre.hh core/object/linuxsll.hh core/object/tcp.hh core/object/ether.hh core/object/icmp.hh core/object/ieee802.hh core/object/ip6.hh core/object/udp.hh core/object/packet.hh core/object/dns.hh core/object/pcap.hh core/object/icmp6.hh core/object/ip.hh core/object/null.hh core/receiver.hh core/object.hh core/log.hh input/zero.hh input/mmpcap.hh input/pcap.hh input/fpcap.hh input/pcapthread.hh filter/layer.hh filter/coro.hh filter/lua.hh filter/thread.hh filter/timing.hh filter/split.hh output/udpcli.hh output/cpool.hh output/null.hh
+lua_hobjects += core/timespec.luaho core/mutex.luaho core/tracking.luaho core/object/loop.luaho core/object/gre.luaho core/object/linuxsll.luaho core/object/tcp.luaho core/object/ether.luaho core/object/icmp.luaho core/object/ieee802.luaho core/object/ip6.luaho core/object/udp.luaho core/object/packet.luaho core/object/dns.luaho core/object/pcap.luaho core/object/icmp6.luaho core/object/ip.luaho core/object/null.luaho core/receiver.luaho core/object.luaho core/log.luaho input/zero.luaho input/mmpcap.luaho input/pcap.luaho input/fpcap.luaho input/pcapthread.luaho filter/layer.luaho filter/coro.luaho filter/lua.luaho filter/thread.luaho filter/timing.luaho filter/split.luaho output/udpcli.luaho output/cpool.luaho output/null.luaho
+
 # Lua sources
-dist_dnsjit_SOURCES += \
-  core/log.lua core/mutex.lua core/object.lua core/tracking.lua \
-  core/object/dns.lua core/object/packet.lua \
-  lib/getopt.lua lib/parseconf.lua \
-  input/pcapthread.lua input/zero.lua \
-  filter/lua.lua filter/split.lua filter/timing.lua \
-  output/cpool.lua output/null.lua
-lua_objects = \
-  core/log.luao core/mutex.luao core/object.luao core/tracking.luao \
-  core/object/dns.luao core/object/packet.luao \
-  lib/getopt.luao lib/parseconf.luao \
-  input/pcapthread.luao input/zero.luao \
-  filter/lua.luao filter/split.luao filter/timing.luao \
-  output/cpool.luao output/null.luao
-# Documentation only sources
-dist_dnsjit_SOURCES += \
-  core.lua core/receiver.lua core/timespec.lua \
-  lib.lua \
-  input.lua \
-  filter.lua \
-  output.lua
+dist_dnsjit_SOURCES += core/mutex.lua core/log.lua core/tracking.lua core/timespec.lua core/object/pcap.lua core/object/icmp6.lua core/object/gre.lua core/object/ether.lua core/object/ip.lua core/object/ieee802.lua core/object/tcp.lua core/object/ip6.lua core/object/linuxsll.lua core/object/null.lua core/object/loop.lua core/object/icmp.lua core/object/packet.lua core/object/dns.lua core/object/udp.lua core/receiver.lua core/object.lua lib/getopt.lua lib/parseconf.lua input/pcapthread.lua input/fpcap.lua input/pcap.lua input/zero.lua input/mmpcap.lua filter/coro.lua filter/timing.lua filter/split.lua filter/layer.lua filter/thread.lua filter/lua.lua output/cpool.lua output/null.lua output/udpcli.lua
+lua_objects += core/mutex.luao core/log.luao core/tracking.luao core/timespec.luao core/object/pcap.luao core/object/icmp6.luao core/object/gre.luao core/object/ether.luao core/object/ip.luao core/object/ieee802.luao core/object/tcp.luao core/object/ip6.luao core/object/linuxsll.luao core/object/null.luao core/object/loop.luao core/object/icmp.luao core/object/packet.luao core/object/dns.luao core/object/udp.luao core/receiver.luao core/object.luao lib/getopt.luao lib/parseconf.luao input/pcapthread.luao input/fpcap.luao input/pcap.luao input/zero.luao input/mmpcap.luao filter/coro.luao filter/timing.luao filter/split.luao filter/layer.luao filter/thread.luao filter/lua.luao output/cpool.luao output/null.luao output/udpcli.luao
+
 dnsjit_LDFLAGS = -Wl,-E
 dnsjit_LDADD += $(lua_hobjects) $(lua_objects)
 CLEANFILES += $(lua_hobjects) $(lua_objects)
@@ -94,12 +61,8 @@ CLEANFILES += $(lua_hobjects) $(lua_objects)
 man1_MANS = dnsjit.1
 CLEANFILES += $(man1_MANS)
 
-man3_MANS = dnsjit.core.3 dnsjit.core.log.3 dnsjit.core.mutex.3 dnsjit.core.object.3 dnsjit.core.receiver.3 dnsjit.core.timespec.3 dnsjit.core.tracking.3 \
-  dnsjit.core.object.dns.3 dnsjit.core.object.packet.3 \
-  dnsjit.lib.3 dnsjit.lib.getopt.3 dnsjit.lib.parseconf.3 \
-  dnsjit.input.3 dnsjit.input.pcapthread.3 dnsjit.input.zero.3 \
-  dnsjit.filter.3 dnsjit.filter.lua.3 dnsjit.filter.split.3 dnsjit.filter.timing.3 \
-  dnsjit.output.3 dnsjit.output.cpool.3 dnsjit.output.null.3
+man3_MANS = dnsjit.core.3 dnsjit.lib.3 dnsjit.input.3 dnsjit.filter.3 dnsjit.output.3
+man3_MANS += dnsjit.core.mutex.3 dnsjit.core.log.3 dnsjit.core.tracking.3 dnsjit.core.timespec.3 dnsjit.core.object.pcap.3 dnsjit.core.object.icmp6.3 dnsjit.core.object.gre.3 dnsjit.core.object.ether.3 dnsjit.core.object.ip.3 dnsjit.core.object.ieee802.3 dnsjit.core.object.tcp.3 dnsjit.core.object.ip6.3 dnsjit.core.object.linuxsll.3 dnsjit.core.object.null.3 dnsjit.core.object.loop.3 dnsjit.core.object.icmp.3 dnsjit.core.object.packet.3 dnsjit.core.object.dns.3 dnsjit.core.object.udp.3 dnsjit.core.receiver.3 dnsjit.core.object.3 dnsjit.lib.getopt.3 dnsjit.lib.parseconf.3 dnsjit.input.pcapthread.3 dnsjit.input.fpcap.3 dnsjit.input.pcap.3 dnsjit.input.zero.3 dnsjit.input.mmpcap.3 dnsjit.filter.coro.3 dnsjit.filter.timing.3 dnsjit.filter.split.3 dnsjit.filter.layer.3 dnsjit.filter.thread.3 dnsjit.filter.3.3 dnsjit.output.cpool.3 dnsjit.output.null.3 dnsjit.output.udpcli.3
 CLEANFILES += *.3in $(man3_MANS)
 
 .lua.luao:
@@ -130,37 +93,84 @@ CLEANFILES += *.3in $(man3_MANS)
   -e 's,[@]PACKAGE_BUGREPORT[@],$(PACKAGE_BUGREPORT),g' \
   < "$<" > "$@"
 
+
 dnsjit.core.3in: core.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core.lua" > "$@"
 
-dnsjit.core.log.3in: core/log.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/log.lua" > "$@"
+dnsjit.lib.3in: lib.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/lib.lua" > "$@"
+
+dnsjit.input.3in: input.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/input.lua" > "$@"
+
+dnsjit.filter.3in: filter.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/filter.lua" > "$@"
+
+dnsjit.output.3in: output.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output.lua" > "$@"
 
 dnsjit.core.mutex.3in: core/mutex.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/mutex.lua" > "$@"
 
-dnsjit.core.object.3in: core/object.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object.lua" > "$@"
-
-dnsjit.core.receiver.3in: core/receiver.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/receiver.lua" > "$@"
-
-dnsjit.core.timespec.3in: core/timespec.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/timespec.lua" > "$@"
+dnsjit.core.log.3in: core/log.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/log.lua" > "$@"
 
 dnsjit.core.tracking.3in: core/tracking.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/tracking.lua" > "$@"
 
+dnsjit.core.timespec.3in: core/timespec.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/timespec.lua" > "$@"
 
-dnsjit.core.object.dns.3in: core/object/dns.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/dns.lua" > "$@"
+dnsjit.core.object.pcap.3in: core/object/pcap.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/pcap.lua" > "$@"
+
+dnsjit.core.object.icmp6.3in: core/object/icmp6.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/icmp6.lua" > "$@"
+
+dnsjit.core.object.gre.3in: core/object/gre.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/gre.lua" > "$@"
+
+dnsjit.core.object.ether.3in: core/object/ether.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/ether.lua" > "$@"
+
+dnsjit.core.object.ip.3in: core/object/ip.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/ip.lua" > "$@"
+
+dnsjit.core.object.ieee802.3in: core/object/ieee802.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/ieee802.lua" > "$@"
+
+dnsjit.core.object.tcp.3in: core/object/tcp.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/tcp.lua" > "$@"
+
+dnsjit.core.object.ip6.3in: core/object/ip6.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/ip6.lua" > "$@"
+
+dnsjit.core.object.linuxsll.3in: core/object/linuxsll.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/linuxsll.lua" > "$@"
+
+dnsjit.core.object.null.3in: core/object/null.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/null.lua" > "$@"
+
+dnsjit.core.object.loop.3in: core/object/loop.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/loop.lua" > "$@"
+
+dnsjit.core.object.icmp.3in: core/object/icmp.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/icmp.lua" > "$@"
 
 dnsjit.core.object.packet.3in: core/object/packet.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/packet.lua" > "$@"
 
+dnsjit.core.object.dns.3in: core/object/dns.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/dns.lua" > "$@"
 
-dnsjit.lib.3in: lib.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/lib.lua" > "$@"
+dnsjit.core.object.udp.3in: core/object/udp.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/udp.lua" > "$@"
+
+dnsjit.core.receiver.3in: core/receiver.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/receiver.lua" > "$@"
+
+dnsjit.core.object.3in: core/object.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object.lua" > "$@"
 
 dnsjit.lib.getopt.3in: lib/getopt.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/lib/getopt.lua" > "$@"
@@ -168,35 +178,44 @@ dnsjit.lib.getopt.3in: lib/getopt.lua gen-manpage.lua
 dnsjit.lib.parseconf.3in: lib/parseconf.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/lib/parseconf.lua" > "$@"
 
-
-dnsjit.input.3in: input.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/input.lua" > "$@"
-
 dnsjit.input.pcapthread.3in: input/pcapthread.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/input/pcapthread.lua" > "$@"
+
+dnsjit.input.fpcap.3in: input/fpcap.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/input/fpcap.lua" > "$@"
+
+dnsjit.input.pcap.3in: input/pcap.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/input/pcap.lua" > "$@"
 
 dnsjit.input.zero.3in: input/zero.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/input/zero.lua" > "$@"
 
+dnsjit.input.mmpcap.3in: input/mmpcap.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/input/mmpcap.lua" > "$@"
 
-dnsjit.filter.3in: filter.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/filter.lua" > "$@"
-
-dnsjit.filter.lua.3in: filter/lua.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/filter/lua.lua" > "$@"
-
-dnsjit.filter.split.3in: filter/split.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/filter/split.lua" > "$@"
+dnsjit.filter.coro.3in: filter/coro.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/filter/coro.lua" > "$@"
 
 dnsjit.filter.timing.3in: filter/timing.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/filter/timing.lua" > "$@"
 
+dnsjit.filter.split.3in: filter/split.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/filter/split.lua" > "$@"
 
-dnsjit.output.3in: output.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output.lua" > "$@"
+dnsjit.filter.layer.3in: filter/layer.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/filter/layer.lua" > "$@"
+
+dnsjit.filter.thread.3in: filter/thread.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/filter/thread.lua" > "$@"
+
+dnsjit.filter.3.3in: filter/lua.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/filter/lua.lua" > "$@"
 
 dnsjit.output.cpool.3in: output/cpool.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output/cpool.lua" > "$@"
 
 dnsjit.output.null.3in: output/null.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output/null.lua" > "$@"
+
+dnsjit.output.udpcli.3in: output/udpcli.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output/udpcli.lua" > "$@"

--- a/src/core.lua
+++ b/src/core.lua
@@ -33,8 +33,6 @@
 -- .IR script .
 module(...,package.seeall)
 
-error("This should not be included, only here for documentation generation")
-
 -- dnsjit.core.log (3),
 -- dnsjit.core.mutex (3),
 -- dnsjit.core.object (3),

--- a/src/core/object.c
+++ b/src/core/object.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "core/object.h"
+#include "core/object/pcap.h"
+#include "core/object/udp.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+core_object_t* core_object_copy(const core_object_t* obj)
+{
+    if (!obj) {
+        return 0;
+    }
+
+    switch (obj->obj_type) {
+    case CORE_OBJECT_PCAP: {
+        core_object_pcap_t* pcap = (core_object_pcap_t*)obj;
+        core_object_pcap_t* copy = malloc(sizeof(core_object_pcap_t) + pcap->caplen);
+
+        memcpy(copy, pcap, sizeof(core_object_pcap_t));
+        copy->obj_prev = 0;
+
+        memcpy((void*)copy + sizeof(core_object_pcap_t), pcap->bytes, pcap->caplen);
+        copy->bytes = (unsigned char*)copy + sizeof(core_object_pcap_t);
+
+        return (core_object_t*)copy;
+    }
+    case CORE_OBJECT_UDP: {
+        core_object_udp_t* udp  = (core_object_udp_t*)obj;
+        core_object_udp_t* copy = malloc(sizeof(core_object_udp_t) + udp->len);
+
+        memcpy(copy, udp, sizeof(core_object_udp_t));
+        copy->obj_prev = 0;
+
+        memcpy((void*)copy + sizeof(core_object_udp_t), udp->payload, udp->len);
+        copy->payload = (unsigned char*)copy + sizeof(core_object_udp_t);
+
+        return (core_object_t*)copy;
+    }
+    default:
+        break;
+    }
+
+    return 0;
+}

--- a/src/core/object.h
+++ b/src/core/object.h
@@ -22,8 +22,25 @@
 #define __dnsjit_core_object_h
 
 #define CORE_OBJECT_NONE 0
-#define CORE_OBJECT_PACKET 1
-#define CORE_OBJECT_DNS 2
+#define CORE_OBJECT_PCAP 1
+/* link level objects */
+#define CORE_OBJECT_ETHER 10
+#define CORE_OBJECT_NULL 11
+#define CORE_OBJECT_LOOP 12
+#define CORE_OBJECT_LINUXSLL 13
+#define CORE_OBJECT_IEEE802 14
+#define CORE_OBJECT_GRE 15
+/* protocol objects */
+#define CORE_OBJECT_IP 20
+#define CORE_OBJECT_IP6 21
+#define CORE_OBJECT_ICMP 22
+#define CORE_OBJECT_ICMP6 23
+/* DNS carrying objects */
+#define CORE_OBJECT_UDP 30
+#define CORE_OBJECT_TCP 31
+#define CORE_OBJECT_PACKET 32
+/* DNS object(s) */
+#define CORE_OBJECT_DNS 40
 
 #include "core/object.hh"
 

--- a/src/core/object.hh
+++ b/src/core/object.hh
@@ -23,3 +23,5 @@ struct core_object {
     unsigned short       obj_type;
     const core_object_t* obj_prev;
 };
+
+core_object_t* core_object_copy(const core_object_t* obj);

--- a/src/core/object.lua
+++ b/src/core/object.lua
@@ -36,21 +36,73 @@
 module(...,package.seeall)
 
 require("dnsjit.core.object_h")
-require("dnsjit.core.object.packet")
-require("dnsjit.core.object.dns")
+require("dnsjit.core.object.pcap_h")
+require("dnsjit.core.object.ether_h")
+require("dnsjit.core.object.null_h")
+require("dnsjit.core.object.loop_h")
+require("dnsjit.core.object.linuxsll_h")
+require("dnsjit.core.object.ieee802_h")
+require("dnsjit.core.object.gre_h")
+require("dnsjit.core.object.ip_h")
+require("dnsjit.core.object.ip6_h")
+require("dnsjit.core.object.icmp_h")
+require("dnsjit.core.object.icmp6_h")
+require("dnsjit.core.object.udp_h")
+require("dnsjit.core.object.tcp_h")
+require("dnsjit.core.object.packet_h")
+require("dnsjit.core.object.dns_h")
 local ffi = require("ffi")
 
 local t_name = "core_object_t"
 local core_object_t
 local Object = {
     CORE_OBJECT_NONE = 0,
-    CORE_OBJECT_PACKET = 1,
-    CORE_OBJECT_DNS = 2,
+    CORE_OBJECT_PCAP = 1,
+    CORE_OBJECT_ETHER = 10,
+    CORE_OBJECT_NULL = 11,
+    CORE_OBJECT_LOOP = 12,
+    CORE_OBJECT_LINUXSLL = 13,
+    CORE_OBJECT_IEEE802 = 14,
+    CORE_OBJECT_GRE = 15,
+    CORE_OBJECT_IP = 20,
+    CORE_OBJECT_IP6 = 21,
+    CORE_OBJECT_ICMP = 22,
+    CORE_OBJECT_ICMP6 = 23,
+    CORE_OBJECT_UDP = 30,
+    CORE_OBJECT_TCP = 31,
+    CORE_OBJECT_PACKET = 32,
+    CORE_OBJECT_DNS = 40
 }
 
 -- Return the textual type of the object.
 function Object:type()
-    if self.obj_type == Object.CORE_OBJECT_PACKET then
+    if self.obj_type == Object.CORE_OBJECT_PCAP then
+        return "pcap"
+    elseif self.obj_type == Object.CORE_OBJECT_ETHER then
+        return "ether"
+    elseif self.obj_type == Object.CORE_OBJECT_NULL then
+        return "null"
+    elseif self.obj_type == Object.CORE_OBJECT_LOOP then
+        return "loop"
+    elseif self.obj_type == Object.CORE_OBJECT_LINUXSLL then
+        return "linuxsll"
+    elseif self.obj_type == Object.CORE_OBJECT_IEEE802 then
+        return "ieee802"
+    elseif self.obj_type == Object.CORE_OBJECT_GRE then
+        return "gre"
+    elseif self.obj_type == Object.CORE_OBJECT_IP then
+        return "ip"
+    elseif self.obj_type == Object.CORE_OBJECT_IP6 then
+        return "ip6"
+    elseif self.obj_type == Object.CORE_OBJECT_ICMP then
+        return "icmp"
+    elseif self.obj_type == Object.CORE_OBJECT_ICMP6 then
+        return "icmp6"
+    elseif self.obj_type == Object.CORE_OBJECT_UDP then
+        return "udp"
+    elseif self.obj_type == Object.CORE_OBJECT_TCP then
+        return "tcp"
+    elseif self.obj_type == Object.CORE_OBJECT_PACKET then
         return "packet"
     elseif self.obj_type == Object.CORE_OBJECT_DNS then
         return "dns"
@@ -65,7 +117,33 @@ end
 
 -- Cast the object to the underlining object module and return it.
 function Object:cast()
-    if self.obj_type == Object.CORE_OBJECT_PACKET then
+    if self.obj_type == Object.CORE_OBJECT_PCAP then
+        return ffi.cast("core_object_pcap_t*", self)
+    elseif self.obj_type == Object.CORE_OBJECT_ETHER then
+        return ffi.cast("core_object_ether_t*", self)
+    elseif self.obj_type == Object.CORE_OBJECT_NULL then
+        return ffi.cast("core_object_null_t*", self)
+    elseif self.obj_type == Object.CORE_OBJECT_LOOP then
+        return ffi.cast("core_object_loop_t*", self)
+    elseif self.obj_type == Object.CORE_OBJECT_LINUXSLL then
+        return ffi.cast("core_object_linuxsll_t*", self)
+    elseif self.obj_type == Object.CORE_OBJECT_IEEE802 then
+        return ffi.cast("core_object_ieee802_t*", self)
+    elseif self.obj_type == Object.CORE_OBJECT_GRE then
+        return ffi.cast("core_object_gre_t*", self)
+    elseif self.obj_type == Object.CORE_OBJECT_IP then
+        return ffi.cast("core_object_ip_t*", self)
+    elseif self.obj_type == Object.CORE_OBJECT_IP6 then
+        return ffi.cast("core_object_ip6_t*", self)
+    elseif self.obj_type == Object.CORE_OBJECT_ICMP then
+        return ffi.cast("core_object_icmp_t*", self)
+    elseif self.obj_type == Object.CORE_OBJECT_ICMP6 then
+        return ffi.cast("core_object_icmp6_t*", self)
+    elseif self.obj_type == Object.CORE_OBJECT_UDP then
+        return ffi.cast("core_object_udp_t*", self)
+    elseif self.obj_type == Object.CORE_OBJECT_TCP then
+        return ffi.cast("core_object_tcp_t*", self)
+    elseif self.obj_type == Object.CORE_OBJECT_PACKET then
         return ffi.cast("core_object_packet_t*", self)
     elseif self.obj_type == Object.CORE_OBJECT_DNS then
         return ffi.cast("core_object_dns_t*", self)
@@ -74,6 +152,19 @@ end
 
 core_object_t = ffi.metatype(t_name, { __index = Object })
 
--- dnsjit.core.object.dns (3),
--- dnsjit.core.object.packet (3)
+-- dnsjit.core.object.pcap (3),
+-- dnsjit.core.object.ether (3),
+-- dnsjit.core.object.null (3),
+-- dnsjit.core.object.loop (3),
+-- dnsjit.core.object.linuxsll (3),
+-- dnsjit.core.object.ieee802 (3),
+-- dnsjit.core.object.gre (3),
+-- dnsjit.core.object.ip (3),
+-- dnsjit.core.object.ip6 (3),
+-- dnsjit.core.object.icmp (3),
+-- dnsjit.core.object.icmp6 (3),
+-- dnsjit.core.object.udp (3),
+-- dnsjit.core.object.tcp (3),
+-- dnsjit.core.object.packet (3),
+-- dnsjit.core.object.dns (3)
 return Object

--- a/src/core/object/dns.c
+++ b/src/core/object/dns.c
@@ -47,7 +47,7 @@ typedef struct _query {
 
 static core_log_t _log      = LOG_T_INIT("core.object.dns");
 static _query_t   _defaults = {
-    CORE_OBJECT_DNS_INIT,
+    CORE_OBJECT_DNS_INIT(0),
     OMG_DNS_T_INIT,
     0
 };

--- a/src/core/object/dns.h
+++ b/src/core/object/dns.h
@@ -30,9 +30,9 @@
 
 #include "core/object/dns.hh"
 
-#define CORE_OBJECT_DNS_INIT                             \
+#define CORE_OBJECT_DNS_INIT(prev)                       \
     {                                                    \
-        CORE_OBJECT_DNS, 0,                              \
+        CORE_OBJECT_DNS, (core_object_t*)prev,           \
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
             0, 0, 0, 0                                   \

--- a/src/core/object/ether.c
+++ b/src/core/object/ether.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "core/object/ether.h"

--- a/src/core/object/ether.h
+++ b/src/core/object/ether.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "core/object.h"
+#include "core/timespec.h"
+
+#ifndef __dnsjit_core_object_ether_h
+#define __dnsjit_core_object_ether_h
+
+#include <stddef.h>
+
+#include "core/object/ether.hh"
+
+#define CORE_OBJECT_ETHER_INIT(prev)                      \
+    {                                                     \
+        CORE_OBJECT_ETHER, (core_object_t*)prev,          \
+            { 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0 }, 0 \
+    }
+
+#endif

--- a/src/core/object/ether.hh
+++ b/src/core/object/ether.hh
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//lua:require("dnsjit.core.object_h")
+
+typedef struct core_object_ether {
+    unsigned short       obj_type;
+    const core_object_t* obj_prev;
+
+    uint8_t  dhost[6];
+    uint8_t  shost[6];
+    uint16_t type;
+} core_object_ether_t;

--- a/src/core/object/ether.lua
+++ b/src/core/object/ether.lua
@@ -1,0 +1,57 @@
+-- Copyright (c) 2018, OARC, Inc.
+-- All rights reserved.
+--
+-- This file is part of dnsjit.
+--
+-- dnsjit is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- dnsjit is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+
+-- dnsjit.core.object.ether
+-- Ether part of a packet
+--
+-- The ether part of a packet that usually can be found in the object chain
+-- after parsing with, for example, Layer filter.
+-- .SS Attributes
+-- .TP
+-- dhost
+-- The destination ether address.
+-- .TP
+-- shost
+-- The source ether address.
+-- .TP
+-- type
+-- The packet type ID field / EtherType field.
+module(...,package.seeall)
+
+require("dnsjit.core.object.ether_h")
+local ffi = require("ffi")
+
+local t_name = "core_object_ether_t"
+local core_object_ether_t
+local Ether = {}
+
+-- Return the textual type of the object.
+function Ether:type()
+    return "ether"
+end
+
+-- Return the previous object.
+function Ether:prev()
+    return self.obj_prev
+end
+
+core_object_ether_t = ffi.metatype(t_name, { __index = Ether })
+
+-- dnsjit.core.object (3),
+-- dnsjit.filter.layer (3)
+return Ether

--- a/src/core/object/gre.c
+++ b/src/core/object/gre.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "core/object/gre.h"

--- a/src/core/object/gre.h
+++ b/src/core/object/gre.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "core/object.h"
+#include "core/timespec.h"
+
+#ifndef __dnsjit_core_object_gre_h
+#define __dnsjit_core_object_gre_h
+
+#include <stddef.h>
+
+#include "core/object/gre.hh"
+
+#define CORE_OBJECT_GRE_INIT(prev)             \
+    {                                          \
+        CORE_OBJECT_GRE, (core_object_t*)prev, \
+            0, 0, 0, 0, 0                      \
+    }
+
+#endif

--- a/src/core/object/gre.hh
+++ b/src/core/object/gre.hh
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//lua:require("dnsjit.core.object_h")
+
+typedef struct core_object_gre {
+    unsigned short       obj_type;
+    const core_object_t* obj_prev;
+
+    uint16_t gre_flags;
+    uint16_t ether_type;
+    uint16_t checksum;
+    uint16_t offset;
+    uint32_t key;
+    uint32_t sequence;
+    // TODO: routing list, check RFC 1701.
+} core_object_gre_t;

--- a/src/core/object/gre.lua
+++ b/src/core/object/gre.lua
@@ -1,0 +1,66 @@
+-- Copyright (c) 2018, OARC, Inc.
+-- All rights reserved.
+--
+-- This file is part of dnsjit.
+--
+-- dnsjit is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- dnsjit is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+
+-- dnsjit.core.object.gre
+-- Generic Routing Encapsulation (GRE) part of a packet
+--
+-- The GRE part of a packet that usually can be found in the object chain
+-- after parsing with, for example, Layer filter.
+-- See RFC 1701.
+-- .SS Attributes
+-- .TP
+-- gre_flags
+-- The GRE flags.
+-- .TP
+-- ether_type
+-- The protocol type of the payload packet.
+-- .TP
+-- checksum
+-- The checksum of the GRE header and the payload packet.
+-- .TP
+-- key
+-- The Key field contains a four octet number which was inserted by
+-- the encapsulator.
+-- .TP
+-- sequence
+-- The Sequence Number field contains an unsigned 32 bit integer which is
+-- inserted by the encapsulator.
+module(...,package.seeall)
+
+require("dnsjit.core.object.gre_h")
+local ffi = require("ffi")
+
+local t_name = "core_object_gre_t"
+local core_object_gre_t
+local Gre = {}
+
+-- Return the textual type of the object.
+function Gre:type()
+    return "gre"
+end
+
+-- Return the previous object.
+function Gre:prev()
+    return self.obj_prev
+end
+
+core_object_gre_t = ffi.metatype(t_name, { __index = Gre })
+
+-- dnsjit.core.object (3),
+-- dnsjit.filter.layer (3)
+return Gre

--- a/src/core/object/icmp.c
+++ b/src/core/object/icmp.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "core/object/icmp.h"

--- a/src/core/object/icmp.h
+++ b/src/core/object/icmp.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "core/object.h"
+#include "core/timespec.h"
+
+#ifndef __dnsjit_core_object_icmp_h
+#define __dnsjit_core_object_icmp_h
+
+#include <stddef.h>
+
+#include "core/object/icmp.hh"
+
+#define CORE_OBJECT_ICMP_INIT(prev)             \
+    {                                           \
+        CORE_OBJECT_ICMP, (core_object_t*)prev, \
+            0, 0, 0                             \
+    }
+
+#endif

--- a/src/core/object/icmp.hh
+++ b/src/core/object/icmp.hh
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//lua:require("dnsjit.core.object_h")
+
+typedef struct core_object_icmp {
+    unsigned short       obj_type;
+    const core_object_t* obj_prev;
+
+    uint8_t  type;
+    uint8_t  code;
+    uint16_t cksum;
+} core_object_icmp_t;

--- a/src/core/object/icmp.lua
+++ b/src/core/object/icmp.lua
@@ -1,0 +1,57 @@
+-- Copyright (c) 2018, OARC, Inc.
+-- All rights reserved.
+--
+-- This file is part of dnsjit.
+--
+-- dnsjit is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- dnsjit is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+
+-- dnsjit.core.object.icmp
+-- An ICMP packet
+--
+-- An ICMP packet which is usually at the top of the object chain
+-- after parsing with, for example, Layer filter.
+-- .SS Attributes
+-- .TP
+-- type
+-- The type of ICMP message.
+-- .TP
+-- code
+-- The (response/error) code for the ICMP type message.
+-- .TP
+-- cksum
+-- The ICMP checksum.
+module(...,package.seeall)
+
+require("dnsjit.core.object.icmp_h")
+local ffi = require("ffi")
+
+local t_name = "core_object_icmp_t"
+local core_object_icmp_t
+local Icmp = {}
+
+-- Return the textual type of the object.
+function Icmp:type()
+    return "icmp"
+end
+
+-- Return the previous object.
+function Icmp:prev()
+    return self.obj_prev
+end
+
+core_object_icmp_t = ffi.metatype(t_name, { __index = Icmp })
+
+-- dnsjit.core.object (3),
+-- dnsjit.filter.layer (3)
+return Icmp

--- a/src/core/object/icmp6.c
+++ b/src/core/object/icmp6.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "core/object/icmp6.h"

--- a/src/core/object/icmp6.h
+++ b/src/core/object/icmp6.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "core/object.h"
+#include "core/timespec.h"
+
+#ifndef __dnsjit_core_object_icmp6_h
+#define __dnsjit_core_object_icmp6_h
+
+#include <stddef.h>
+
+#include "core/object/icmp6.hh"
+
+#define CORE_OBJECT_ICMP6_INIT(prev)             \
+    {                                            \
+        CORE_OBJECT_ICMP6, (core_object_t*)prev, \
+            0, 0, 0                              \
+    }
+
+#endif

--- a/src/core/object/icmp6.hh
+++ b/src/core/object/icmp6.hh
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//lua:require("dnsjit.core.object_h")
+
+typedef struct core_object_icmp6 {
+    unsigned short       obj_type;
+    const core_object_t* obj_prev;
+
+    uint8_t  type;
+    uint8_t  code;
+    uint16_t cksum;
+} core_object_icmp6_t;

--- a/src/core/object/icmp6.lua
+++ b/src/core/object/icmp6.lua
@@ -1,0 +1,57 @@
+-- Copyright (c) 2018, OARC, Inc.
+-- All rights reserved.
+--
+-- This file is part of dnsjit.
+--
+-- dnsjit is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- dnsjit is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+
+-- dnsjit.core.object.icmp6
+-- An ICMPv6 packet
+--
+-- An ICMPv6 packet which is usually at the top of the object chain
+-- after parsing with, for example, Layer filter.
+-- .SS Attributes
+-- .TP
+-- type
+-- The type of ICMPv6 message.
+-- .TP
+-- code
+-- The (response/error) code for the ICMPv6 type message.
+-- .TP
+-- cksum
+-- The ICMPv6 checksum.
+module(...,package.seeall)
+
+require("dnsjit.core.object.icmp6_h")
+local ffi = require("ffi")
+
+local t_name = "core_object_icmp6_t"
+local core_object_icmp6_t
+local Icmp6 = {}
+
+-- Return the textual type of the object.
+function Icmp6:type()
+    return "icmp6"
+end
+
+-- Return the previous object.
+function Icmp6:prev()
+    return self.obj_prev
+end
+
+core_object_icmp6_t = ffi.metatype(t_name, { __index = Icmp6 })
+
+-- dnsjit.core.object (3),
+-- dnsjit.filter.layer (3)
+return Icmp6

--- a/src/core/object/ieee802.c
+++ b/src/core/object/ieee802.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "core/object/ieee802.h"

--- a/src/core/object/ieee802.h
+++ b/src/core/object/ieee802.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "core/object.h"
+#include "core/timespec.h"
+
+#ifndef __dnsjit_core_object_ieee802_h
+#define __dnsjit_core_object_ieee802_h
+
+#include <stddef.h>
+
+#include "core/object/ieee802.hh"
+
+#define CORE_OBJECT_IEEE802_INIT(prev)             \
+    {                                              \
+        CORE_OBJECT_IEEE802, (core_object_t*)prev, \
+            0, 0, 0, 0, 0                          \
+    }
+
+#endif

--- a/src/core/object/ieee802.hh
+++ b/src/core/object/ieee802.hh
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//lua:require("dnsjit.core.object_h")
+
+typedef struct core_object_ieee802 {
+    unsigned short       obj_type;
+    const core_object_t* obj_prev;
+
+    uint16_t       tpid;
+    unsigned short pcp : 3;
+    unsigned short dei : 1;
+    unsigned short vid : 12;
+    uint16_t       ether_type;
+} core_object_ieee802_t;

--- a/src/core/object/ieee802.lua
+++ b/src/core/object/ieee802.lua
@@ -1,0 +1,63 @@
+-- Copyright (c) 2018, OARC, Inc.
+-- All rights reserved.
+--
+-- This file is part of dnsjit.
+--
+-- dnsjit is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- dnsjit is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+
+-- dnsjit.core.object.ieee802
+-- IEEE802 part of a packet
+--
+-- The IEEE802 part of a packet that usually can be found in the object chain
+-- after parsing with, for example, Layer filter.
+-- .SS Attributes
+-- .TP
+-- tpid
+-- Tag protocol identifier.
+-- .TP
+-- pcp
+-- Priority code point.
+-- .TP
+-- dei
+-- Drop eligible indicator.
+-- .TP
+-- vid
+-- VLAN identifier.
+-- .TP
+-- ether_type
+-- The packet type ID field / EtherType field.
+module(...,package.seeall)
+
+require("dnsjit.core.object.ieee802_h")
+local ffi = require("ffi")
+
+local t_name = "core_object_ieee802_t"
+local core_object_ieee802_t
+local Ieee802 = {}
+
+-- Return the textual type of the object.
+function Ieee802:type()
+    return "ieee802"
+end
+
+-- Return the previous object.
+function Ieee802:prev()
+    return self.obj_prev
+end
+
+core_object_ieee802_t = ffi.metatype(t_name, { __index = Ieee802 })
+
+-- dnsjit.core.object (3),
+-- dnsjit.filter.layer (3)
+return Ieee802

--- a/src/core/object/ip.c
+++ b/src/core/object/ip.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "core/object/ip.h"

--- a/src/core/object/ip.h
+++ b/src/core/object/ip.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "core/object.h"
+#include "core/timespec.h"
+
+#ifndef __dnsjit_core_object_ip_h
+#define __dnsjit_core_object_ip_h
+
+#include <stddef.h>
+
+#include "core/object/ip.hh"
+
+#define CORE_OBJECT_IP_INIT(prev)                                      \
+    {                                                                  \
+        CORE_OBJECT_IP, (core_object_t*)prev,                          \
+            0, 0, 0, 0, 0, 0, 0, 0, 0, { 0, 0, 0, 0 }, { 0, 0, 0, 0 }, \
+            0, 0                                                       \
+    }
+
+#endif

--- a/src/core/object/ip.hh
+++ b/src/core/object/ip.hh
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//lua:require("dnsjit.core.object_h")
+
+typedef struct core_object_ip {
+    unsigned short       obj_type;
+    const core_object_t* obj_prev;
+
+    unsigned int v : 4;
+    unsigned int hl : 4;
+    uint8_t      tos;
+    uint16_t     len;
+    uint16_t     id;
+    uint16_t     off;
+    uint8_t      ttl;
+    uint8_t      p;
+    uint16_t     sum;
+    uint8_t      src[4], dst[4];
+
+    const uint8_t* payload;
+    size_t         plen;
+} core_object_ip_t;

--- a/src/core/object/ip.lua
+++ b/src/core/object/ip.lua
@@ -1,0 +1,87 @@
+-- Copyright (c) 2018, OARC, Inc.
+-- All rights reserved.
+--
+-- This file is part of dnsjit.
+--
+-- dnsjit is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- dnsjit is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+
+-- dnsjit.core.object.ip
+-- An IP packet
+--
+-- An IP packet that usually can be found in the object chain
+-- after parsing with, for example, Layer filter.
+-- .SS Attributes
+-- .TP
+-- v
+-- Version.
+-- .TP
+-- hl
+-- Header length.
+-- .TP
+-- tos
+-- Type of service.
+-- .TP
+-- len
+-- Total length.
+-- .TP
+-- id
+-- Identification.
+-- .TP
+-- off
+-- Fragment offset field.
+-- .TP
+-- ttl
+-- Time to live.
+-- .TP
+-- p
+-- Protocol.
+-- .TP
+-- sum
+-- Checksum.
+-- .TP
+-- src
+-- Source address.
+-- .TP
+-- dst
+-- Destination address.
+-- .TP
+-- payload
+-- A pointer to the payload.
+-- .TP
+-- plen
+-- The length of the payload.
+module(...,package.seeall)
+
+require("dnsjit.core.object.ip_h")
+local ffi = require("ffi")
+
+local t_name = "core_object_ip_t"
+local core_object_ip_t
+local Ip = {}
+
+-- Return the textual type of the object.
+function Ip:type()
+    return "ip"
+end
+
+-- Return the previous object.
+function Ip:prev()
+    return self.obj_prev
+end
+
+core_object_ip_t = ffi.metatype(t_name, { __index = Ip })
+
+-- dnsjit.core.object (3),
+-- dnsjit.filter.layer (3)
+return Ip

--- a/src/core/object/ip6.c
+++ b/src/core/object/ip6.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "core/object/ip6.h"

--- a/src/core/object/ip6.h
+++ b/src/core/object/ip6.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "core/object.h"
+#include "core/timespec.h"
+
+#ifndef __dnsjit_core_object_ip6_h
+#define __dnsjit_core_object_ip6_h
+
+#include <stddef.h>
+
+#include "core/object/ip6.hh"
+
+#define CORE_OBJECT_IP6_INIT(prev)                              \
+    {                                                           \
+        CORE_OBJECT_IP6, (core_object_t*)prev,                  \
+            0, 0, 0, 0,                                         \
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, \
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, \
+            0, 0                                                \
+    }
+
+#endif

--- a/src/core/object/ip6.hh
+++ b/src/core/object/ip6.hh
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//lua:require("dnsjit.core.object_h")
+
+typedef struct core_object_ip6 {
+    unsigned short       obj_type;
+    const core_object_t* obj_prev;
+
+    uint32_t flow;
+    uint16_t plen;
+    uint8_t  nxt;
+    uint8_t  hlim;
+    uint8_t  src[16];
+    uint8_t  dst[16];
+
+    const uint8_t* payload;
+    size_t         len;
+} core_object_ip6_t;

--- a/src/core/object/ip6.lua
+++ b/src/core/object/ip6.lua
@@ -1,0 +1,72 @@
+-- Copyright (c) 2018, OARC, Inc.
+-- All rights reserved.
+--
+-- This file is part of dnsjit.
+--
+-- dnsjit is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- dnsjit is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+
+-- dnsjit.core.object.ip6
+-- An IPv6 packet
+--
+-- An IPv6 packet that usually can be found in the object chain
+-- after parsing with, for example, Layer filter.
+-- .SS Attributes
+-- .TP
+-- flow
+-- 4 bits version, 8 bits TC and 20 bits flow-ID.
+-- .TP
+-- plen
+-- Payload length (as in the IPv6 header).
+-- .TP
+-- nxt
+-- Next header.
+-- .TP
+-- hlim
+-- Hop limit.
+-- .TP
+-- src
+-- Source address.
+-- .TP
+-- dst
+-- Destination address.
+-- .TP
+-- payload
+-- A pointer to the payload.
+-- .TP
+-- len
+-- The length of the payload.
+module(...,package.seeall)
+
+require("dnsjit.core.object.ip6_h")
+local ffi = require("ffi")
+
+local t_name = "core_object_ip6_t"
+local core_object_ip6_t
+local Ip6 = {}
+
+-- Return the textual type of the object.
+function Ip6:type()
+    return "ip6"
+end
+
+-- Return the previous object.
+function Ip6:prev()
+    return self.obj_prev
+end
+
+core_object_ip6_t = ffi.metatype(t_name, { __index = Ip6 })
+
+-- dnsjit.core.object (3),
+-- dnsjit.filter.layer (3)
+return Ip6

--- a/src/core/object/linuxsll.c
+++ b/src/core/object/linuxsll.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "core/object/linuxsll.h"

--- a/src/core/object/linuxsll.h
+++ b/src/core/object/linuxsll.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "core/object.h"
+#include "core/timespec.h"
+
+#ifndef __dnsjit_core_object_linuxsll_h
+#define __dnsjit_core_object_linuxsll_h
+
+#include <stddef.h>
+
+#include "core/object/linuxsll.hh"
+
+#define CORE_OBJECT_LINUXSLL_INIT(prev)             \
+    {                                               \
+        CORE_OBJECT_LINUXSLL, (core_object_t*)prev, \
+            0, 0, 0, { 0, 0, 0, 0, 0, 0, 0, 0 }, 0  \
+    }
+
+#endif

--- a/src/core/object/linuxsll.hh
+++ b/src/core/object/linuxsll.hh
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//lua:require("dnsjit.core.object_h")
+
+typedef struct core_object_linuxsll {
+    unsigned short       obj_type;
+    const core_object_t* obj_prev;
+
+    uint16_t packet_type;
+    uint16_t arp_hardware;
+    uint16_t link_layer_address_length;
+    uint8_t  link_layer_address[8];
+    uint16_t ether_type;
+} core_object_linuxsll_t;

--- a/src/core/object/linuxsll.lua
+++ b/src/core/object/linuxsll.lua
@@ -1,0 +1,63 @@
+-- Copyright (c) 2018, OARC, Inc.
+-- All rights reserved.
+--
+-- This file is part of dnsjit.
+--
+-- dnsjit is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- dnsjit is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+
+-- dnsjit.core.object.linuxsll
+-- Linux cooked-mode capture (SLL) part of a packet
+--
+-- The SLL part of a packet that usually can be found in the object chain
+-- after parsing with, for example, Layer filter.
+-- .SS Attributes
+-- .TP
+-- packet_type
+-- The packet type.
+-- .TP
+-- arp_hardware
+-- The link-layer device type.
+-- .TP
+-- link_layer_address_length
+-- The length of the link-layer address.
+-- .TP
+-- link_layer_address
+-- The link-layer address.
+-- .TP
+-- ether_type
+-- An Ethernet protocol type.
+module(...,package.seeall)
+
+require("dnsjit.core.object.linuxsll_h")
+local ffi = require("ffi")
+
+local t_name = "core_object_linuxsll_t"
+local core_object_linuxsll_t
+local Linuxsll = {}
+
+-- Return the textual type of the object.
+function Linuxsll:type()
+    return "linuxsll"
+end
+
+-- Return the previous object.
+function Linuxsll:prev()
+    return self.obj_prev
+end
+
+core_object_linuxsll_t = ffi.metatype(t_name, { __index = Linuxsll })
+
+-- dnsjit.core.object (3).
+-- dnsjit.filter.layer (3)
+return Linuxsll

--- a/src/core/object/loop.c
+++ b/src/core/object/loop.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "core/object/loop.h"

--- a/src/core/object/loop.h
+++ b/src/core/object/loop.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "core/object.h"
+#include "core/timespec.h"
+
+#ifndef __dnsjit_core_object_loop_h
+#define __dnsjit_core_object_loop_h
+
+#include <stddef.h>
+
+#include "core/object/loop.hh"
+
+#define CORE_OBJECT_LOOP_INIT(prev)             \
+    {                                           \
+        CORE_OBJECT_LOOP, (core_object_t*)prev, \
+            0                                   \
+    }
+
+#endif

--- a/src/core/object/loop.hh
+++ b/src/core/object/loop.hh
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//lua:require("dnsjit.core.object_h")
+
+typedef struct core_object_loop {
+    unsigned short       obj_type;
+    const core_object_t* obj_prev;
+
+    uint32_t family;
+} core_object_loop_t;

--- a/src/core/object/loop.lua
+++ b/src/core/object/loop.lua
@@ -1,0 +1,51 @@
+-- Copyright (c) 2018, OARC, Inc.
+-- All rights reserved.
+--
+-- This file is part of dnsjit.
+--
+-- dnsjit is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- dnsjit is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+
+-- dnsjit.core.object.loop
+-- OpenBSD loopback encapsulation (loop) part of a packet
+--
+-- The loop part of a packet that usually can be found in the object chain
+-- after parsing with, for example, Layer filter.
+-- .SS Attributes
+-- .TP
+-- family
+-- The link-layer header describing what type of packet is encapsulated.
+module(...,package.seeall)
+
+require("dnsjit.core.object.loop_h")
+local ffi = require("ffi")
+
+local t_name = "core_object_loop_t"
+local core_object_loop_t
+local Loop = {}
+
+-- Return the textual type of the object.
+function Loop:type()
+    return "loop"
+end
+
+-- Return the previous object.
+function Loop:prev()
+    return self.obj_prev
+end
+
+core_object_loop_t = ffi.metatype(t_name, { __index = Loop })
+
+-- dnsjit.core.object (3),
+-- dnsjit.filter.layer (3)
+return Loop

--- a/src/core/object/null.c
+++ b/src/core/object/null.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "core/object/null.h"

--- a/src/core/object/null.h
+++ b/src/core/object/null.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "core/object.h"
+#include "core/timespec.h"
+
+#ifndef __dnsjit_core_object_null_h
+#define __dnsjit_core_object_null_h
+
+#include <stddef.h>
+
+#include "core/object/null.hh"
+
+#define CORE_OBJECT_NULL_INIT(prev)             \
+    {                                           \
+        CORE_OBJECT_NULL, (core_object_t*)prev, \
+            0                                   \
+    }
+
+#endif

--- a/src/core/object/null.hh
+++ b/src/core/object/null.hh
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//lua:require("dnsjit.core.object_h")
+
+typedef struct core_object_null {
+    unsigned short       obj_type;
+    const core_object_t* obj_prev;
+
+    uint32_t family;
+} core_object_null_t;

--- a/src/core/object/null.lua
+++ b/src/core/object/null.lua
@@ -1,0 +1,51 @@
+-- Copyright (c) 2018, OARC, Inc.
+-- All rights reserved.
+--
+-- This file is part of dnsjit.
+--
+-- dnsjit is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- dnsjit is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+
+-- dnsjit.core.object.null
+-- BSD loopback encapsulation (null) part of a packet
+--
+-- The null part of a packet that usually can be found in the object chain
+-- after parsing with, for example, Layer filter.
+-- .SS Attributes
+-- .TP
+-- family
+-- The link-layer header describing what type of packet is encapsulated.
+module(...,package.seeall)
+
+require("dnsjit.core.object.null_h")
+local ffi = require("ffi")
+
+local t_name = "core_object_null_t"
+local core_object_null_t
+local Null = {}
+
+-- Return the textual type of the object.
+function Null:type()
+    return "null"
+end
+
+-- Return the previous object.
+function Null:prev()
+    return self.obj_prev
+end
+
+core_object_null_t = ffi.metatype(t_name, { __index = Null })
+
+-- dnsjit.core.object (3),
+-- dnsjit.filter.layer (3)
+return Null

--- a/src/core/object/packet.h
+++ b/src/core/object/packet.h
@@ -28,14 +28,14 @@
 
 #include "core/object/packet.hh"
 
-#define CORE_OBJECT_PACKET_INIT       \
-    {                                 \
-        CORE_OBJECT_PACKET, 0,        \
-            0, 0, 0,                  \
-            0, 0, 0,                  \
-            0, 0,                     \
-            0, 0, CORE_TIMESPEC_INIT, \
-            0, 0                      \
+#define CORE_OBJECT_PACKET_INIT(prev)             \
+    {                                             \
+        CORE_OBJECT_PACKET, (core_object_t*)prev, \
+            0, 0, 0,                              \
+            0, 0, 0,                              \
+            0, 0,                                 \
+            0, 0, CORE_TIMESPEC_INIT,             \
+            0, 0                                  \
     }
 
 #endif

--- a/src/core/object/pcap.c
+++ b/src/core/object/pcap.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "core/object/pcap.h"

--- a/src/core/object/pcap.h
+++ b/src/core/object/pcap.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "core/object.h"
+#include "core/timespec.h"
+
+#ifndef __dnsjit_core_object_pcap_h
+#define __dnsjit_core_object_pcap_h
+
+#include "core/object/pcap.hh"
+
+#define CORE_OBJECT_PCAP_INIT(prev)             \
+    {                                           \
+        CORE_OBJECT_PCAP, (core_object_t*)prev, \
+            0, 0,                               \
+            { 0, 0 }, 0, 0, 0,                  \
+            0                                   \
+    }
+
+#endif

--- a/src/core/object/pcap.hh
+++ b/src/core/object/pcap.hh
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//lua:require("dnsjit.core.object_h")
+//lua:require("dnsjit.core.timespec_h")
+
+typedef struct core_object_pcap {
+    unsigned short       obj_type;
+    const core_object_t* obj_prev;
+
+    uint32_t snaplen, linktype;
+
+    core_timespec_t      ts;
+    uint32_t             caplen, len;
+    const unsigned char* bytes;
+
+    unsigned short is_swapped : 1;
+} core_object_pcap_t;

--- a/src/core/object/pcap.lua
+++ b/src/core/object/pcap.lua
@@ -1,0 +1,76 @@
+-- Copyright (c) 2018, OARC, Inc.
+-- All rights reserved.
+--
+-- This file is part of dnsjit.
+--
+-- dnsjit is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- dnsjit is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+
+-- dnsjit.core.object.pcap
+-- Container of a packet found in a PCAP
+--
+-- Container of a PCAP packet which contains information both from the PCAP
+-- itself and the
+-- .I pcap_pkthdr
+-- object receied for each packet in the PCAP.
+-- .SS Attributes
+-- .TP
+-- snaplen
+-- Max length saved portion of each packet.
+-- .TP
+-- linktype
+-- Data link type for the PCAP.
+-- .TP
+-- ts
+-- Time stamp of this packet.
+-- .TP
+-- caplen
+-- Length of portion present.
+-- .TP
+-- len
+-- Length of this packet (off wire).
+-- .TP
+-- bytes
+-- A pointer to the packet.
+-- .TP
+-- is_swapped
+-- Indicate if the byte order of the PCAP is different then the host.
+-- This is used in, for example, the Layer filter to correctly parse null
+-- objects since they are stored in the capturers host byte order.
+module(...,package.seeall)
+
+require("dnsjit.core.object.pcap_h")
+local ffi = require("ffi")
+
+local t_name = "core_object_pcap_t"
+local core_object_pcap_t
+local Pcap = {}
+
+-- Return the textual type of the object.
+function Pcap:type()
+    return "pcap"
+end
+
+-- Return the previous object.
+function Pcap:prev()
+    return self.obj_prev
+end
+
+core_object_pcap_t = ffi.metatype(t_name, { __index = Pcap })
+
+-- dnsjit.core.object (3),
+-- dnsjit.input.pcap (3),
+-- dnsjit.input.fpcap (3),
+-- dnsjit.input.mmpcap (3),
+-- dnsjit.filter.layer (3)
+return Pcap

--- a/src/core/object/tcp.c
+++ b/src/core/object/tcp.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "core/object/tcp.h"

--- a/src/core/object/tcp.h
+++ b/src/core/object/tcp.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "core/object.h"
+#include "core/timespec.h"
+
+#ifndef __dnsjit_core_object_tcp_h
+#define __dnsjit_core_object_tcp_h
+
+#include <stddef.h>
+
+#include "core/object/tcp.hh"
+
+#define CORE_OBJECT_TCP_INIT(prev)                              \
+    {                                                           \
+        CORE_OBJECT_TCP, (core_object_t*)prev,                  \
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                       \
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
+              0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
+              0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
+              0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, \
+            0,                                                  \
+            0, 0                                                \
+    }
+
+#endif

--- a/src/core/object/tcp.hh
+++ b/src/core/object/tcp.hh
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//lua:require("dnsjit.core.object_h")
+
+typedef struct core_object_tcp {
+    unsigned short       obj_type;
+    const core_object_t* obj_prev;
+
+    uint16_t sport;
+    uint16_t dport;
+    uint32_t seq;
+    uint32_t ack;
+    uint8_t  off : 4;
+    uint8_t  x2 : 4;
+    uint8_t  flags;
+    uint16_t win;
+    uint16_t sum;
+    uint16_t urp;
+
+    uint8_t opts[64];
+    size_t  opts_len;
+
+    const uint8_t* payload;
+    size_t         len;
+} core_object_tcp_t;

--- a/src/core/object/tcp.lua
+++ b/src/core/object/tcp.lua
@@ -1,0 +1,90 @@
+-- Copyright (c) 2018, OARC, Inc.
+-- All rights reserved.
+--
+-- This file is part of dnsjit.
+--
+-- dnsjit is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- dnsjit is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+
+-- dnsjit.core.object.tcp
+-- A TCP packet
+--
+-- A TCP packet which is usually at the top of the object chain
+-- after parsing with, for example, Layer filter.
+-- .SS Attributes
+-- .TP
+-- sport
+-- Source port.
+-- .TP
+-- dport
+-- Destination port.
+-- .TP
+-- seq
+-- Sequence number.
+-- .TP
+-- ack
+-- Acknowledgement number.
+-- .TP
+-- off
+-- Data offset.
+-- .TP
+-- x2
+-- Unused.
+-- .TP
+-- flags
+-- TCP flags.
+-- .TP
+-- win
+-- Window.
+-- .TP
+-- sum
+-- Checksum.
+-- .TP
+-- urp
+-- Urgent pointer.
+-- .TP
+-- opts
+-- Array of bytes with the TCP options found.
+-- .TP
+-- opts_len
+-- Length of the TCP options.
+-- .TP
+-- payload
+-- A pointer to the payload.
+-- .TP
+-- len
+-- The length of the payload.
+module(...,package.seeall)
+
+require("dnsjit.core.object.tcp_h")
+local ffi = require("ffi")
+
+local t_name = "core_object_tcp_t"
+local core_object_tcp_t
+local Tcp = {}
+
+-- Return the textual type of the object.
+function Tcp:type()
+    return "tcp"
+end
+
+-- Return the previous object.
+function Tcp:prev()
+    return self.obj_prev
+end
+
+core_object_tcp_t = ffi.metatype(t_name, { __index = Tcp })
+
+-- dnsjit.core.object (3),
+-- dnsjit.filter.layer (3)
+return Tcp

--- a/src/core/object/udp.c
+++ b/src/core/object/udp.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "core/object/udp.h"

--- a/src/core/object/udp.h
+++ b/src/core/object/udp.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "core/object.h"
+#include "core/timespec.h"
+
+#ifndef __dnsjit_core_object_udp_h
+#define __dnsjit_core_object_udp_h
+
+#include <stddef.h>
+
+#include "core/object/udp.hh"
+
+#define CORE_OBJECT_UDP_INIT(prev)             \
+    {                                          \
+        CORE_OBJECT_UDP, (core_object_t*)prev, \
+            0, 0, 0, 0,                        \
+            0, 0                               \
+    }
+
+#endif

--- a/src/core/object/udp.hh
+++ b/src/core/object/udp.hh
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//lua:require("dnsjit.core.object_h")
+
+typedef struct core_object_udp {
+    unsigned short       obj_type;
+    const core_object_t* obj_prev;
+
+    uint16_t sport;
+    uint16_t dport;
+    uint16_t ulen;
+    uint16_t sum;
+
+    const uint8_t* payload;
+    size_t         len;
+} core_object_udp_t;

--- a/src/core/object/udp.lua
+++ b/src/core/object/udp.lua
@@ -1,0 +1,66 @@
+-- Copyright (c) 2018, OARC, Inc.
+-- All rights reserved.
+--
+-- This file is part of dnsjit.
+--
+-- dnsjit is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- dnsjit is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+
+-- dnsjit.core.object.udp
+-- An UDP packet
+--
+-- An UDP packet which is usually at the top of the object chain
+-- after parsing with, for example, Layer filter.
+-- .SS Attributes
+-- .TP
+-- sport
+-- Source port.
+-- .TP
+-- dport
+-- Destination port.
+-- .TP
+-- ulen
+-- UDP length (as described in the UDP header).
+-- .TP
+-- sum
+-- Checksum.
+-- .TP
+-- payload
+-- A pointer to the payload.
+-- .TP
+-- len
+-- The length of the payload.
+module(...,package.seeall)
+
+require("dnsjit.core.object.udp_h")
+local ffi = require("ffi")
+
+local t_name = "core_object_udp_t"
+local core_object_udp_t
+local Udp = {}
+
+-- Return the textual type of the object.
+function Udp:type()
+    return "udp"
+end
+
+-- Return the previous object.
+function Udp:prev()
+    return self.obj_prev
+end
+
+core_object_udp_t = ffi.metatype(t_name, { __index = Udp })
+
+-- dnsjit.core.object (3),
+-- dnsjit.filter.layer (3)
+return Udp

--- a/src/core/receiver.lua
+++ b/src/core/receiver.lua
@@ -26,8 +26,6 @@
 -- input, filter and output modules to pass query objects for processing.
 module(...,package.seeall)
 
-error("This should not be included, only here for documentation generation")
-
 -- dnsjit.core.query (3),
 -- dnsjit.input.lua (3)
 return

--- a/src/core/timespec.lua
+++ b/src/core/timespec.lua
@@ -30,5 +30,3 @@
 -- Mainly used in C modules for a system independent time specification
 -- structure that can be passed to Lua.
 module(...,package.seeall)
-
-error("This should not be included, only here for documentation generation")

--- a/src/dnsjit.c
+++ b/src/dnsjit.c
@@ -31,6 +31,8 @@
 #include <string.h>
 #include <stdio.h>
 
+void dnsjit_globals(lua_State* L);
+
 static void* _sighthr(void* arg)
 {
     sigset_t* set = (sigset_t*)arg;
@@ -85,6 +87,7 @@ int main(int argc, char* argv[])
 
     L = luaL_newstate();
     luaL_openlibs(L);
+    dnsjit_globals(L);
 
     lua_createtable(L, argc, 0);
     for (n = 0; n < argc; n++) {

--- a/src/filter.lua
+++ b/src/filter.lua
@@ -22,9 +22,10 @@
 -- Filter modules to process or manipulate DNS messages.
 module(...,package.seeall)
 
-error("This should not be included, only here for documentation generation")
-
+-- dnsjit.filter.coro (3),
+-- dnsjit.filter.layer (3),
 -- dnsjit.filter.lua (3),
 -- dnsjit.filter.split (3),
+-- dnsjit.filter.thread (3),
 -- dnsjit.filter.timing (3)
 return

--- a/src/filter/coro.c
+++ b/src/filter/coro.c
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "filter/coro.h"
+
+#include <lualib.h>
+#include <lauxlib.h>
+
+static core_log_t    _log      = LOG_T_INIT("filter.coro");
+static filter_coro_t _defaults = {
+    LOG_T_INIT_OBJ("filter.coro"),
+    0, 0, 0, 0, 0
+};
+
+core_log_t* filter_coro_log()
+{
+    return &_log;
+}
+
+int filter_coro_init(filter_coro_t* self)
+{
+    if (!self) {
+        return 1;
+    }
+
+    *self = _defaults;
+
+    ldebug("init");
+
+    return 0;
+}
+
+int filter_coro_destroy(filter_coro_t* self)
+{
+    if (!self) {
+        return 1;
+    }
+
+    ldebug("destroy");
+
+    return 0;
+}
+
+lua_State* _T = 0;
+
+int filter_coro_set_thread(filter_coro_t* self)
+{
+    if (!self || !_T || self->T) {
+        return 1;
+    }
+
+    ldebug("pickup thread %p", _T);
+    self->T = _T;
+    _T      = 0;
+
+    return 0;
+}
+
+int filter_coro_clear_thread(filter_coro_t* self)
+{
+    if (!self) {
+        return 1;
+    }
+
+    self->T = 0;
+
+    return 0;
+}
+
+int filter_coro_store_thread(lua_State* L)
+{
+    luaL_checktype(L, 1, LUA_TTHREAD);
+    _T = lua_tothread(L, 1);
+
+    mldebug("store thread %p", _T);
+
+    return 0;
+}
+
+const core_object_t* filter_coro_get(filter_coro_t* self)
+{
+    return self ? self->obj : 0;
+}
+
+static int _receive(void* ctx, const core_object_t* obj)
+{
+    filter_coro_t* self = (filter_coro_t*)ctx;
+
+    if (!self || !obj) {
+        return 1;
+    }
+
+    self->obj = obj;
+    lua_resume(self->T, 0);
+    self->obj = 0;
+
+    return 1;
+}
+
+core_receiver_t filter_coro_receiver()
+{
+    return _receive;
+}

--- a/src/filter/coro.h
+++ b/src/filter/coro.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "core/log.h"
+#include "core/receiver.h"
+
+#ifndef __dnsjit_filter_coro_h
+#define __dnsjit_filter_coro_h
+
+#include <lua.h>
+
+#include "filter/coro.hh"
+
+#endif

--- a/src/filter/coro.hh
+++ b/src/filter/coro.hh
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#if 0
+typedef struct {} lua_State;
+#endif
+
+//lua:require("dnsjit.core.log")
+//lua:require("dnsjit.core.receiver_h")
+
+typedef struct filter_coro {
+    core_log_t           _log;
+    core_receiver_t      recv;
+    void*                ctx;
+    lua_State*           T;
+    const core_object_t* obj;
+    int                  done;
+} filter_coro_t;
+
+core_log_t* filter_coro_log();
+
+int filter_coro_init(filter_coro_t* self);
+int filter_coro_destroy(filter_coro_t* self);
+
+int filter_coro_set_thread(filter_coro_t* self);
+int filter_coro_clear_thread(filter_coro_t* self);
+int filter_coro_store_thread(lua_State* L);
+const core_object_t* filter_coro_get(filter_coro_t* self);
+
+core_receiver_t filter_coro_receiver();

--- a/src/filter/coro.lua
+++ b/src/filter/coro.lua
@@ -1,0 +1,115 @@
+-- Copyright (c) 2018, OARC, Inc.
+-- All rights reserved.
+--
+-- This file is part of dnsjit.
+--
+-- dnsjit is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- dnsjit is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+
+-- dnsjit.filter.coro
+-- Filter through a custom Lua function
+--   local filter = require("dnsjit.filter.coro").new()
+--   filter:func(function(filter, object)
+--      filter:send(object)
+--   end)
+--
+-- Filter module to run custom Lua code on received objects with the option
+-- to send them to the next receiver.
+module(...,package.seeall)
+
+require("dnsjit.filter.coro_h")
+local ffi = require("ffi")
+local C = ffi.C
+
+local t_name = "filter_coro_t"
+local filter_coro_t = ffi.typeof(t_name)
+local Coro = {}
+
+-- Create a new Coro filter.
+function Coro.new()
+    local self = {
+        receivers = {},
+        obj = filter_coro_t(),
+        thread = nil,
+    }
+    C.filter_coro_init(self.obj)
+    ffi.gc(self.obj, function(self)
+        self:stop()
+        C.filter_coro_destroy()
+    end)
+    return setmetatable(self, { __index = Coro })
+end
+
+-- Return the Log object to control logging of this instance or module.
+function Coro:log()
+    if self == nil then
+        return C.filter_coro_log()
+    end
+    return self.obj._log
+end
+
+-- Set the function to call on each receive and start a coroutine.
+function Coro:func(func)
+    if self.thread then
+        return
+    end
+    self.thread = coroutine.create(function()
+        local self, func = coroutine.yield()
+        while true do
+            coroutine.yield()
+            if self.obj.done == 1 then
+                return
+            end
+            func(self, C.filter_coro_get(self.obj))
+        end
+    end)
+    -- TODO: check return
+    dnsjit_filter_coro_store_thread(self.thread)
+    C.filter_coro_set_thread(self.obj)
+
+    coroutine.resume(self.thread)
+    coroutine.resume(self.thread, self, func)
+end
+
+-- Stop the coroutine.
+function Coro:stop()
+    if self.thread then
+        self.obj.done = 1
+        coroutine.resume(self.thread)
+        C.filter_coro_clear_thread(self.obj)
+        self.thread = nil
+    end
+end
+
+-- Return the C functions and context for receiving objects.
+function Coro:receive()
+    self.obj._log:debug("receive()")
+    return C.filter_coro_receiver(), self.obj
+end
+
+-- Set the receiver to pass queries to.
+function Coro:receiver(o)
+    self.obj._log:debug("receiver()")
+    self.obj.recv, self.obj.ctx = o:receive()
+    self._receiver = o
+end
+
+-- Used from the Lua function to send objects to the next receiver,
+-- returns 0 on success.
+function Coro:send(object)
+    return C.core_receiver_call(self.obj.recv, self.obj.ctx, object)
+end
+
+-- dnsjit.core.object (3),
+-- dnsjit.filter.lua (3)
+return Coro

--- a/src/filter/layer.c
+++ b/src/filter/layer.c
@@ -1,0 +1,579 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "filter/layer.h"
+#include "core/object/pcap.h"
+#include "core/object/null.h"
+#include "core/object/ether.h"
+#include "core/object/loop.h"
+#include "core/object/linuxsll.h"
+#include "core/object/ieee802.h"
+#include "core/object/ip.h"
+#include "core/object/ip6.h"
+#include "core/object/gre.h"
+#include "core/object/icmp.h"
+#include "core/object/icmp6.h"
+#include "core/object/udp.h"
+#include "core/object/tcp.h"
+
+#include <string.h>
+#include <pcap/pcap.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/ip.h>
+#include <netinet/ip6.h>
+#ifdef HAVE_NET_ETHERNET_H
+#include <net/ethernet.h>
+#endif
+#ifdef HAVE_NET_ETHERTYPES_H
+#include <net/ethertypes.h>
+#endif
+
+static core_log_t     _log      = LOG_T_INIT("filter.layer");
+static filter_layer_t _defaults = {
+    LOG_T_INIT_OBJ("filter.layer"),
+    0, 0
+};
+
+core_log_t* filter_layer_log()
+{
+    return &_log;
+}
+
+int filter_layer_init(filter_layer_t* self)
+{
+    if (!self) {
+        return 1;
+    }
+
+    *self = _defaults;
+
+    ldebug("init");
+
+    return 0;
+}
+
+int filter_layer_destroy(filter_layer_t* self)
+{
+    if (!self) {
+        return 1;
+    }
+
+    ldebug("destroy");
+
+    return 0;
+}
+
+#define need4x2(v1, v2, p, l) \
+    if (l < 1) {              \
+        break;                \
+    }                         \
+    v1 = (*p) >> 4;           \
+    v2 = (*p) & 0xf;          \
+    p += 1;                   \
+    l -= 1
+
+#define need8(v, p, l) \
+    if (l < 1) {       \
+        break;         \
+    }                  \
+    v = *p;            \
+    p += 1;            \
+    l -= 1
+
+#define need16(v, p, l)       \
+    if (l < 2) {              \
+        break;                \
+    }                         \
+    v = (*p << 8) | *(p + 1); \
+    p += 2;                   \
+    l -= 2
+
+#define needr16(v, p, l)      \
+    if (l < 2) {              \
+        break;                \
+    }                         \
+    v = *p | (*(p + 1) << 8); \
+    p += 2;                   \
+    l -= 2
+
+#define need32(v, p, l)                                             \
+    if (l < 4) {                                                    \
+        break;                                                      \
+    }                                                               \
+    v = (*p << 24) | (*(p + 1) << 16) | (*(p + 2) << 8) | *(p + 3); \
+    p += 4;                                                         \
+    l -= 4
+
+#define needr32(v, p, l)                                            \
+    if (l < 4) {                                                    \
+        break;                                                      \
+    }                                                               \
+    v = *p | (*(p + 1) << 8) | (*(p + 2) << 16) | (*(p + 3) << 24); \
+    p += 4;                                                         \
+    l -= 4
+
+#define needxb(b, x, p, l) \
+    if (l < x) {           \
+        break;             \
+    }                      \
+    memcpy(b, p, x);       \
+    p += x;                \
+    l -= x
+
+#define advancexb(x, p, l) \
+    if (l < x) {           \
+        break;             \
+    }                      \
+    p += x;                \
+    l -= x
+
+static int _ip(filter_layer_t* self, const core_object_t* obj, const unsigned char* pkt, size_t len);
+
+static int _proto(filter_layer_t* self, uint8_t proto, const core_object_t* obj, const unsigned char* pkt, size_t len)
+{
+    switch (proto) {
+    case IPPROTO_GRE: {
+        core_object_gre_t gre = CORE_OBJECT_GRE_INIT(obj);
+
+        need16(gre.gre_flags, pkt, len);
+        need16(gre.ether_type, pkt, len);
+
+        /* TODO: Incomplete, check RFC 1701 */
+
+        self->recv(self->ctx, (core_object_t*)&gre);
+
+        // if (gre.gre_flags & 0x1) {
+        //     need16(gre.checksum, pkt, len);
+        // }
+        // if (gre.gre_flags & 0x4) {
+        //     need16(gre.key, pkt, len);
+        // }
+        // if (gre.gre_flags & 0x8) {
+        //     need16(gre.sequence, pkt, len);
+        // }
+        //
+        // switch (gre.ether_type) {
+        // case ETHERTYPE_IP:
+        // case ETHERTYPE_IPV6:
+        //     return _ip(self, (core_object_t*)&gre, pkt, len);
+        //
+        // default:
+        //     break;
+        // }
+        break;
+    }
+    case IPPROTO_ICMP: {
+        core_object_icmp_t icmp = CORE_OBJECT_ICMP_INIT(obj);
+
+        need8(icmp.type, pkt, len);
+        need8(icmp.code, pkt, len);
+        need16(icmp.cksum, pkt, len);
+
+        self->recv(self->ctx, (core_object_t*)&icmp);
+        break;
+    }
+    case IPPROTO_ICMPV6: {
+        core_object_icmp6_t icmp6 = CORE_OBJECT_ICMP_INIT(obj);
+
+        need8(icmp6.type, pkt, len);
+        need8(icmp6.code, pkt, len);
+        need16(icmp6.cksum, pkt, len);
+
+        self->recv(self->ctx, (core_object_t*)&icmp6);
+        break;
+    }
+    case IPPROTO_UDP: {
+        core_object_udp_t udp = CORE_OBJECT_UDP_INIT(obj);
+
+        need16(udp.sport, pkt, len);
+        need16(udp.dport, pkt, len);
+        need16(udp.ulen, pkt, len);
+        need16(udp.sum, pkt, len);
+
+        udp.payload = (uint8_t*)pkt;
+        udp.len     = len;
+
+        self->recv(self->ctx, (core_object_t*)&udp);
+        break;
+    }
+    case IPPROTO_TCP: {
+        core_object_tcp_t tcp = CORE_OBJECT_TCP_INIT(obj);
+
+        need16(tcp.sport, pkt, len);
+        need16(tcp.dport, pkt, len);
+        need32(tcp.seq, pkt, len);
+        need32(tcp.ack, pkt, len);
+        need4x2(tcp.off, tcp.x2, pkt, len);
+        need8(tcp.flags, pkt, len);
+        need16(tcp.win, pkt, len);
+        need16(tcp.sum, pkt, len);
+        need16(tcp.urp, pkt, len);
+        if (tcp.off > 5) {
+            tcp.opts_len = (tcp.off - 5) * 4;
+            needxb(tcp.opts, tcp.opts_len, pkt, len);
+        }
+
+        tcp.payload = (uint8_t*)pkt;
+        tcp.len     = len;
+
+        self->recv(self->ctx, (core_object_t*)&tcp);
+        break;
+    }
+    default:
+        self->recv(self->ctx, obj);
+        break;
+    }
+
+    return 0;
+}
+
+static int _ip(filter_layer_t* self, const core_object_t* obj, const unsigned char* pkt, size_t len)
+{
+    if (len) {
+        switch ((*pkt >> 4)) {
+        case 4: {
+            core_object_ip_t ip = CORE_OBJECT_IP_INIT(obj);
+
+            need4x2(ip.v, ip.hl, pkt, len);
+            need8(ip.tos, pkt, len);
+            need16(ip.len, pkt, len);
+            need16(ip.id, pkt, len);
+            need16(ip.off, pkt, len);
+            need8(ip.ttl, pkt, len);
+            need8(ip.p, pkt, len);
+            need16(ip.sum, pkt, len);
+            needxb(&ip.src, 4, pkt, len);
+            needxb(&ip.dst, 4, pkt, len);
+
+            /* TODO: IPv4 options */
+
+            if (ip.hl < 5)
+                break;
+            if (ip.hl > 5) {
+                advancexb((ip.hl - 5) * 4, pkt, len);
+            }
+
+            /* Check reported length for missing payload or padding */
+            if (ip.len < (ip.hl * 4)) {
+                break;
+            }
+            if (len < (ip.len - (ip.hl * 4))) {
+                break;
+            }
+            if (len > (ip.len - (ip.hl * 4))) {
+                // TODO: Padding
+                // layer_trace("have_ippadding");
+                // packet->ippadding      = len - (ip.len - (ip.hl * 4));
+                // packet->have_ippadding = 1;
+                // len -= packet->ippadding;
+            }
+
+            if (ip.off & 0x2000 || ip.off & 0x1fff) {
+                ip.payload = (uint8_t*)pkt;
+                ip.plen    = len;
+                self->recv(self->ctx, (core_object_t*)&ip);
+                return 0;
+            }
+
+            return _proto(self, ip.p, (core_object_t*)&ip, pkt, len);
+        }
+        case 6: {
+            core_object_ip6_t ip6 = CORE_OBJECT_IP6_INIT(obj);
+            struct ip6_ext    ext;
+            size_t            already_advanced = 0;
+
+            need32(ip6.flow, pkt, len);
+            need16(ip6.plen, pkt, len);
+            need8(ip6.nxt, pkt, len);
+            need8(ip6.hlim, pkt, len);
+            needxb(&ip6.src, 16, pkt, len);
+            needxb(&ip6.dst, 16, pkt, len);
+
+            /* Check reported length for missing payload or padding */
+            if (len < ip6.plen) {
+                break;
+            }
+            if (len > ip6.plen) {
+                // TODO: Padding
+                // layer_trace("have_ip6padding");
+                // packet->ip6padding      = len - ip6.ip6_plen;
+                // packet->have_ip6padding = 1;
+                // len -= packet->ip6padding;
+            }
+
+            ext.ip6e_nxt = ip6.nxt;
+            ext.ip6e_len = 0;
+            while (ext.ip6e_nxt != IPPROTO_NONE
+                   && ext.ip6e_nxt != IPPROTO_GRE
+                   && ext.ip6e_nxt != IPPROTO_ICMPV6
+                   && ext.ip6e_nxt != IPPROTO_UDP
+                   && ext.ip6e_nxt != IPPROTO_TCP) {
+
+                /*
+                 * Advance to the start of next header, this may not be needed
+                 * if it's the first header or if the header is supported.
+                 */
+                if (ext.ip6e_len) {
+                    if (ext.ip6e_len < already_advanced) {
+                        ext.ip6e_nxt = IPPROTO_NONE;
+                        break;
+                    }
+                    /* Advance if not already there */
+                    else if (ext.ip6e_len > already_advanced) {
+                        advancexb((ext.ip6e_len - already_advanced) * 8, pkt, len);
+                    }
+                    already_advanced = 0;
+                } else if (already_advanced) {
+                    ext.ip6e_nxt = IPPROTO_NONE;
+                    break;
+                }
+
+                /* TODO: Store IPv6 headers? */
+
+                /* Handle supported headers */
+                if (ext.ip6e_nxt == IPPROTO_FRAGMENT) {
+                    break;
+                    // if (packet->have_ip6frag) {
+                    //     layer_trace("dup ip6frag");
+                    //     break;
+                    // }
+                    // layer_trace("ip6frag");
+                    // need8(ext.ip6e_nxt, pkt, len);
+                    // need8(packet->ip6frag.ip6f_reserved, pkt, len);
+                    // need16(packet->ip6frag.ip6f_offlg, pkt, len);
+                    // need32(packet->ip6frag.ip6f_ident, pkt, len);
+                    // packet->have_ip6frag = 1;
+                    // ext.ip6e_len         = 1;
+                    // already_advanced     = 1;
+                    // } else if (ext.ip6e_nxt == IPPROTO_ROUTING) {
+                    //     struct ip6_rthdr rthdr;
+                    //     struct in6_addr  rt[255];
+                    //
+                    //     if (packet->have_ip6rtdst) {
+                    //         layer_trace("dup ip6rtdst");
+                    //         break;
+                    //     }
+                    //     need8(ext.ip6e_nxt, pkt, len);
+                    //     need8(ext.ip6e_len, pkt, len);
+                    //     need8(rthdr.ip6r_type, pkt, len);
+                    //     need8(rthdr.ip6r_segleft, pkt, len);
+                    //     if (!rthdr.ip6r_type) {
+                    //         if (rthdr.ip6r_segleft > ext.ip6e_len)
+                    //             break;
+                    //         for (rthdr.ip6r_len = 0; rthdr.ip6r_len < ext.ip6e_len; rthdr.ip6r_len++, already_advanced += 2) {
+                    //             needxb(&rt[rthdr.ip6r_len], 16, pkt, len);
+                    //         }
+                    //         if (!rthdr.ip6r_len || rthdr.ip6r_len != ext.ip6e_len) {
+                    //             break;
+                    //         }
+                    //         if (rthdr.ip6r_segleft) {
+                    //             packet->ip6rtdst      = rt[rthdr.ip6r_segleft];
+                    //             packet->have_ip6rtdst = 1;
+                    //         }
+                    //     }
+                } else {
+                    need8(ext.ip6e_nxt, pkt, len);
+                    need8(ext.ip6e_len, pkt, len);
+                }
+
+                if (!ext.ip6e_len)
+                    break;
+            }
+
+            if (ext.ip6e_nxt == IPPROTO_NONE || ext.ip6e_nxt == IPPROTO_FRAGMENT) {
+                ip6.payload = (uint8_t*)pkt;
+                ip6.len     = len;
+                self->recv(self->ctx, (core_object_t*)&ip6);
+                return 0;
+            }
+
+            return _proto(self, ext.ip6e_nxt, (core_object_t*)&ip6, pkt, len);
+        }
+        default:
+            break;
+        }
+    }
+
+    self->recv(self->ctx, obj);
+
+    return 0;
+}
+
+static int _ieee802(filter_layer_t* self, uint16_t tpid, const core_object_t* obj, const unsigned char* pkt, size_t len)
+{
+    core_object_ieee802_t ieee802 = CORE_OBJECT_IEEE802_INIT(obj);
+    uint16_t              tci;
+
+    for (;;) {
+        ieee802.tpid = tpid;
+        need16(tci, pkt, len);
+        ieee802.pcp = (tci & 0xe000) >> 13;
+        ieee802.dei = (tci & 0x1000) >> 12;
+        ieee802.vid = tci & 0x0fff;
+        need16(ieee802.ether_type, pkt, len);
+
+        switch (ieee802.ether_type) {
+        case 0x88a8: /* 802.1ad */
+        case 0x9100: /* 802.1 QinQ non-standard */
+            return _ieee802(self, ieee802.ether_type, (core_object_t*)&ieee802, pkt, len);
+
+        case ETHERTYPE_IP:
+        case ETHERTYPE_IPV6:
+            return _ip(self, (core_object_t*)&ieee802, pkt, len);
+
+        default:
+            break;
+        }
+        break;
+    }
+
+    self->recv(self->ctx, obj);
+
+    return 0;
+}
+
+static int _receive(void* ctx, const core_object_t* obj)
+{
+    filter_layer_t*      self = (filter_layer_t*)ctx;
+    core_object_pcap_t*  pcap = (core_object_pcap_t*)obj;
+    const unsigned char* pkt;
+    size_t               len;
+
+    if (!self || !obj || obj->obj_type != CORE_OBJECT_PCAP || !self->recv) {
+        return 1;
+    }
+
+    pkt = pcap->bytes;
+    len = pcap->caplen;
+
+    switch (pcap->linktype) {
+    case DLT_NULL: {
+        core_object_null_t null = CORE_OBJECT_NULL_INIT(pcap);
+
+        if (pcap->is_swapped) {
+            needr32(null.family, pkt, len);
+        } else {
+            need32(null.family, pkt, len);
+        }
+
+        switch (null.family) {
+        case 2:
+        case 24:
+        case 28:
+        case 30:
+            return _ip(self, (core_object_t*)&null, pkt, len);
+
+        default:
+            break;
+        }
+        break;
+    }
+    case DLT_EN10MB: {
+        core_object_ether_t ether = CORE_OBJECT_ETHER_INIT(pcap);
+
+        needxb(ether.dhost, 6, pkt, len);
+        needxb(ether.shost, 6, pkt, len);
+        need16(ether.type, pkt, len);
+
+        switch (ether.type) {
+        case 0x8100: /* 802.1q */
+        case 0x88a8: /* 802.1ad */
+        case 0x9100: /* 802.1 QinQ non-standard */
+            return _ieee802(self, ether.type, (core_object_t*)&ether, pkt, len);
+
+        case ETHERTYPE_IP:
+        case ETHERTYPE_IPV6:
+            return _ip(self, (core_object_t*)&ether, pkt, len);
+
+        default:
+            break;
+        }
+        break;
+    }
+    case DLT_LOOP: {
+        core_object_loop_t loop = CORE_OBJECT_LOOP_INIT(pcap);
+
+        need32(loop.family, pkt, len);
+
+        switch (loop.family) {
+        case 2:
+        case 24:
+        case 28:
+        case 30:
+            return _ip(self, (core_object_t*)&loop, pkt, len);
+
+        default:
+            break;
+        }
+        break;
+    }
+    case DLT_RAW:
+#ifdef DLT_IPV4
+    case DLT_IPV4:
+#endif
+#ifdef DLT_IPV6
+    case DLT_IPV6:
+#endif
+        return _ip(self, (core_object_t*)&pcap, pkt, len);
+    case DLT_LINUX_SLL: {
+        core_object_linuxsll_t linuxsll = CORE_OBJECT_LINUXSLL_INIT(pcap);
+
+        need16(linuxsll.packet_type, pkt, len);
+        need16(linuxsll.arp_hardware, pkt, len);
+        need16(linuxsll.link_layer_address_length, pkt, len);
+        needxb(linuxsll.link_layer_address, 8, pkt, len);
+        need16(linuxsll.ether_type, pkt, len);
+
+        switch (linuxsll.ether_type) {
+        case 0x8100: /* 802.1q */
+        case 0x88a8: /* 802.1ad */
+        case 0x9100: /* 802.1 QinQ non-standard */
+            return _ieee802(self, linuxsll.ether_type, (core_object_t*)&linuxsll, pkt, len);
+
+        case ETHERTYPE_IP:
+        case ETHERTYPE_IPV6:
+            return _ip(self, (core_object_t*)&linuxsll, pkt, len);
+
+        default:
+            break;
+        }
+        break;
+    }
+    /* TODO: These might be interesting to implement
+        case DLT_IPNET:
+        case DLT_PKTAP:
+        */
+    default:
+        break;
+    }
+
+    self->recv(self->ctx, (core_object_t*)pcap);
+
+    return 0;
+}
+
+core_receiver_t filter_layer_receiver()
+{
+    return _receive;
+}

--- a/src/filter/layer.h
+++ b/src/filter/layer.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "core/log.h"
+#include "core/receiver.h"
+
+#ifndef __dnsjit_filter_layer_h
+#define __dnsjit_filter_layer_h
+
+#include "filter/layer.hh"
+
+#endif

--- a/src/filter/layer.hh
+++ b/src/filter/layer.hh
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//lua:require("dnsjit.core.log")
+//lua:require("dnsjit.core.receiver_h")
+
+typedef struct filter_layer {
+    core_log_t      _log;
+    core_receiver_t recv;
+    void*           ctx;
+} filter_layer_t;
+
+core_log_t* filter_layer_log();
+
+int filter_layer_init(filter_layer_t* self);
+int filter_layer_destroy(filter_layer_t* self);
+
+core_receiver_t filter_layer_receiver();

--- a/src/filter/layer.lua
+++ b/src/filter/layer.lua
@@ -1,0 +1,83 @@
+-- Copyright (c) 2018, OARC, Inc.
+-- All rights reserved.
+--
+-- This file is part of dnsjit.
+--
+-- dnsjit is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- dnsjit is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+
+-- dnsjit.filter.layer
+-- Parse the ether/IP stack
+--   local filter = require("dnsjit.filter.layer").new()
+--
+-- Parse the ether/IP stack of the received objects and send the top most
+-- object to the receivers.
+-- Objects are chained which each layer in the stack with the top most first.
+-- Currently supports input
+-- .IR dnsjit.core.object.pcap .
+module(...,package.seeall)
+
+require("dnsjit.filter.layer_h")
+local ffi = require("ffi")
+local C = ffi.C
+
+local t_name = "filter_layer_t"
+local filter_layer_t = ffi.typeof(t_name)
+local Layer = {}
+
+-- Create a new Layer filter.
+function Layer.new()
+    local self = {
+        _receiver = nil,
+        obj = filter_layer_t(),
+    }
+    C.filter_layer_init(self.obj)
+    ffi.gc(self.obj, C.filter_layer_destroy)
+    return setmetatable(self, { __index = Layer })
+end
+
+-- Return the Log object to control logging of this instance or module.
+function Layer:log()
+    if self == nil then
+        return C.filter_layer_log()
+    end
+    return self.obj._log
+end
+
+-- Return the C functions and context for receiving objects.
+function Layer:receive()
+    self.obj._log:debug("receive()")
+    return C.filter_layer_receiver(), self.obj
+end
+
+-- Set the receiver to pass queries to.
+function Layer:receiver(o)
+    self.obj._log:debug("receiver()")
+    self.obj.recv, self.obj.ctx = o:receive()
+    self._receiver = o
+end
+
+-- dnsjit.core.object.pcap (3),
+-- dnsjit.core.object.ether (3),
+-- dnsjit.core.object.null (3),
+-- dnsjit.core.object.loop (3),
+-- dnsjit.core.object.linuxsll (3),
+-- dnsjit.core.object.ieee802 (3),
+-- dnsjit.core.object.gre (3),
+-- dnsjit.core.object.ip (3),
+-- dnsjit.core.object.ip6 (3),
+-- dnsjit.core.object.icmp (3),
+-- dnsjit.core.object.icmp6 (3),
+-- dnsjit.core.object.udp (3),
+-- dnsjit.core.object.tcp (3)
+return Layer

--- a/src/filter/lua.c
+++ b/src/filter/lua.c
@@ -27,7 +27,8 @@
 
 static core_log_t   _log      = LOG_T_INIT("filter.lua");
 static filter_lua_t _defaults = {
-    LOG_T_INIT_OBJ("filter.lua"), 0, 0, 0, 0
+    LOG_T_INIT_OBJ("filter.lua"),
+    0, 0, 0, 0
 };
 
 core_log_t* filter_lua_log()

--- a/src/filter/lua.lua
+++ b/src/filter/lua.lua
@@ -17,7 +17,7 @@
 -- along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
 
 -- dnsjit.filter.lua
--- Filter through custom Lua function
+-- Filter through a custom Lua function
 --   local filter = require("dnsjit.filter.lua").new()
 --   filter:push("arg1")
 --   filter:push(2)
@@ -29,6 +29,10 @@
 --
 -- Filter module to run custom Lua code on received objects with the option
 -- to send them to the next receiver.
+-- It will create a new Lua state for the function provided which means it
+-- can not share any globals or knows of any previous loaded modules, see
+-- .BR dnsjit.filter.coro (3)
+-- for another way to do this using Lua coroutines.
 module(...,package.seeall)
 
 local object = require("dnsjit.core.object")
@@ -148,5 +152,5 @@ function Lua:send(object)
 end
 
 -- dnsjit.core.object (3),
--- dnsjit.filter.thread (3)
+-- dnsjit.filter.coro (3)
 return Lua

--- a/src/filter/split.hh
+++ b/src/filter/split.hh
@@ -23,7 +23,8 @@
 
 typedef enum filter_split_mode {
     FILTER_SPLIT_MODE_ROUNDROBIN,
-    FILTER_SPLIT_MODE_SENDALL
+    FILTER_SPLIT_MODE_SENDALL,
+    FILTER_SPLIT_MODE_ANY
 } filter_split_mode_t;
 
 typedef struct filter_split_recv filter_split_recv_t;
@@ -46,4 +47,4 @@ int filter_split_init(filter_split_t* self);
 int filter_split_destroy(filter_split_t* self);
 int filter_split_add(filter_split_t* self, core_receiver_t recv, void* ctx);
 
-core_receiver_t filter_split_receiver();
+core_receiver_t filter_split_receiver(filter_split_t* self);

--- a/src/filter/split.lua
+++ b/src/filter/split.lua
@@ -64,10 +64,15 @@ function Split:sendall()
     self.obj.mode = "FILTER_SPLIT_MODE_SENDALL"
 end
 
+-- Set the passthrough mode to send to any of the receivers, TODO
+function Split:any()
+    self.obj.mode = "FILTER_SPLIT_MODE_ANY"
+end
+
 -- Return the C functions and context for receiving objects.
 function Split:receive()
     self.obj._log:debug("receive()")
-    return C.filter_split_receiver(), self.obj
+    return C.filter_split_receiver(self.obj), self.obj
 end
 
 -- Set the receiver to pass objects to, this can be called multiple times to

--- a/src/filter/thread.c
+++ b/src/filter/thread.c
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "filter/thread.h"
+
+#include <sched.h>
+
+#if SIZEOF_UINT64_T < SIZEOF_PTHREAD_T
+#error "Can not store pthread_t in uint64_t, please report this"
+#endif
+
+static core_log_t      _log      = LOG_T_INIT("filter.thread");
+static filter_thread_t _defaults = {
+    LOG_T_INIT_OBJ("filter.thread"),
+    0, 0,
+    0, 0, 0
+};
+
+core_log_t* filter_thread_log()
+{
+    return &_log;
+}
+
+void* _thread(void* user)
+{
+    filter_thread_t* self = (filter_thread_t*)user;
+    size_t           ends = 0, at = 0;
+    core_object_t*   obj = 0;
+
+    while (ends < self->works) {
+        filter_thread_work_t* w = &self->work[at];
+        pthread_mutex_lock(&w->mutex);
+        if (!w->end) {
+            while (!w->end && !w->obj) {
+                pthread_cond_wait(&w->read, &w->mutex);
+            }
+        }
+        if (w->obj) {
+            obj    = w->obj;
+            w->obj = 0;
+            pthread_cond_signal(&w->write);
+        }
+        if (w->end) {
+            ends++;
+        }
+        pthread_mutex_unlock(&w->mutex);
+
+        if (obj) {
+            self->recv(self->ctx, obj);
+            free(obj);
+            obj = 0;
+        }
+
+        at++;
+        if (at == self->works)
+            at = 0;
+    }
+
+    return 0;
+}
+
+int filter_thread_init(filter_thread_t* self, size_t queue_size)
+{
+    filter_thread_work_t defwork = { 0, PTHREAD_MUTEX_INITIALIZER, PTHREAD_COND_INITIALIZER, PTHREAD_COND_INITIALIZER, 0 };
+    size_t               n;
+
+    if (!self || !queue_size) {
+        return 1;
+    }
+
+    *self = _defaults;
+
+    ldebug("init");
+
+    self->works = queue_size;
+
+    if (!(self->work = malloc(sizeof(filter_thread_work_t) * self->works))) {
+        return 1;
+    }
+    for (n = 0; n < self->works; n++) {
+        self->work[n] = defwork;
+    }
+
+    return 0;
+}
+
+int filter_thread_destroy(filter_thread_t* self)
+{
+    if (!self) {
+        return 1;
+    }
+
+    ldebug("destroy");
+
+    free(self->work);
+
+    return 0;
+}
+
+int filter_thread_start(filter_thread_t* self)
+{
+    pthread_t tid;
+
+    if (!self || !self->work) {
+        return 1;
+    }
+
+    if (pthread_create(&tid, 0, _thread, (void*)self)) {
+        return 2;
+    }
+    self->tid = (uint64_t)tid;
+
+    return 0;
+}
+
+int filter_thread_stop(filter_thread_t* self)
+{
+    pthread_t tid;
+    size_t    n;
+
+    if (!self) {
+        return 1;
+    }
+
+    tid = (pthread_t)self->tid;
+
+    for (n = 0; n < self->works; n++) {
+        filter_thread_work_t* w = &self->work[n];
+        pthread_mutex_lock(&w->mutex);
+        w->end = 1;
+        pthread_cond_broadcast(&w->read);
+        pthread_mutex_unlock(&w->mutex);
+    }
+    pthread_join(tid, 0);
+
+    return 0;
+}
+
+static int _receive(void* ctx, const core_object_t* obj)
+{
+    filter_thread_t*      self = (filter_thread_t*)ctx;
+    core_object_t*        copy = core_object_copy(obj);
+    filter_thread_work_t* w;
+
+    if (!self || !copy || !self->recv) {
+        return 1;
+    }
+
+    w = &self->work[self->at];
+    pthread_mutex_lock(&w->mutex);
+    while (w->obj) {
+        pthread_cond_wait(&w->write, &w->mutex);
+    }
+    w->obj = copy;
+    pthread_cond_signal(&w->read);
+    pthread_mutex_unlock(&w->mutex);
+
+    self->at++;
+    if (self->at == self->works)
+        self->at = 0;
+
+    return 0;
+}
+
+core_receiver_t filter_thread_receiver()
+{
+    return _receive;
+}

--- a/src/filter/thread.h
+++ b/src/filter/thread.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "core/log.h"
+#include "core/receiver.h"
+
+#ifndef __dnsjit_filter_thread_h
+#define __dnsjit_filter_thread_h
+
+#include <stdint.h>
+#include <pthread.h>
+
+typedef struct filter_thread_work {
+    core_object_t*  obj;
+    pthread_mutex_t mutex;
+    pthread_cond_t  read, write;
+    char            end;
+} filter_thread_work_t;
+
+#include "filter/thread.hh"
+
+#endif

--- a/src/filter/thread.hh
+++ b/src/filter/thread.hh
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#if 0
+typedef struct {} filter_thread_work_t;
+#endif
+
+//lua:require("dnsjit.core.log")
+//lua:require("dnsjit.core.receiver_h")
+
+typedef struct filter_thread {
+    core_log_t      _log;
+    core_receiver_t recv;
+    void*           ctx;
+
+    uint64_t              tid;
+    filter_thread_work_t* work;
+    size_t                works, at;
+} filter_thread_t;
+
+core_log_t* filter_thread_log();
+
+int filter_thread_init(filter_thread_t* self, size_t queue_size);
+int filter_thread_destroy(filter_thread_t* self);
+int filter_thread_start(filter_thread_t* self);
+int filter_thread_stop(filter_thread_t* self);
+
+core_receiver_t filter_thread_receiver();

--- a/src/filter/thread.lua
+++ b/src/filter/thread.lua
@@ -1,0 +1,90 @@
+-- Copyright (c) 2018, OARC, Inc.
+-- All rights reserved.
+--
+-- This file is part of dnsjit.
+--
+-- dnsjit is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- dnsjit is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+
+-- dnsjit.filter.thread
+-- Send objects to a receiver in another thread
+--   local input = ...
+--   local thread = require("dnsjit.filter.thread").new()
+--   local output = ...
+--   input:receiver(thread)
+--   thread:receiver(output)
+--   thread:start()
+--   input:run()
+--   thread:stop()
+--
+-- NOTE; Work in progress!
+-- Send objects to a receiver which will run in another thread using a
+-- circular buffer.
+-- Currently only support 1 producer and 1 consumer and copies objects
+-- (which is a huge slowdown).
+module(...,package.seeall)
+
+require("dnsjit.filter.thread_h")
+local ffi = require("ffi")
+local C = ffi.C
+
+local t_name = "filter_thread_t"
+local filter_thread_t = ffi.typeof(t_name)
+local Thread = {}
+
+-- Create a new Thread filter.
+function Thread.new(queue_size)
+    if queue_size == nil then
+        queue_size = 1000
+    end
+    local self = {
+        receivers = {},
+        obj = filter_thread_t(),
+    }
+    C.filter_thread_init(self.obj, queue_size)
+    ffi.gc(self.obj, C.filter_thread_destroy)
+    return setmetatable(self, { __index = Thread })
+end
+
+-- Return the Log object to control logging of this instance or module.
+function Thread:log()
+    if self == nil then
+        return C.filter_thread_log()
+    end
+    return self.obj._log
+end
+
+-- Start the thread(s), returns 0 on success.
+function Thread:start()
+    return C.filter_thread_start(self.obj)
+end
+
+-- Stop the thread(s) and flush the queue, returns 0 on success.
+function Thread:stop()
+    return C.filter_thread_stop(self.obj)
+end
+
+-- Return the C functions and context for receiving objects.
+function Thread:receive()
+    self.obj._log:debug("receive()")
+    return C.filter_thread_receiver(), self.obj
+end
+
+-- Set the receiver to pass queries to.
+function Thread:receiver(o)
+    self.obj._log:debug("receiver()")
+    self.obj.recv, self.obj.ctx = o:receive()
+    self._receiver = o
+end
+
+return Thread

--- a/src/filter/timing.c
+++ b/src/filter/timing.c
@@ -42,7 +42,8 @@ typedef struct _filter_timing {
 
 static core_log_t      _log      = LOG_T_INIT("filter.timing");
 static filter_timing_t _defaults = {
-    LOG_T_INIT_OBJ("filter.timing"), 0, 0,
+    LOG_T_INIT_OBJ("filter.timing"),
+    0, 0,
     TIMING_MODE_KEEP, 0, 0, 0.0,
 };
 

--- a/src/gen-makefile.sh
+++ b/src/gen-makefile.sh
@@ -1,0 +1,116 @@
+#!/bin/sh
+
+echo '# Copyright (c) 2018, OARC, Inc.
+# All rights reserved.
+#
+# This file is part of dnsjit.
+#
+# dnsjit is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# dnsjit is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+
+MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
+CLEANFILES =
+
+#SUBDIRS = test
+
+AM_CFLAGS = -I$(srcdir) \
+  -I$(top_srcdir) \
+  $(PTHREAD_CFLAGS) \
+  $(luajit_CFLAGS)
+
+EXTRA_DIST = gen-manpage.lua dnsjit.1in
+
+bin_PROGRAMS = dnsjit
+
+dnsjit_SOURCES = dnsjit.c globals.c \
+  omg-dns/omg_dns.c \
+  pcap-thread/pcap_thread.c \
+  sllq/sllq.c
+dist_dnsjit_SOURCES = core.lua lib.lua input.lua filter.lua output.lua \
+  omg-dns/omg_dns.h \
+  pcap-thread/pcap_thread.h \
+  sllq/sllq.h
+lua_hobjects =
+lua_objects = core.luao lib.luao input.luao filter.luao output.luao
+dnsjit_LDADD = $(PTHREAD_LIBS) $(luajit_LIBS)
+
+# C source and headers';
+
+echo "dnsjit_SOURCES +=`find core lib input filter output -type f -name '*.c' -printf ' %p'`"
+echo "dist_dnsjit_SOURCES +=`find core lib input filter output -type f -name '*.h' -printf ' %p'`"
+
+echo '
+# Lua headers'
+echo "dist_dnsjit_SOURCES +=`find core lib input filter output -type f -name '*.hh' -printf ' %p'`"
+echo "lua_hobjects +=`find core lib input filter output -type f -name '*.hh' -printf ' %p'|sed -e 's%.hh%.luaho%g'`"
+
+echo '
+# Lua sources'
+echo "dist_dnsjit_SOURCES +=`find core lib input filter output -type f -name '*.lua' -printf ' %p'`"
+echo "lua_objects +=`find core lib input filter output -type f -name '*.lua' -printf ' %p '|sed -e 's%.lua %.luao%g'`"
+
+echo '
+dnsjit_LDFLAGS = -Wl,-E
+dnsjit_LDADD += $(lua_hobjects) $(lua_objects)
+CLEANFILES += $(lua_hobjects) $(lua_objects)
+
+man1_MANS = dnsjit.1
+CLEANFILES += $(man1_MANS)
+
+man3_MANS = dnsjit.core.3 dnsjit.lib.3 dnsjit.input.3 dnsjit.filter.3 dnsjit.output.3';
+echo "man3_MANS +=`find core lib input filter output -type f -name '*.lua' -printf ' dnsjit.%p'|sed -e 's%.lua%.3%g'|sed -e 's%/%.%g'`"
+
+echo 'CLEANFILES += *.3in $(man3_MANS)
+
+.lua.luao:
+	@mkdir -p `dirname "$@"`
+	$(LUAJIT) -bg -n "dnsjit.`echo \"$@\" | sed '"'"'s%\..*%%'"'"' | sed '"'"'s%/%.%g'"'"'`" -t o "$<" "$@"
+
+.luah.luaho:
+	@mkdir -p `dirname "$@"`
+	$(LUAJIT) -bg -n "dnsjit.`echo \"$@\" | sed '"'"'s%\..*%%'"'"' | sed '"'"'s%/%.%g'"'"'`_h" -t o "$<" "$@"
+
+.hh.luah:
+	@mkdir -p `dirname "$@"`
+	@echo '"'"'module(...,package.seeall);'"'"' > "$@"
+	@cat "$<" | grep '"'"'^//lua:'"'"' | sed '"'"'s%^//lua:%%'"'"' >> "$@"
+	@echo '"'"'require("ffi").cdef[['"'"' >> "$@"
+	@cat "$<" | grep -v '"'"'^#'"'"' >> "$@"
+	@echo '"'"']]'"'"' >> "$@"
+
+.1in.1:
+	sed -e '"'"'s,[@]PACKAGE_VERSION[@],$(PACKAGE_VERSION),g'"'"' \
+  -e '"'"'s,[@]PACKAGE_URL[@],$(PACKAGE_URL),g'"'"' \
+  -e '"'"'s,[@]PACKAGE_BUGREPORT[@],$(PACKAGE_BUGREPORT),g'"'"' \
+  < "$<" > "$@"
+
+.3in.3:
+	sed -e '"'"'s,[@]PACKAGE_VERSION[@],$(PACKAGE_VERSION),g'"'"' \
+  -e '"'"'s,[@]PACKAGE_URL[@],$(PACKAGE_URL),g'"'"' \
+  -e '"'"'s,[@]PACKAGE_BUGREPORT[@],$(PACKAGE_BUGREPORT),g'"'"' \
+  < "$<" > "$@"
+';
+
+for file in core.lua lib.lua input.lua filter.lua output.lua; do
+    man=`echo "$file"|sed -e 's%.lua%.3%g'|sed -e 's%/%.%g'`
+echo "
+dnsjit.${man}in: $file gen-manpage.lua
+	\$(LUAJIT) \"\$(srcdir)/gen-manpage.lua\" \"\$(srcdir)/$file\" > \"\$@\"";
+done
+
+find core lib input filter output -type f -name '*.lua' | while read file; do
+    man=`echo "$file"|sed -e 's%.lua%.3%g'|sed -e 's%/%.%g'`
+echo "
+dnsjit.${man}in: $file gen-manpage.lua
+	\$(LUAJIT) \"\$(srcdir)/gen-manpage.lua\" \"\$(srcdir)/$file\" > \"\$@\"";
+done

--- a/src/globals.c
+++ b/src/globals.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "filter/coro.h"
+
+#include <lua.h>
+#include <lualib.h>
+#include <lauxlib.h>
+
+void dnsjit_globals(lua_State* L)
+{
+    lua_pushcfunction(L, filter_coro_store_thread);
+    lua_setglobal(L, "dnsjit_filter_coro_store_thread");
+}

--- a/src/input.lua
+++ b/src/input.lua
@@ -22,8 +22,9 @@
 -- Input modules used to read DNS messages in various ways.
 module(...,package.seeall)
 
-error("This should not be included, only here for documentation generation")
-
+-- dnsjit.input.fpcap (3),
+-- dnsjit.input.mmpcap (3),
+-- dnsjit.input.pcap (3),
 -- dnsjit.input.pcapthread (3),
 -- dnsjit.input.zero (3)
 return

--- a/src/input/fpcap.c
+++ b/src/input/fpcap.c
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "input/fpcap.h"
+#include "core/object/pcap.h"
+
+#include <time.h>
+#include <stdio.h>
+
+static core_log_t    _log      = LOG_T_INIT("input.fpcap");
+static input_fpcap_t _defaults = {
+    LOG_T_INIT_OBJ("input.fpcap"),
+    0, 0,
+    0, 0,
+    0, { 0, 0 }, { 0, 0 }, 0, 0,
+    0, 0, 0, 0, 0, 0, 0
+};
+
+core_log_t* input_fpcap_log()
+{
+    return &_log;
+}
+
+int input_fpcap_init(input_fpcap_t* self)
+{
+    if (!self) {
+        return 1;
+    }
+
+    *self = _defaults;
+
+    ldebug("init");
+
+    return 0;
+}
+
+int input_fpcap_destroy(input_fpcap_t* self)
+{
+    if (!self) {
+        return 1;
+    }
+
+    ldebug("destroy");
+
+    if (self->file) {
+        fclose(self->file);
+    }
+    if (self->buf) {
+        free(self->buf);
+    }
+
+    return 0;
+}
+
+static inline uint16_t _flip16(uint16_t u16)
+{
+    return ((u16 & 0xff) << 8) | (u16 >> 8);
+}
+
+static inline uint32_t _flip32(uint32_t u32)
+{
+    return ((u32 & 0xff) << 24) | ((u32 & 0xff00) << 8) | ((u32 & 0xff0000) >> 8) | (u32 >> 24);
+}
+
+int input_fpcap_open(input_fpcap_t* self, const char* file)
+{
+    int ret;
+
+    if (!self || !file) {
+        return 1;
+    }
+
+    if (self->file) {
+        fclose(self->file);
+        self->file = 0;
+    }
+    if (self->buf) {
+        free(self->buf);
+        self->buf = 0;
+    }
+
+    if (!(self->file = fopen(file, "rb"))) {
+        return 1;
+    }
+
+    if ((ret = fread(&self->magic_number, 1, 24, self->file)) != 24) {
+        fclose(self->file);
+        self->file = 0;
+        return 1;
+    }
+    switch (self->magic_number) {
+    case 0x4d3cb2a1:
+        self->is_nanosec = 1;
+    case 0xd4c3b2a1:
+        self->is_swapped    = 1;
+        self->version_major = _flip16(self->version_major);
+        self->version_minor = _flip16(self->version_minor);
+        self->thiszone      = (int32_t)_flip32((uint32_t)self->thiszone);
+        self->sigfigs       = _flip32(self->sigfigs);
+        self->snaplen       = _flip32(self->snaplen);
+        self->network       = _flip32(self->network);
+        break;
+    case 0xa1b2c3d4:
+    case 0xa1b23c4d:
+        break;
+    default:
+        fclose(self->file);
+        self->file = 0;
+        return 2;
+    }
+
+    if (self->version_major == 2 && self->version_minor == 4) {
+        if (!(self->buf = malloc(self->snaplen))) {
+            fclose(self->file);
+            self->file = 0;
+            return 1;
+        }
+        ldebug("pcap v%u.%u snaplen:%lu %s", self->version_major, self->version_minor, self->snaplen, self->is_swapped ? " swapped" : "");
+        return 0;
+    }
+
+    fclose(self->file);
+    self->file = 0;
+    return 2;
+}
+
+int input_fpcap_run(input_fpcap_t* self)
+{
+    struct timespec ts;
+    struct {
+        uint32_t ts_sec;
+        uint32_t ts_usec;
+        uint32_t incl_len;
+        uint32_t orig_len;
+    } hdr;
+    core_object_pcap_t pkt = CORE_OBJECT_PCAP_INIT(0);
+
+    if (!self || !self->file || !self->recv) {
+        return 1;
+    }
+
+    pkt.snaplen    = self->snaplen;
+    pkt.linktype   = self->network;
+    pkt.bytes      = (unsigned char*)self->buf;
+    pkt.is_swapped = self->is_swapped;
+
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    self->ts.sec  = ts.tv_sec;
+    self->ts.nsec = ts.tv_nsec;
+
+    while (fread(&hdr, 1, 16, self->file) == 16) {
+        if (self->is_swapped) {
+            hdr.ts_sec   = _flip32(hdr.ts_sec);
+            hdr.ts_usec  = _flip32(hdr.ts_usec);
+            hdr.incl_len = _flip32(hdr.incl_len);
+            hdr.orig_len = _flip32(hdr.orig_len);
+        }
+        if (hdr.incl_len > self->snaplen) {
+            return 2;
+        }
+        if (fread(self->buf, 1, hdr.incl_len, self->file) != hdr.incl_len) {
+            return 3;
+        }
+
+        self->pkts++;
+
+        pkt.ts.sec = hdr.ts_sec;
+        if (self->is_nanosec) {
+            pkt.ts.nsec = hdr.ts_usec;
+        } else {
+            pkt.ts.nsec = hdr.ts_usec * 1000;
+        }
+        pkt.caplen = hdr.incl_len;
+        pkt.len    = hdr.orig_len;
+
+        self->recv(self->ctx, (core_object_t*)&pkt);
+    }
+
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    self->te.sec  = ts.tv_sec;
+    self->te.nsec = ts.tv_nsec;
+
+    return 0;
+}

--- a/src/input/fpcap.h
+++ b/src/input/fpcap.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "core/log.h"
+#include "core/receiver.h"
+#include "core/timespec.h"
+
+#ifndef __dnsjit_input_fpcap_h
+#define __dnsjit_input_fpcap_h
+
+#include "input/fpcap.hh"
+
+#endif

--- a/src/input/fpcap.hh
+++ b/src/input/fpcap.hh
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//lua:require("dnsjit.core.log")
+//lua:require("dnsjit.core.receiver_h")
+//lua:require("dnsjit.core.timespec_h")
+
+typedef struct input_fpcap {
+    core_log_t      _log;
+    core_receiver_t recv;
+    void*           ctx;
+
+    unsigned short is_swapped : 1;
+    unsigned short is_nanosec : 1;
+
+    void*           file;
+    core_timespec_t ts, te;
+    size_t          pkts;
+    uint8_t*        buf;
+
+    uint32_t magic_number;
+    uint16_t version_major;
+    uint16_t version_minor;
+    int32_t  thiszone;
+    uint32_t sigfigs;
+    uint32_t snaplen;
+    uint32_t network;
+} input_fpcap_t;
+
+core_log_t* input_fpcap_log();
+
+int input_fpcap_init(input_fpcap_t* self);
+int input_fpcap_destroy(input_fpcap_t* self);
+int input_fpcap_open(input_fpcap_t* self, const char* file);
+int input_fpcap_run(input_fpcap_t* self);

--- a/src/input/fpcap.lua
+++ b/src/input/fpcap.lua
@@ -1,0 +1,124 @@
+-- Copyright (c) 2018, OARC, Inc.
+-- All rights reserved.
+--
+-- This file is part of dnsjit.
+--
+-- dnsjit is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- dnsjit is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+
+-- dnsjit.input.fpcap
+-- Read input from a PCAP file using fopen()
+--   local input = require("dnsjit.input.fpcap").new()
+--   input:open("file.pcap")
+--   input:receiver(filter_or_output)
+--   input:run()
+--
+-- Read input from a PCAP file using standard library function
+-- .B fopen()
+-- and parse the PCAP without libpcap.
+-- After opening a file and reading the PCAP header, the attributes are
+-- populated.
+-- .SS Attributes
+-- .TP
+-- is_swapped
+-- Indicate if the byte order in the PCAP is in reverse order of the host.
+-- .TP
+-- is_nanosec
+-- Indicate if the time stamps are in nanoseconds or not.
+-- .TP
+-- magic_number
+-- Magic number.
+-- .TP
+-- version_major
+-- Major version number.
+-- .TP
+-- version_minor
+-- Minor version number.
+-- .TP
+-- thiszone
+-- GMT to local correction.
+-- .TP
+-- sigfigs
+-- Accuracy of timestamps.
+-- .TP
+-- snaplen
+-- Max length of captured packets, in octets.
+-- .TP
+-- network
+-- Data link type.
+module(...,package.seeall)
+
+require("dnsjit.input.fpcap_h")
+local ffi = require("ffi")
+local C = ffi.C
+
+local t_name = "input_fpcap_t"
+local input_fpcap_t = ffi.typeof(t_name)
+local Fpcap = {}
+
+-- Create a new Fpcap input.
+function Fpcap.new()
+    local self = {
+        _receiver = nil,
+        obj = input_fpcap_t(),
+    }
+    C.input_fpcap_init(self.obj)
+    ffi.gc(self.obj, C.input_fpcap_destroy)
+    return setmetatable(self, { __index = Fpcap })
+end
+
+-- Return the Log object to control logging of this instance or module.
+function Fpcap:log()
+    if self == nil then
+        return C.input_fpcap_log()
+    end
+    return self.obj._log
+end
+
+-- Set the receiver to pass queries to.
+function Fpcap:receiver(o)
+    self.obj._log:debug("receiver()")
+    self.obj.recv, self.obj.ctx = o:receive()
+    self._receiver = o
+end
+
+-- Open a PCAP file for processing and read the PCAP header.
+-- Returns 0 on success.
+function Fpcap:open(file)
+    return C.input_fpcap_open(self.obj, file)
+end
+
+-- Start processing packets.
+-- Returns 0 on success.
+function Fpcap:run()
+    return C.input_fpcap_run(self.obj)
+end
+
+-- Return the seconds and nanoseconds (as a list) of the start time for
+-- .BR Fpcap:run() .
+function Fpcap:start_time()
+    return tonumber(self.obj.ts.sec), tonumber(self.obj.ts.nsec)
+end
+
+-- Return the seconds and nanoseconds (as a list) of the stop time for
+-- .BR Fpcap:run() .
+function Fpcap:end_time()
+    return tonumber(self.obj.te.sec), tonumber(self.obj.te.nsec)
+end
+
+-- Return the number of packets seen.
+function Fpcap:packets()
+    return tonumber(self.obj.pkts)
+end
+
+return Fpcap

--- a/src/input/mmpcap.c
+++ b/src/input/mmpcap.c
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "input/mmpcap.h"
+#include "core/object/pcap.h"
+
+#include <time.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <string.h>
+
+static core_log_t     _log      = LOG_T_INIT("input.mmpcap");
+static input_mmpcap_t _defaults = {
+    LOG_T_INIT_OBJ("input.mmpcap"),
+    0, 0,
+    0, 0,
+    -1, 0, 0, { 0, 0 }, { 0, 0 }, 0, 0,
+    0, 0, 0, 0, 0, 0, 0
+};
+
+core_log_t* input_mmpcap_log()
+{
+    return &_log;
+}
+
+int input_mmpcap_init(input_mmpcap_t* self)
+{
+    if (!self) {
+        return 1;
+    }
+
+    *self = _defaults;
+
+    ldebug("init");
+
+    return 0;
+}
+
+int input_mmpcap_destroy(input_mmpcap_t* self)
+{
+    if (!self) {
+        return 1;
+    }
+
+    ldebug("destroy");
+
+    if (self->buf) {
+        munmap(self->buf, self->len);
+    }
+    if (self->fd) {
+        close(self->fd);
+    }
+
+    return 0;
+}
+
+static inline uint16_t _flip16(uint16_t u16)
+{
+    return ((u16 & 0xff) << 8) | (u16 >> 8);
+}
+
+static inline uint32_t _flip32(uint32_t u32)
+{
+    return ((u32 & 0xff) << 24) | ((u32 & 0xff00) << 8) | ((u32 & 0xff0000) >> 8) | (u32 >> 24);
+}
+
+int input_mmpcap_open(input_mmpcap_t* self, const char* file)
+{
+    struct stat sb;
+
+    if (!self || !file) {
+        return 1;
+    }
+
+    if (self->buf) {
+        munmap(self->buf, self->len);
+        self->buf = 0;
+    }
+    if (self->fd) {
+        close(self->fd);
+    }
+
+    if ((self->fd = open(file, O_RDONLY)) < 0) {
+        return 1;
+    }
+
+    if (fstat(self->fd, &sb)) {
+        close(self->fd);
+        self->fd = -1;
+        return 1;
+    }
+    self->len = sb.st_size;
+
+    if ((self->buf = mmap(0, self->len, PROT_READ, MAP_PRIVATE, self->fd, 0)) == MAP_FAILED) {
+        self->buf = 0;
+        close(self->fd);
+        self->fd = -1;
+        return 1;
+    }
+
+    if (self->len < 24) {
+        munmap(self->buf, self->len);
+        self->buf = 0;
+        close(self->fd);
+        self->fd = -1;
+        return 1;
+    }
+    memcpy(&self->magic_number, self->buf, 24);
+    self->at = 24;
+    switch (self->magic_number) {
+    case 0x4d3cb2a1:
+        self->is_nanosec = 1;
+    case 0xd4c3b2a1:
+        self->is_swapped    = 1;
+        self->version_major = _flip16(self->version_major);
+        self->version_minor = _flip16(self->version_minor);
+        self->thiszone      = (int32_t)_flip32((uint32_t)self->thiszone);
+        self->sigfigs       = _flip32(self->sigfigs);
+        self->snaplen       = _flip32(self->snaplen);
+        self->network       = _flip32(self->network);
+        break;
+    case 0xa1b2c3d4:
+    case 0xa1b23c4d:
+        break;
+    default:
+        munmap(self->buf, self->len);
+        self->buf = 0;
+        close(self->fd);
+        self->fd = -1;
+        return 2;
+    }
+
+    if (self->version_major == 2 && self->version_minor == 4) {
+        ldebug("pcap v%u.%u snaplen:%lu %s", self->version_major, self->version_minor, self->snaplen, self->is_swapped ? " swapped" : "");
+        return 0;
+    }
+
+    munmap(self->buf, self->len);
+    self->buf = 0;
+    close(self->fd);
+    self->fd = -1;
+    return 2;
+}
+
+struct _hdr {
+    uint32_t ts_sec;
+    uint32_t ts_usec;
+    uint32_t incl_len;
+    uint32_t orig_len;
+};
+
+int input_mmpcap_run(input_mmpcap_t* self)
+{
+    struct timespec    ts;
+    struct _hdr        hdr;
+    core_object_pcap_t pkt = CORE_OBJECT_PCAP_INIT(0);
+
+    if (!self || !self->buf || !self->recv) {
+        return 1;
+    }
+
+    pkt.snaplen    = self->snaplen;
+    pkt.linktype   = self->network;
+    pkt.is_swapped = self->is_swapped;
+
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    self->ts.sec  = ts.tv_sec;
+    self->ts.nsec = ts.tv_nsec;
+
+    while (self->len - self->at > 16) {
+        memcpy(&hdr, &self->buf[self->at], 16);
+        self->at += 16;
+        if (self->is_swapped) {
+            hdr.ts_sec   = _flip32(hdr.ts_sec);
+            hdr.ts_usec  = _flip32(hdr.ts_usec);
+            hdr.incl_len = _flip32(hdr.incl_len);
+            hdr.orig_len = _flip32(hdr.orig_len);
+        }
+        if (hdr.incl_len > self->snaplen) {
+            return 2;
+        }
+        if (self->len - self->at < hdr.incl_len) {
+            return 3;
+        }
+
+        self->pkts++;
+
+        pkt.ts.sec = hdr.ts_sec;
+        if (self->is_nanosec) {
+            pkt.ts.nsec = hdr.ts_usec;
+        } else {
+            pkt.ts.nsec = hdr.ts_usec * 1000;
+        }
+        pkt.bytes  = (unsigned char*)&self->buf[self->at];
+        pkt.caplen = hdr.incl_len;
+        pkt.len    = hdr.orig_len;
+
+        self->recv(self->ctx, (core_object_t*)&pkt);
+
+        self->at += hdr.incl_len;
+    }
+
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    self->te.sec  = ts.tv_sec;
+    self->te.nsec = ts.tv_nsec;
+
+    return 0;
+}

--- a/src/input/mmpcap.h
+++ b/src/input/mmpcap.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "core/log.h"
+#include "core/receiver.h"
+#include "core/timespec.h"
+
+#ifndef __dnsjit_input_mmpcap_h
+#define __dnsjit_input_mmpcap_h
+
+#include "input/mmpcap.hh"
+
+#endif

--- a/src/input/mmpcap.hh
+++ b/src/input/mmpcap.hh
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//lua:require("dnsjit.core.log")
+//lua:require("dnsjit.core.receiver_h")
+//lua:require("dnsjit.core.timespec_h")
+
+typedef struct input_mmpcap {
+    core_log_t      _log;
+    core_receiver_t recv;
+    void*           ctx;
+
+    unsigned short is_swapped : 1;
+    unsigned short is_nanosec : 1;
+
+    int             fd;
+    size_t          len, at;
+    core_timespec_t ts, te;
+    size_t          pkts;
+    uint8_t*        buf;
+
+    uint32_t magic_number;
+    uint16_t version_major;
+    uint16_t version_minor;
+    int32_t  thiszone;
+    uint32_t sigfigs;
+    uint32_t snaplen;
+    uint32_t network;
+} input_mmpcap_t;
+
+core_log_t* input_mmpcap_log();
+
+int input_mmpcap_init(input_mmpcap_t* self);
+int input_mmpcap_destroy(input_mmpcap_t* self);
+int input_mmpcap_open(input_mmpcap_t* self, const char* file);
+int input_mmpcap_run(input_mmpcap_t* self);

--- a/src/input/mmpcap.lua
+++ b/src/input/mmpcap.lua
@@ -1,0 +1,124 @@
+-- Copyright (c) 2018, OARC, Inc.
+-- All rights reserved.
+--
+-- This file is part of dnsjit.
+--
+-- dnsjit is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- dnsjit is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+
+-- dnsjit.input.mmpcap
+-- Read input from a PCAP file using mmap()
+--   local input = require("dnsjit.input.fpcap").new()
+--   input:open("file.pcap")
+--   input:receiver(filter_or_output)
+--   input:run()
+--
+-- Read input from a PCAP file by mapping the whole file to memory using
+-- .B mmap()
+-- and parse the PCAP without libpcap.
+-- After opening a file and reading the PCAP header, the attributes are
+-- populated.
+-- .SS Attributes
+-- .TP
+-- is_swapped
+-- Indicate if the byte order in the PCAP is in reverse order of the host.
+-- .TP
+-- is_nanosec
+-- Indicate if the time stamps are in nanoseconds or not.
+-- .TP
+-- magic_number
+-- Magic number.
+-- .TP
+-- version_major
+-- Major version number.
+-- .TP
+-- version_minor
+-- Minor version number.
+-- .TP
+-- thiszone
+-- GMT to local correction.
+-- .TP
+-- sigfigs
+-- Accuracy of timestamps.
+-- .TP
+-- snaplen
+-- Max length of captured packets, in octets.
+-- .TP
+-- network
+-- Data link type.
+module(...,package.seeall)
+
+require("dnsjit.input.mmpcap_h")
+local ffi = require("ffi")
+local C = ffi.C
+
+local t_name = "input_mmpcap_t"
+local input_mmpcap_t = ffi.typeof(t_name)
+local Mmpcap = {}
+
+-- Create a new Mmpcap input.
+function Mmpcap.new()
+    local self = {
+        _receiver = nil,
+        obj = input_mmpcap_t(),
+    }
+    C.input_mmpcap_init(self.obj)
+    ffi.gc(self.obj, C.input_mmpcap_destroy)
+    return setmetatable(self, { __index = Mmpcap })
+end
+
+-- Return the Log object to control logging of this instance or module.
+function Mmpcap:log()
+    if self == nil then
+        return C.input_mmpcap_log()
+    end
+    return self.obj._log
+end
+
+-- Set the receiver to pass queries to.
+function Mmpcap:receiver(o)
+    self.obj._log:debug("receiver()")
+    self.obj.recv, self.obj.ctx = o:receive()
+    self._receiver = o
+end
+
+-- Open a PCAP file for processing and read the PCAP header.
+-- Returns 0 on success.
+function Mmpcap:open(file)
+    return C.input_mmpcap_open(self.obj, file)
+end
+
+-- Start processing packets.
+-- Returns 0 on success.
+function Mmpcap:run()
+    return C.input_mmpcap_run(self.obj)
+end
+
+-- Return the seconds and nanoseconds (as a list) of the start time for
+-- .BR Mmpcap:run() .
+function Mmpcap:start_time()
+    return tonumber(self.obj.ts.sec), tonumber(self.obj.ts.nsec)
+end
+
+-- Return the seconds and nanoseconds (as a list) of the stop time for
+-- .BR Mmpcap:run() .
+function Mmpcap:end_time()
+    return tonumber(self.obj.te.sec), tonumber(self.obj.te.nsec)
+end
+
+-- Return the number of packets seen.
+function Mmpcap:packets()
+    return tonumber(self.obj.pkts)
+end
+
+return Mmpcap

--- a/src/input/pcap.c
+++ b/src/input/pcap.c
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "input/pcap.h"
+#include "core/object/pcap.h"
+
+#include <time.h>
+
+static core_log_t   _log      = LOG_T_INIT("input.pcap");
+static input_pcap_t _defaults = {
+    LOG_T_INIT_OBJ("input.pcap"),
+    0, 0,
+    0, { 0, 0 }, { 0, 0 }, 0,
+    0, 0,
+    0
+};
+
+core_log_t* input_pcap_log()
+{
+    return &_log;
+}
+
+int input_pcap_init(input_pcap_t* self)
+{
+    if (!self) {
+        return 1;
+    }
+
+    *self = _defaults;
+
+    ldebug("init");
+
+    return 0;
+}
+
+int input_pcap_destroy(input_pcap_t* self)
+{
+    if (!self) {
+        return 1;
+    }
+
+    ldebug("destroy");
+
+    if (self->pcap) {
+        pcap_close(self->pcap);
+    }
+
+    return 0;
+}
+
+int input_pcap_open_offline(input_pcap_t* self, const char* file)
+{
+    if (!self || !file) {
+        return 1;
+    }
+
+    if (self->pcap) {
+        pcap_close(self->pcap);
+    }
+
+    if (!(self->pcap = pcap_open_offline(file, 0))) {
+        return 1;
+    }
+
+    self->snaplen  = pcap_snapshot(self->pcap);
+    self->linktype = pcap_datalink(self->pcap);
+    self->swapped  = pcap_is_swapped(self->pcap);
+
+    return 0;
+}
+
+static void _handler(u_char* user, const struct pcap_pkthdr* h, const u_char* bytes)
+{
+    input_pcap_t*      self = (input_pcap_t*)user;
+    core_object_pcap_t pkt  = CORE_OBJECT_PCAP_INIT(0);
+
+    if (!self || !h || !bytes) {
+        return;
+    }
+
+    self->pkts++;
+
+    pkt.snaplen    = self->snaplen;
+    pkt.linktype   = self->linktype;
+    pkt.ts.sec     = h->ts.tv_sec;
+    pkt.ts.nsec    = h->ts.tv_usec * 1000;
+    pkt.caplen     = h->caplen;
+    pkt.len        = h->len;
+    pkt.bytes      = bytes;
+    pkt.is_swapped = self->swapped;
+
+    self->recv(self->ctx, (core_object_t*)&pkt);
+}
+
+int input_pcap_loop(input_pcap_t* self, int cnt)
+{
+    struct timespec ts;
+    int             ret;
+
+    if (!self || !self->pcap || !self->recv) {
+        return -1;
+    }
+
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    self->ts.sec  = ts.tv_sec;
+    self->ts.nsec = ts.tv_nsec;
+
+    ret = pcap_loop(self->pcap, cnt, _handler, (void*)self);
+
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    self->te.sec  = ts.tv_sec;
+    self->te.nsec = ts.tv_nsec;
+
+    return ret;
+}
+
+int input_pcap_dispatch(input_pcap_t* self, int cnt)
+{
+    struct timespec ts;
+    int             ret;
+
+    if (!self || !self->pcap || !self->recv) {
+        return -1;
+    }
+
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    self->ts.sec  = ts.tv_sec;
+    self->ts.nsec = ts.tv_nsec;
+
+    ret = pcap_dispatch(self->pcap, cnt, _handler, (void*)self);
+
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    self->te.sec  = ts.tv_sec;
+    self->te.nsec = ts.tv_nsec;
+
+    return ret;
+}

--- a/src/input/pcap.h
+++ b/src/input/pcap.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "core/log.h"
+#include "core/receiver.h"
+#include "core/timespec.h"
+
+#ifndef __dnsjit_input_pcap_h
+#define __dnsjit_input_pcap_h
+
+#include <pcap/pcap.h>
+
+#include "input/pcap.hh"
+
+#endif

--- a/src/input/pcap.hh
+++ b/src/input/pcap.hh
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#if 0
+typedef struct pcap {} pcap_t;
+#endif
+
+//lua:require("dnsjit.core.log")
+//lua:require("dnsjit.core.receiver_h")
+//lua:require("dnsjit.core.timespec_h")
+
+typedef struct input_pcap {
+    core_log_t      _log;
+    core_receiver_t recv;
+    void*           ctx;
+
+    pcap_t*         pcap;
+    core_timespec_t ts, te;
+    size_t          pkts;
+
+    size_t   snaplen;
+    uint32_t linktype;
+
+    unsigned short swapped : 1;
+} input_pcap_t;
+
+core_log_t* input_pcap_log();
+
+int input_pcap_init(input_pcap_t* self);
+int input_pcap_destroy(input_pcap_t* self);
+int input_pcap_open_offline(input_pcap_t* self, const char* file);
+int input_pcap_loop(input_pcap_t* self, int cnt);
+int input_pcap_dispatch(input_pcap_t* self, int cnt);

--- a/src/input/pcapthread.c
+++ b/src/input/pcapthread.c
@@ -45,7 +45,7 @@ core_log_t* input_pcapthread_log()
 static void _udp(u_char* user, const pcap_thread_packet_t* packet, const u_char* payload, size_t length)
 {
     input_pcapthread_t*  self = (input_pcapthread_t*)user;
-    core_object_packet_t pkt  = CORE_OBJECT_PACKET_INIT;
+    core_object_packet_t pkt  = CORE_OBJECT_PACKET_INIT(0);
 
     self->pkts++;
 
@@ -104,7 +104,7 @@ static void _udp(u_char* user, const pcap_thread_packet_t* packet, const u_char*
 static void _tcp(u_char* user, const pcap_thread_packet_t* packet, const u_char* payload, size_t length)
 {
     input_pcapthread_t*  self = (input_pcapthread_t*)user;
-    core_object_packet_t pkt  = CORE_OBJECT_PACKET_INIT;
+    core_object_packet_t pkt  = CORE_OBJECT_PACKET_INIT(0);
 
     self->pkts++;
 

--- a/src/input/pcapthread.lua
+++ b/src/input/pcapthread.lua
@@ -17,13 +17,13 @@
 -- along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
 
 -- dnsjit.input.pcapthread
--- Read input from an interface or PCAP file
+-- Read input from an interface or PCAP file using pcap-thread
 --   local input = require("dnsjit.input.pcapthread").new()
 --   input:open_offline("file.pcap")
 --   input:receiver(filter_or_output)
 --   input:run()
 --
--- Input module for reading input from interfaces and PCAP files.
+-- Input module for reading packets from interfaces and PCAP files.
 module(...,package.seeall)
 
 require("dnsjit.input.pcapthread_h")
@@ -259,7 +259,7 @@ function Pcapthread:open_offline(file)
     return C.input_pcapthread_open_offline(self.obj, file)
 end
 
--- Start processing packet from opened devices and PCAP files.
+-- Start processing packets from opened devices and PCAP files.
 -- Returns 0 on success.
 function Pcapthread:run()
     return C.input_pcapthread_run(self.obj)

--- a/src/input/zero.c
+++ b/src/input/zero.c
@@ -64,7 +64,7 @@ int input_zero_destroy(input_zero_t* self)
 int input_zero_run(input_zero_t* self, uint64_t num)
 {
     struct timespec      ts, te;
-    core_object_packet_t pkt = CORE_OBJECT_PACKET_INIT;
+    core_object_packet_t pkt = CORE_OBJECT_PACKET_INIT(0);
 
     if (!self || !self->recv) {
         return 1;

--- a/src/lib.lua
+++ b/src/lib.lua
@@ -20,8 +20,6 @@
 -- Various Lua libraries or C library bindings
 module(...,package.seeall)
 
-error("This should not be included, only here for documentation generation")
-
 -- dnsjit.lib.getopt (3),
 -- dnsjit.lib.parseconf (3)
 return

--- a/src/output.lua
+++ b/src/output.lua
@@ -23,8 +23,7 @@
 -- replay them against other targets.
 module(...,package.seeall)
 
-error("This should not be included, only here for documentation generation")
-
 -- dnsjit.output.cpool (3),
--- dnsjit.output.null (3)
+-- dnsjit.output.null (3),
+-- dnsjit.output.udpcli (3)
 return

--- a/src/output/cpool.c
+++ b/src/output/cpool.c
@@ -244,13 +244,11 @@ void _client_read(void* vp, const client_t* client)
         return;
     }
     if (client->nrecv > 0) {
-        core_object_packet_t pkt = CORE_OBJECT_PACKET_INIT;
+        core_object_packet_t pkt = CORE_OBJECT_PACKET_INIT(client->query);
         ev_tstamp            ts  = client->recvts - client->sendts;
         if (ts < 0.) {
             ts = 0.;
         }
-
-        pkt.obj_prev = (core_object_t*)client->query;
 
         pkt.src_id = client->query->src_id;
         pkt.qr_id  = client->query->qr_id;

--- a/src/output/udpcli.c
+++ b/src/output/udpcli.c
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "output/udpcli.h"
+#include "core/object/udp.h"
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netdb.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <string.h>
+#include <netinet/in.h>
+
+static core_log_t      _log      = LOG_T_INIT("output.udpcli");
+static output_udpcli_t _defaults = {
+    LOG_T_INIT_OBJ("output.udpcli"),
+    0, 0, -1,
+    0, 0
+};
+
+core_log_t* output_udpcli_log()
+{
+    return &_log;
+}
+
+int output_udpcli_init(output_udpcli_t* self, const char* host, const char* port)
+{
+    struct addrinfo* addr;
+    int              err;
+
+    if (!self || !host || !port) {
+        return 1;
+    }
+
+    *self = _defaults;
+
+    ldebug("init %s %s", host, port);
+
+    if (!(self->addr = malloc(sizeof(struct sockaddr_storage)))) {
+        lcritical("malloc");
+        return 1;
+    }
+
+    if ((err = getaddrinfo(host, port, 0, &addr))) {
+        lcritical("getaddrinfo() %d", err);
+        return 1;
+    }
+    if (!addr) {
+        lcritical("getaddrinfo failed");
+        return 1;
+    }
+    ldebug("getaddrinfo() flags: 0x%x family: 0x%x socktype: 0x%x protocol: 0x%x addrlen: %d",
+        addr->ai_flags,
+        addr->ai_family,
+        addr->ai_socktype,
+        addr->ai_protocol,
+        addr->ai_addrlen);
+
+    memcpy(self->addr, addr->ai_addr, addr->ai_addrlen);
+    self->addr_len = addr->ai_addrlen;
+    freeaddrinfo(addr);
+
+    if ((self->fd = socket(((struct sockaddr*)self->addr)->sa_family, SOCK_DGRAM, IPPROTO_UDP)) < 0) {
+        lcritical("socket failed");
+        return 1;
+    }
+
+    if ((err = fcntl(self->fd, F_GETFL)) == -1
+        || fcntl(self->fd, F_SETFL, err | O_NONBLOCK)) {
+        lcritical("fcntl failed");
+    }
+
+    return 0;
+}
+
+int output_udpcli_destroy(output_udpcli_t* self)
+{
+    if (!self) {
+        return 1;
+    }
+
+    ldebug("destroy");
+
+    if (self->fd > -1) {
+        close(self->fd);
+    }
+
+    return 0;
+}
+
+static int _receive(void* ctx, const core_object_t* obj)
+{
+    output_udpcli_t*   self = (output_udpcli_t*)ctx;
+    core_object_udp_t* udp  = (core_object_udp_t*)obj;
+
+    if (!self || !obj || obj->obj_type != CORE_OBJECT_UDP) {
+        return 1;
+    }
+
+    if (udp->len < 3 || udp->payload[2] & 0x80) {
+        return 0;
+    }
+
+    self->pkts++;
+    if (sendto(self->fd, udp->payload, udp->len, 0, (struct sockaddr*)self->addr, self->addr_len) < 0) {
+        self->errs++;
+    }
+
+    return 0;
+}
+
+core_receiver_t output_udpcli_receiver()
+{
+    return _receive;
+}

--- a/src/output/udpcli.h
+++ b/src/output/udpcli.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "core/log.h"
+#include "core/receiver.h"
+
+#ifndef __dnsjit_output_udpcli_h
+#define __dnsjit_output_udpcli_h
+
+#include "output/udpcli.hh"
+
+#endif

--- a/src/output/udpcli.hh
+++ b/src/output/udpcli.hh
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//lua:require("dnsjit.core.log")
+//lua:require("dnsjit.core.receiver_h")
+
+typedef struct output_udpcli {
+    core_log_t _log;
+    size_t     pkts, errs;
+    int        fd;
+
+    void*  addr;
+    size_t addr_len;
+} output_udpcli_t;
+
+core_log_t* output_udpcli_log();
+
+int output_udpcli_init(output_udpcli_t* self, const char* host, const char* port);
+int output_udpcli_destroy(output_udpcli_t* self);
+
+core_receiver_t output_udpcli_receiver();

--- a/src/output/udpcli.lua
+++ b/src/output/udpcli.lua
@@ -1,0 +1,64 @@
+-- Copyright (c) 2018, OARC, Inc.
+-- All rights reserved.
+--
+-- This file is part of dnsjit.
+--
+-- dnsjit is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- dnsjit is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+
+-- dnsjit.output.udpcli
+-- Simple and dumb UDP DNS client
+--   local output = require("dnsjit.output.udpcli").new("127.0.0.1", "53")
+--
+-- Simple and rather dumb DNS client that takes any payload you give it,
+-- look for the bit in the payload that says it's a DNS query and sends
+-- the full payload over UDP if it is.
+module(...,package.seeall)
+
+require("dnsjit.output.udpcli_h")
+local ffi = require("ffi")
+local C = ffi.C
+
+local t_name = "output_udpcli_t"
+local output_udpcli_t = ffi.typeof(t_name)
+local Udpcli = {}
+
+-- Create a new Udpcli output to send queries to the
+-- .I host
+-- and
+-- .IR port .
+function Udpcli.new(host, port)
+    local self = {
+        obj = output_udpcli_t(),
+    }
+    C.output_udpcli_init(self.obj, host, port)
+    ffi.gc(self.obj, C.output_udpcli_destroy)
+    return setmetatable(self, { __index = Udpcli })
+end
+
+-- Return the C functions and context for receiving objects.
+function Udpcli:receive()
+    return C.output_udpcli_receiver(), self.obj
+end
+
+-- Return the number of queries we sent.
+function Udpcli:packets()
+    return tonumber(self.obj.pkts)
+end
+
+-- Return the number of errors when sending.
+function Udpcli:errors()
+    return tonumber(self.obj.errs)
+end
+
+return Udpcli


### PR DESCRIPTION
- Correct grammar in README
- Generate `src/Makefile.am` with `gen-makefile.sh`
- Remove `error()` in code-less Lua modules
- `core.object`:
  - Add objects: pcap, ether, null, loop, linuxsll, ieee802, gre, ip, ip6, icmp, icmp6, udp and tcp
  - Add `core_object_copy()` to copy (duh) objects
  - Change object initialization macros to take previous object
- `src/globals.c`: Add way to setup Lua globals in other modules
- `input`
- `filter.coro`: New filter to process objects in Lua by using Lua coroutines
- `filter.layer`: New filter to parse the ether/IP stack of packets
- `filter.lua`: Update documentation
- `filter.split`:
  - Rework how modes are called
  - Add new mode `any` to send to any (duh) receiver
- `filter.thread`: "New" filter to send object to other receivers in threads
- `input.fpcap`: New input to read PCAPs with `fopen()` and parse without libpcap
- `input.mmpcap`: New input to read PCAPs with `mmap()` and parse without libpcap
- `input.pcap`: New input to read PCAPs with libpcap
- `input.pcapthread`: Update documentation
- `output.udpcli`: New output to send DNS queries over UDP
- Update examples to reflect changes
- `examples/test_pcap_read.lua`: Test the read performance of each PCAP input