### PR TITLE
Sharable objects

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -49,8 +49,9 @@ fi
 
 # Checks for sizes
 AC_CHECK_SIZEOF([void*])
-AC_CHECK_SIZEOF([uint64_t])
 AC_CHECK_SIZEOF([pthread_t])
+AC_CHECK_SIZEOF([pthread_mutex_t])
+AC_CHECK_SIZEOF([pthread_cond_t])
 
 # Output Makefiles
 AC_CONFIG_FILES([

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -26,7 +26,7 @@ AM_CFLAGS = -I$(srcdir) \
   $(PTHREAD_CFLAGS) \
   $(luajit_CFLAGS)
 
-EXTRA_DIST = gen-manpage.lua dnsjit.1in
+EXTRA_DIST = gen-compat.lua gen-manpage.lua dnsjit.1in
 
 bin_PROGRAMS = dnsjit
 
@@ -38,7 +38,7 @@ dist_dnsjit_SOURCES = core.lua lib.lua input.lua filter.lua output.lua \
   omg-dns/omg_dns.h \
   pcap-thread/pcap_thread.h \
   sllq/sllq.h
-lua_hobjects =
+lua_hobjects = core/compat.luaho
 lua_objects = core.luao lib.luao input.luao filter.luao output.luao
 dnsjit_LDADD = $(PTHREAD_LIBS) $(luajit_LIBS)
 
@@ -92,6 +92,9 @@ CLEANFILES += *.3in $(man3_MANS)
   -e 's,[@]PACKAGE_URL[@],$(PACKAGE_URL),g' \
   -e 's,[@]PACKAGE_BUGREPORT[@],$(PACKAGE_BUGREPORT),g' \
   < "$<" > "$@"
+
+core/compat.hh: gen-compat.lua
+	$(LUAJIT) "$(srcdir)/gen-compat.lua" > "$@"
 
 
 dnsjit.core.3in: core.lua gen-manpage.lua

--- a/src/core/object.c
+++ b/src/core/object.c
@@ -27,10 +27,16 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* TODO: document */
 core_object_t* core_object_copy(const core_object_t* obj)
 {
     if (!obj) {
         return 0;
+    }
+
+    if (obj->obj_ref) {
+        obj->obj_ref((core_object_t*)obj, CORE_OBJECT_INCREF);
+        return (core_object_t*)obj;
     }
 
     switch (obj->obj_type) {

--- a/src/core/object.h
+++ b/src/core/object.h
@@ -44,4 +44,14 @@
 
 #include "core/object.hh"
 
+#define CORE_OBJECT_INIT(type, prev) type, (core_object_t*)prev, 0, 0
+
+/* TODO: document */
+#define core_object_free(obj)                  \
+    if (obj->obj_ref) {                        \
+        obj->obj_ref(obj, CORE_OBJECT_DECREF); \
+    } else {                                   \
+        free(obj);                             \
+    }
+
 #endif

--- a/src/core/object.hh
+++ b/src/core/object.hh
@@ -19,9 +19,19 @@
  */
 
 typedef struct core_object core_object_t;
+
+typedef enum core_object_reference {
+    CORE_OBJECT_INCREF,
+    CORE_OBJECT_DECREF
+} core_object_reference_t;
+
+typedef void (*core_object_refcall_t)(core_object_t* obj, core_object_reference_t ref);
+
 struct core_object {
-    unsigned short       obj_type;
-    const core_object_t* obj_prev;
+    unsigned short        obj_type;
+    const core_object_t*  obj_prev;
+    core_object_refcall_t obj_ref;
+    void*                 obj_refctx;
 };
 
 core_object_t* core_object_copy(const core_object_t* obj);

--- a/src/core/object/dns.h
+++ b/src/core/object/dns.h
@@ -32,7 +32,8 @@
 
 #define CORE_OBJECT_DNS_INIT(prev)                       \
     {                                                    \
-        CORE_OBJECT_DNS, (core_object_t*)prev,           \
+        CORE_OBJECT_INIT(CORE_OBJECT_DNS, prev)          \
+        ,                                                \
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
             0, 0, 0, 0                                   \

--- a/src/core/object/dns.hh
+++ b/src/core/object/dns.hh
@@ -22,8 +22,10 @@
 //lua:require("dnsjit.core.object_h")
 
 typedef struct core_object_dns {
-    unsigned short       obj_type;
-    const core_object_t* obj_prev;
+    unsigned short        obj_type;
+    const core_object_t*  obj_prev;
+    core_object_refcall_t obj_ref;
+    void*                 obj_refctx;
 
     unsigned short have_id : 1;
     unsigned short have_qr : 1;

--- a/src/core/object/ether.h
+++ b/src/core/object/ether.h
@@ -30,7 +30,8 @@
 
 #define CORE_OBJECT_ETHER_INIT(prev)                      \
     {                                                     \
-        CORE_OBJECT_ETHER, (core_object_t*)prev,          \
+        CORE_OBJECT_INIT(CORE_OBJECT_ETHER, prev)         \
+        ,                                                 \
             { 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0 }, 0 \
     }
 

--- a/src/core/object/ether.hh
+++ b/src/core/object/ether.hh
@@ -21,8 +21,10 @@
 //lua:require("dnsjit.core.object_h")
 
 typedef struct core_object_ether {
-    unsigned short       obj_type;
-    const core_object_t* obj_prev;
+    unsigned short        obj_type;
+    const core_object_t*  obj_prev;
+    core_object_refcall_t obj_ref;
+    void*                 obj_refctx;
 
     uint8_t  dhost[6];
     uint8_t  shost[6];

--- a/src/core/object/gre.h
+++ b/src/core/object/gre.h
@@ -28,10 +28,11 @@
 
 #include "core/object/gre.hh"
 
-#define CORE_OBJECT_GRE_INIT(prev)             \
-    {                                          \
-        CORE_OBJECT_GRE, (core_object_t*)prev, \
-            0, 0, 0, 0, 0                      \
+#define CORE_OBJECT_GRE_INIT(prev)              \
+    {                                           \
+        CORE_OBJECT_INIT(CORE_OBJECT_GRE, prev) \
+        ,                                       \
+            0, 0, 0, 0, 0                       \
     }
 
 #endif

--- a/src/core/object/gre.hh
+++ b/src/core/object/gre.hh
@@ -21,8 +21,10 @@
 //lua:require("dnsjit.core.object_h")
 
 typedef struct core_object_gre {
-    unsigned short       obj_type;
-    const core_object_t* obj_prev;
+    unsigned short        obj_type;
+    const core_object_t*  obj_prev;
+    core_object_refcall_t obj_ref;
+    void*                 obj_refctx;
 
     uint16_t gre_flags;
     uint16_t ether_type;

--- a/src/core/object/icmp.h
+++ b/src/core/object/icmp.h
@@ -28,10 +28,11 @@
 
 #include "core/object/icmp.hh"
 
-#define CORE_OBJECT_ICMP_INIT(prev)             \
-    {                                           \
-        CORE_OBJECT_ICMP, (core_object_t*)prev, \
-            0, 0, 0                             \
+#define CORE_OBJECT_ICMP_INIT(prev)              \
+    {                                            \
+        CORE_OBJECT_INIT(CORE_OBJECT_ICMP, prev) \
+        ,                                        \
+            0, 0, 0                              \
     }
 
 #endif

--- a/src/core/object/icmp.hh
+++ b/src/core/object/icmp.hh
@@ -21,8 +21,10 @@
 //lua:require("dnsjit.core.object_h")
 
 typedef struct core_object_icmp {
-    unsigned short       obj_type;
-    const core_object_t* obj_prev;
+    unsigned short        obj_type;
+    const core_object_t*  obj_prev;
+    core_object_refcall_t obj_ref;
+    void*                 obj_refctx;
 
     uint8_t  type;
     uint8_t  code;

--- a/src/core/object/icmp6.h
+++ b/src/core/object/icmp6.h
@@ -28,10 +28,11 @@
 
 #include "core/object/icmp6.hh"
 
-#define CORE_OBJECT_ICMP6_INIT(prev)             \
-    {                                            \
-        CORE_OBJECT_ICMP6, (core_object_t*)prev, \
-            0, 0, 0                              \
+#define CORE_OBJECT_ICMP6_INIT(prev)              \
+    {                                             \
+        CORE_OBJECT_INIT(CORE_OBJECT_ICMP6, prev) \
+        ,                                         \
+            0, 0, 0                               \
     }
 
 #endif

--- a/src/core/object/icmp6.hh
+++ b/src/core/object/icmp6.hh
@@ -21,8 +21,10 @@
 //lua:require("dnsjit.core.object_h")
 
 typedef struct core_object_icmp6 {
-    unsigned short       obj_type;
-    const core_object_t* obj_prev;
+    unsigned short        obj_type;
+    const core_object_t*  obj_prev;
+    core_object_refcall_t obj_ref;
+    void*                 obj_refctx;
 
     uint8_t  type;
     uint8_t  code;

--- a/src/core/object/ieee802.h
+++ b/src/core/object/ieee802.h
@@ -28,10 +28,11 @@
 
 #include "core/object/ieee802.hh"
 
-#define CORE_OBJECT_IEEE802_INIT(prev)             \
-    {                                              \
-        CORE_OBJECT_IEEE802, (core_object_t*)prev, \
-            0, 0, 0, 0, 0                          \
+#define CORE_OBJECT_IEEE802_INIT(prev)              \
+    {                                               \
+        CORE_OBJECT_INIT(CORE_OBJECT_IEEE802, prev) \
+        ,                                           \
+            0, 0, 0, 0, 0                           \
     }
 
 #endif

--- a/src/core/object/ieee802.hh
+++ b/src/core/object/ieee802.hh
@@ -21,8 +21,10 @@
 //lua:require("dnsjit.core.object_h")
 
 typedef struct core_object_ieee802 {
-    unsigned short       obj_type;
-    const core_object_t* obj_prev;
+    unsigned short        obj_type;
+    const core_object_t*  obj_prev;
+    core_object_refcall_t obj_ref;
+    void*                 obj_refctx;
 
     uint16_t       tpid;
     unsigned short pcp : 3;

--- a/src/core/object/ip.h
+++ b/src/core/object/ip.h
@@ -30,7 +30,8 @@
 
 #define CORE_OBJECT_IP_INIT(prev)                                      \
     {                                                                  \
-        CORE_OBJECT_IP, (core_object_t*)prev,                          \
+        CORE_OBJECT_INIT(CORE_OBJECT_IP, prev)                         \
+        ,                                                              \
             0, 0, 0, 0, 0, 0, 0, 0, 0, { 0, 0, 0, 0 }, { 0, 0, 0, 0 }, \
             0, 0                                                       \
     }

--- a/src/core/object/ip.hh
+++ b/src/core/object/ip.hh
@@ -21,8 +21,10 @@
 //lua:require("dnsjit.core.object_h")
 
 typedef struct core_object_ip {
-    unsigned short       obj_type;
-    const core_object_t* obj_prev;
+    unsigned short        obj_type;
+    const core_object_t*  obj_prev;
+    core_object_refcall_t obj_ref;
+    void*                 obj_refctx;
 
     unsigned int v : 4;
     unsigned int hl : 4;

--- a/src/core/object/ip6.h
+++ b/src/core/object/ip6.h
@@ -30,7 +30,8 @@
 
 #define CORE_OBJECT_IP6_INIT(prev)                              \
     {                                                           \
-        CORE_OBJECT_IP6, (core_object_t*)prev,                  \
+        CORE_OBJECT_INIT(CORE_OBJECT_IP6, prev)                 \
+        ,                                                       \
             0, 0, 0, 0,                                         \
             { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, \
             { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, \

--- a/src/core/object/ip6.hh
+++ b/src/core/object/ip6.hh
@@ -21,8 +21,10 @@
 //lua:require("dnsjit.core.object_h")
 
 typedef struct core_object_ip6 {
-    unsigned short       obj_type;
-    const core_object_t* obj_prev;
+    unsigned short        obj_type;
+    const core_object_t*  obj_prev;
+    core_object_refcall_t obj_ref;
+    void*                 obj_refctx;
 
     uint32_t flow;
     uint16_t plen;

--- a/src/core/object/linuxsll.h
+++ b/src/core/object/linuxsll.h
@@ -28,10 +28,11 @@
 
 #include "core/object/linuxsll.hh"
 
-#define CORE_OBJECT_LINUXSLL_INIT(prev)             \
-    {                                               \
-        CORE_OBJECT_LINUXSLL, (core_object_t*)prev, \
-            0, 0, 0, { 0, 0, 0, 0, 0, 0, 0, 0 }, 0  \
+#define CORE_OBJECT_LINUXSLL_INIT(prev)              \
+    {                                                \
+        CORE_OBJECT_INIT(CORE_OBJECT_LINUXSLL, prev) \
+        ,                                            \
+            0, 0, 0, { 0, 0, 0, 0, 0, 0, 0, 0 }, 0   \
     }
 
 #endif

--- a/src/core/object/linuxsll.hh
+++ b/src/core/object/linuxsll.hh
@@ -21,8 +21,10 @@
 //lua:require("dnsjit.core.object_h")
 
 typedef struct core_object_linuxsll {
-    unsigned short       obj_type;
-    const core_object_t* obj_prev;
+    unsigned short        obj_type;
+    const core_object_t*  obj_prev;
+    core_object_refcall_t obj_ref;
+    void*                 obj_refctx;
 
     uint16_t packet_type;
     uint16_t arp_hardware;

--- a/src/core/object/loop.h
+++ b/src/core/object/loop.h
@@ -28,10 +28,11 @@
 
 #include "core/object/loop.hh"
 
-#define CORE_OBJECT_LOOP_INIT(prev)             \
-    {                                           \
-        CORE_OBJECT_LOOP, (core_object_t*)prev, \
-            0                                   \
+#define CORE_OBJECT_LOOP_INIT(prev)              \
+    {                                            \
+        CORE_OBJECT_INIT(CORE_OBJECT_LOOP, prev) \
+        ,                                        \
+            0                                    \
     }
 
 #endif

--- a/src/core/object/loop.hh
+++ b/src/core/object/loop.hh
@@ -21,8 +21,10 @@
 //lua:require("dnsjit.core.object_h")
 
 typedef struct core_object_loop {
-    unsigned short       obj_type;
-    const core_object_t* obj_prev;
+    unsigned short        obj_type;
+    const core_object_t*  obj_prev;
+    core_object_refcall_t obj_ref;
+    void*                 obj_refctx;
 
     uint32_t family;
 } core_object_loop_t;

--- a/src/core/object/null.h
+++ b/src/core/object/null.h
@@ -28,10 +28,11 @@
 
 #include "core/object/null.hh"
 
-#define CORE_OBJECT_NULL_INIT(prev)             \
-    {                                           \
-        CORE_OBJECT_NULL, (core_object_t*)prev, \
-            0                                   \
+#define CORE_OBJECT_NULL_INIT(prev)              \
+    {                                            \
+        CORE_OBJECT_INIT(CORE_OBJECT_NULL, prev) \
+        ,                                        \
+            0                                    \
     }
 
 #endif

--- a/src/core/object/null.hh
+++ b/src/core/object/null.hh
@@ -21,8 +21,10 @@
 //lua:require("dnsjit.core.object_h")
 
 typedef struct core_object_null {
-    unsigned short       obj_type;
-    const core_object_t* obj_prev;
+    unsigned short        obj_type;
+    const core_object_t*  obj_prev;
+    core_object_refcall_t obj_ref;
+    void*                 obj_refctx;
 
     uint32_t family;
 } core_object_null_t;

--- a/src/core/object/packet.h
+++ b/src/core/object/packet.h
@@ -28,14 +28,15 @@
 
 #include "core/object/packet.hh"
 
-#define CORE_OBJECT_PACKET_INIT(prev)             \
-    {                                             \
-        CORE_OBJECT_PACKET, (core_object_t*)prev, \
-            0, 0, 0,                              \
-            0, 0, 0,                              \
-            0, 0,                                 \
-            0, 0, CORE_TIMESPEC_INIT,             \
-            0, 0                                  \
+#define CORE_OBJECT_PACKET_INIT(prev)              \
+    {                                              \
+        CORE_OBJECT_INIT(CORE_OBJECT_PACKET, prev) \
+        ,                                          \
+            0, 0, 0,                               \
+            0, 0, 0,                               \
+            0, 0,                                  \
+            0, 0, CORE_TIMESPEC_INIT,              \
+            0, 0                                   \
     }
 
 #endif

--- a/src/core/object/packet.hh
+++ b/src/core/object/packet.hh
@@ -22,8 +22,10 @@
 //lua:require("dnsjit.core.timespec_h")
 
 typedef struct core_object_packet {
-    unsigned short       obj_type;
-    const core_object_t* obj_prev;
+    unsigned short        obj_type;
+    const core_object_t*  obj_prev;
+    core_object_refcall_t obj_ref;
+    void*                 obj_refctx;
 
     uint64_t src_id, qr_id, dst_id;
 

--- a/src/core/object/pcap.h
+++ b/src/core/object/pcap.h
@@ -26,12 +26,13 @@
 
 #include "core/object/pcap.hh"
 
-#define CORE_OBJECT_PCAP_INIT(prev)             \
-    {                                           \
-        CORE_OBJECT_PCAP, (core_object_t*)prev, \
-            0, 0,                               \
-            { 0, 0 }, 0, 0, 0,                  \
-            0                                   \
+#define CORE_OBJECT_PCAP_INIT(prev)              \
+    {                                            \
+        CORE_OBJECT_INIT(CORE_OBJECT_PCAP, prev) \
+        ,                                        \
+            0, 0,                                \
+            { 0, 0 }, 0, 0, 0,                   \
+            0, 0                                 \
     }
 
 #endif

--- a/src/core/object/pcap.hh
+++ b/src/core/object/pcap.hh
@@ -22,8 +22,10 @@
 //lua:require("dnsjit.core.timespec_h")
 
 typedef struct core_object_pcap {
-    unsigned short       obj_type;
-    const core_object_t* obj_prev;
+    unsigned short        obj_type;
+    const core_object_t*  obj_prev;
+    core_object_refcall_t obj_ref;
+    void*                 obj_refctx;
 
     uint32_t snaplen, linktype;
 
@@ -32,4 +34,5 @@ typedef struct core_object_pcap {
     const unsigned char* bytes;
 
     unsigned short is_swapped : 1;
+    unsigned short is_multiple : 1;
 } core_object_pcap_t;

--- a/src/core/object/tcp.h
+++ b/src/core/object/tcp.h
@@ -30,7 +30,8 @@
 
 #define CORE_OBJECT_TCP_INIT(prev)                              \
     {                                                           \
-        CORE_OBJECT_TCP, (core_object_t*)prev,                  \
+        CORE_OBJECT_INIT(CORE_OBJECT_TCP, prev)                 \
+        ,                                                       \
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                       \
             { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
               0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \

--- a/src/core/object/tcp.hh
+++ b/src/core/object/tcp.hh
@@ -21,8 +21,10 @@
 //lua:require("dnsjit.core.object_h")
 
 typedef struct core_object_tcp {
-    unsigned short       obj_type;
-    const core_object_t* obj_prev;
+    unsigned short        obj_type;
+    const core_object_t*  obj_prev;
+    core_object_refcall_t obj_ref;
+    void*                 obj_refctx;
 
     uint16_t sport;
     uint16_t dport;

--- a/src/core/object/udp.h
+++ b/src/core/object/udp.h
@@ -28,11 +28,12 @@
 
 #include "core/object/udp.hh"
 
-#define CORE_OBJECT_UDP_INIT(prev)             \
-    {                                          \
-        CORE_OBJECT_UDP, (core_object_t*)prev, \
-            0, 0, 0, 0,                        \
-            0, 0                               \
+#define CORE_OBJECT_UDP_INIT(prev)              \
+    {                                           \
+        CORE_OBJECT_INIT(CORE_OBJECT_UDP, prev) \
+        ,                                       \
+            0, 0, 0, 0,                         \
+            0, 0                                \
     }
 
 #endif

--- a/src/core/object/udp.hh
+++ b/src/core/object/udp.hh
@@ -21,8 +21,10 @@
 //lua:require("dnsjit.core.object_h")
 
 typedef struct core_object_udp {
-    unsigned short       obj_type;
-    const core_object_t* obj_prev;
+    unsigned short        obj_type;
+    const core_object_t*  obj_prev;
+    core_object_refcall_t obj_ref;
+    void*                 obj_refctx;
 
     uint16_t sport;
     uint16_t dport;

--- a/src/filter/thread.h
+++ b/src/filter/thread.h
@@ -27,13 +27,6 @@
 #include <stdint.h>
 #include <pthread.h>
 
-typedef struct filter_thread_work {
-    core_object_t*  obj;
-    pthread_mutex_t mutex;
-    pthread_cond_t  read, write;
-    char            end;
-} filter_thread_work_t;
-
 #include "filter/thread.hh"
 
 #endif

--- a/src/filter/thread.hh
+++ b/src/filter/thread.hh
@@ -18,19 +18,23 @@
  * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#if 0
-typedef struct {} filter_thread_work_t;
-#endif
-
+//lua:require("dnsjit.core.compat_h")
 //lua:require("dnsjit.core.log")
 //lua:require("dnsjit.core.receiver_h")
+
+typedef struct filter_thread_work {
+    core_object_t*  obj;
+    pthread_mutex_t mutex;
+    pthread_cond_t  read, write;
+    char            end;
+} filter_thread_work_t;
 
 typedef struct filter_thread {
     core_log_t      _log;
     core_receiver_t recv;
     void*           ctx;
 
-    uint64_t              tid;
+    pthread_t             tid;
     filter_thread_work_t* work;
     size_t                works, at;
 } filter_thread_t;

--- a/src/filter/thread.lua
+++ b/src/filter/thread.lua
@@ -48,7 +48,7 @@ function Thread.new(queue_size)
         queue_size = 1000
     end
     local self = {
-        receivers = {},
+        _receiver = nil,
         obj = filter_thread_t(),
     }
     C.filter_thread_init(self.obj, queue_size)

--- a/src/gen-compat.lua
+++ b/src/gen-compat.lua
@@ -1,0 +1,8 @@
+for line in io.lines("config.h") do
+    local n,s = line:match("define SIZEOF_(PTHREAD%S*)_T (%d+)")
+    if n and s then
+        s = math.ceil(s / 8)
+        n = n:lower()
+        print("typedef struct "..n.." { uint64_t a["..s.."]; } "..n.."_t;")
+    end
+end

--- a/src/gen-makefile.sh
+++ b/src/gen-makefile.sh
@@ -40,7 +40,7 @@ dist_dnsjit_SOURCES = core.lua lib.lua input.lua filter.lua output.lua \
   omg-dns/omg_dns.h \
   pcap-thread/pcap_thread.h \
   sllq/sllq.h
-lua_hobjects =
+lua_hobjects = core/compat.luaho
 lua_objects = core.luao lib.luao input.luao filter.luao output.luao
 dnsjit_LDADD = $(PTHREAD_LIBS) $(luajit_LIBS)
 
@@ -99,6 +99,9 @@ echo 'CLEANFILES += *.3in $(man3_MANS)
   -e '"'"'s,[@]PACKAGE_URL[@],$(PACKAGE_URL),g'"'"' \
   -e '"'"'s,[@]PACKAGE_BUGREPORT[@],$(PACKAGE_BUGREPORT),g'"'"' \
   < "$<" > "$@"
+
+core/compat.hh: gen-compat.lua
+	$(LUAJIT) "$(srcdir)/gen-compat.lua" > "$@"
 ';
 
 for file in core.lua lib.lua input.lua filter.lua output.lua; do

--- a/src/input/fpcap.h
+++ b/src/input/fpcap.h
@@ -21,6 +21,7 @@
 #include "core/log.h"
 #include "core/receiver.h"
 #include "core/timespec.h"
+#include "core/object/pcap.h"
 
 #ifndef __dnsjit_input_fpcap_h
 #define __dnsjit_input_fpcap_h

--- a/src/input/fpcap.hh
+++ b/src/input/fpcap.hh
@@ -21,6 +21,7 @@
 //lua:require("dnsjit.core.log")
 //lua:require("dnsjit.core.receiver_h")
 //lua:require("dnsjit.core.timespec_h")
+//lua:require("dnsjit.core.object.pcap_h")
 
 typedef struct input_fpcap {
     core_log_t      _log;
@@ -29,11 +30,17 @@ typedef struct input_fpcap {
 
     unsigned short is_swapped : 1;
     unsigned short is_nanosec : 1;
+    unsigned short use_shared : 1;
+
+    core_object_pcap_t* shared_pkts;
+    size_t              num_shared_pkts;
+    size_t              num_multiple_pkts;
 
     void*           file;
     core_timespec_t ts, te;
     size_t          pkts;
     uint8_t*        buf;
+    size_t          buf_size;
 
     uint32_t magic_number;
     uint16_t version_major;

--- a/src/input/fpcap.lua
+++ b/src/input/fpcap.lua
@@ -98,6 +98,23 @@ function Fpcap:open(file)
     return C.input_fpcap_open(self.obj, file)
 end
 
+-- Enable (true) or disable (false) usage of shared objects, if
+-- .I bool
+-- is not specified then return the current state.
+function Fpcap:use_shared(bool)
+    if bool == nil then
+        if self.obj.use_shared == 1 then
+            return true
+        else
+            return false
+        end
+    elseif bool == true then
+        self.obj.use_shared = 1
+    else
+        self.obj.use_shared = 0
+    end
+end
+
 -- Start processing packets.
 -- Returns 0 on success.
 function Fpcap:run()

--- a/src/input/mmpcap.h
+++ b/src/input/mmpcap.h
@@ -21,6 +21,7 @@
 #include "core/log.h"
 #include "core/receiver.h"
 #include "core/timespec.h"
+#include "core/object/pcap.h"
 
 #ifndef __dnsjit_input_mmpcap_h
 #define __dnsjit_input_mmpcap_h

--- a/src/input/mmpcap.hh
+++ b/src/input/mmpcap.hh
@@ -21,6 +21,7 @@
 //lua:require("dnsjit.core.log")
 //lua:require("dnsjit.core.receiver_h")
 //lua:require("dnsjit.core.timespec_h")
+//lua:require("dnsjit.core.object.pcap_h")
 
 typedef struct input_mmpcap {
     core_log_t      _log;
@@ -29,6 +30,11 @@ typedef struct input_mmpcap {
 
     unsigned short is_swapped : 1;
     unsigned short is_nanosec : 1;
+    unsigned short use_shared : 1;
+
+    core_object_pcap_t* shared_pkts;
+    size_t              num_shared_pkts;
+    size_t              num_multiple_pkts;
 
     int             fd;
     size_t          len, at;

--- a/src/input/mmpcap.lua
+++ b/src/input/mmpcap.lua
@@ -98,6 +98,23 @@ function Mmpcap:open(file)
     return C.input_mmpcap_open(self.obj, file)
 end
 
+-- Enable (true) or disable (false) usage of shared objects, if
+-- .I bool
+-- is not specified then return the current state.
+function Mmpcap:use_shared(bool)
+    if bool == nil then
+        if self.obj.use_shared == 1 then
+            return true
+        else
+            return false
+        end
+    elseif bool == true then
+        self.obj.use_shared = 1
+    else
+        self.obj.use_shared = 0
+    end
+end
+
 -- Start processing packets.
 -- Returns 0 on success.
 function Mmpcap:run()

--- a/src/input/pcap.c
+++ b/src/input/pcap.c
@@ -29,9 +29,9 @@ static core_log_t   _log      = LOG_T_INIT("input.pcap");
 static input_pcap_t _defaults = {
     LOG_T_INIT_OBJ("input.pcap"),
     0, 0,
+    0,
     0, { 0, 0 }, { 0, 0 }, 0,
-    0, 0,
-    0
+    0, 0
 };
 
 core_log_t* input_pcap_log()
@@ -81,9 +81,9 @@ int input_pcap_open_offline(input_pcap_t* self, const char* file)
         return 1;
     }
 
-    self->snaplen  = pcap_snapshot(self->pcap);
-    self->linktype = pcap_datalink(self->pcap);
-    self->swapped  = pcap_is_swapped(self->pcap);
+    self->snaplen    = pcap_snapshot(self->pcap);
+    self->linktype   = pcap_datalink(self->pcap);
+    self->is_swapped = pcap_is_swapped(self->pcap);
 
     return 0;
 }
@@ -106,7 +106,7 @@ static void _handler(u_char* user, const struct pcap_pkthdr* h, const u_char* by
     pkt.caplen     = h->caplen;
     pkt.len        = h->len;
     pkt.bytes      = bytes;
-    pkt.is_swapped = self->swapped;
+    pkt.is_swapped = self->is_swapped;
 
     self->recv(self->ctx, (core_object_t*)&pkt);
 }

--- a/src/input/pcap.hh
+++ b/src/input/pcap.hh
@@ -31,14 +31,14 @@ typedef struct input_pcap {
     core_receiver_t recv;
     void*           ctx;
 
+    unsigned short is_swapped : 1;
+
     pcap_t*         pcap;
     core_timespec_t ts, te;
     size_t          pkts;
 
     size_t   snaplen;
     uint32_t linktype;
-
-    unsigned short swapped : 1;
 } input_pcap_t;
 
 core_log_t* input_pcap_log();

--- a/src/input/zero.c
+++ b/src/input/zero.c
@@ -29,7 +29,8 @@ static core_log_t   _log      = LOG_T_INIT("input.zero");
 static input_zero_t _defaults = {
     LOG_T_INIT_OBJ("input.zero"),
     0, 0,
-    { 0, 0 }, { 0, 0 }
+    { 0, 0 }, { 0, 0 },
+    0
 };
 
 core_log_t* input_zero_log()
@@ -61,10 +62,17 @@ int input_zero_destroy(input_zero_t* self)
     return 0;
 }
 
+static core_object_packet_t shared_pkt = CORE_OBJECT_PACKET_INIT(0);
+
+static void _ref(core_object_t* obj, core_object_reference_t ref)
+{
+}
+
 int input_zero_run(input_zero_t* self, uint64_t num)
 {
     struct timespec      ts, te;
     core_object_packet_t pkt = CORE_OBJECT_PACKET_INIT(0);
+    core_object_t*       obj = (core_object_t*)&pkt;
 
     if (!self || !self->recv) {
         return 1;
@@ -72,9 +80,14 @@ int input_zero_run(input_zero_t* self, uint64_t num)
 
     ldebug("run");
 
+    if (self->use_shared) {
+        shared_pkt.obj_ref = _ref;
+        obj                = (core_object_t*)&shared_pkt;
+    }
+
     clock_gettime(CLOCK_MONOTONIC, &ts);
     while (num--) {
-        self->recv(self->ctx, (core_object_t*)&pkt);
+        self->recv(self->ctx, obj);
     }
     clock_gettime(CLOCK_MONOTONIC, &te);
 

--- a/src/input/zero.hh
+++ b/src/input/zero.hh
@@ -26,7 +26,10 @@ typedef struct input_zero {
     core_log_t      _log;
     core_receiver_t recv;
     void*           ctx;
+
     core_timespec_t ts, te;
+
+    unsigned short use_shared : 1;
 } input_zero_t;
 
 core_log_t* input_zero_log();

--- a/src/input/zero.lua
+++ b/src/input/zero.lua
@@ -59,6 +59,23 @@ function Zero:receiver(o)
     self._receiver = o
 end
 
+-- Enable (true) or disable (false) usage of shared objects, if
+-- .I bool
+-- is not specified then return the current state.
+function Zero:use_shared(bool)
+    if bool == nil then
+        if self.obj.use_shared == 1 then
+            return true
+        else
+            return false
+        end
+    elseif bool == true then
+        self.obj.use_shared = 1
+    else
+        self.obj.use_shared = 0
+    end
+end
+
 -- Generate
 -- .I num
 -- empty queries and send them to the receiver, return 0 if successful.

--- a/src/output/null.c
+++ b/src/output/null.c
@@ -21,12 +21,25 @@
 #include "config.h"
 
 #include "output/null.h"
+#include "core/object/pcap.h"
+
+#include "core/log.h"
 
 static int _receive(void* ctx, const core_object_t* obj)
 {
     output_null_t* self = (output_null_t*)ctx;
 
     if (self) {
+        if (obj && obj->obj_type == CORE_OBJECT_PCAP) {
+            const core_object_pcap_t* pkt = (core_object_pcap_t*)obj;
+            if (pkt->is_multiple) {
+                while (pkt) {
+                    self->pkts++;
+                    pkt = (core_object_pcap_t*)pkt->obj_prev;
+                }
+                return 0;
+            }
+        }
         self->pkts++;
     }
 


### PR DESCRIPTION
- Add `core.compat` for LuaJIT to understand how big some structures are
- Add macro `core_object_free()`
- Add reference call and context to objects so they can be shared
- Rework initialization macro for objects
- `core.object.pcap`: Add `is_multiple` to indicate if `obj_prev` will contain additional PCAP objects
- `filter.layer`: Handle multiple PCAP objects
- `filter.thread`: Use compat `pthread_t` and move worker structure to global namespace
- `input.fpcap`, `input.mmpcap`:
  - Use shared objects and send multiple PCAP objects at a time
  - Add `:use_shared(bool)` to control it
- `input.pcap`: Rename `swapped` to `is_swapped`
- `input.zero`: Add `use_shared()` to generate a empty shared object
- `output.null`: Handle multiple PCAP objects