### PR TITLE
Producer, clock and threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ capturing, parsing and statistics gathering of DNS messages while also
 providing facilities for replaying DNS traffic.
 
 One of the core functionality that **dnsjit** brings is to tie together C
-and Lua modules through a receiver/receive interface.
+and Lua modules through a receiver/producer interface.
 This allows creation of custom chains of functionality to meet various
 requirements.
 Another core functionality is the ability to parse and process DNS messages

--- a/examples/readme.lua
+++ b/examples/readme.lua
@@ -1,0 +1,16 @@
+#!/usr/bin/env dnsjit
+local input = require("dnsjit.input.pcapthread").new()
+local output = require("dnsjit.filter.lua").new()
+
+output:func(function(filter, object)
+    local packet = object:cast()
+    local dns = require("dnsjit.core.object.dns").new(packet)
+    if dns:parse() == 0 then
+        print(dns.id)
+    end
+end)
+
+input:open_offline(arg[2])
+input:only_queries(true)
+input:receiver(output)
+input:run()

--- a/examples/replay.lua
+++ b/examples/replay.lua
@@ -1,4 +1,5 @@
 #!/usr/bin/env dnsjit
+local clock = require("dnsjit.lib.clock")
 local log = require("dnsjit.core.log")
 local getopt = require("dnsjit.lib.getopt").new({
     { "v", "verbose", 0, "Enable and increase verbosity for each time given", "?+" },
@@ -109,14 +110,12 @@ end
 input:receiver(output)
 
 output:start()
+local start_sec, start_nsec = clock:monotonic()
 input:run()
 output:stop()
+local end_sec, end_nsec = clock:monotonic()
 
-local start_sec, start_nsec, end_sec, end_nsec, runtime
-
-start_sec, start_nsec = input:start_time()
-end_sec, end_nsec = input:end_time()
-runtime = 0
+local runtime = 0
 if end_sec > start_sec then
     runtime = ((end_sec - start_sec) - 1) + ((1000000000 - start_nsec + end_nsec)/1000000000)
 elseif end_sec == start_sec and end_nsec > start_nsec then

--- a/examples/test_throughput.lua
+++ b/examples/test_throughput.lua
@@ -1,27 +1,40 @@
 #!/usr/bin/env dnsjit
-local num = tonumber(arg[2])
-local runs = tonumber(arg[3])
+local clock = require("dnsjit.lib.clock")
+local getopt = require("dnsjit.lib.getopt").new({
+    { "t", "thread", false, "Test also with dnsjit.filter.thread", "?" },
+    { "c", "coro", false, "Test also with dnsjit.filter.coro", "?" },
+    { "s", "split", false, "Test also with dnsjit.filter.split", "?" }
+})
+local num, runs = unpack(getopt:parse())
+if getopt:val("help") then
+    getopt:usage()
+    return
+end
 
 if num == nil then
     print("usage: "..arg[1].." <num> [runs]")
     return
+else
+    num = tonumber(num)
 end
 
-if runs == nil or not type(runs) == "number" or runs < 1 then
+if runs == nil then
     runs = 1
+else
+    runs = tonumber(runs)
 end
 
-local input = require("dnsjit.input.zero").new()
-local output = require("dnsjit.output.null").new()
-
-input:receiver(output)
-
+print("zero:receiver() -> null:receive()")
 local run
 for run = 1, runs do
-    input:run(num)
+    local i = require("dnsjit.input.zero").new()
+    local o = require("dnsjit.output.null").new()
 
-    local start_sec, start_nsec = input:start_time()
-    local end_sec, end_nsec = input:end_time()
+    i:receiver(o)
+    local start_sec, start_nsec = clock:monotonic()
+    i:run(num)
+    local end_sec, end_nsec = clock:monotonic()
+
     local runtime = 0
     if end_sec > start_sec then
         runtime = ((end_sec - start_sec) - 1) + ((1000000000 - start_nsec + end_nsec)/1000000000)
@@ -29,8 +42,230 @@ for run = 1, runs do
         runtime = (end_nsec - start_nsec) / 1000000000
     end
 
-    print("run", run)
-    print("runtime", runtime)
-    print("num", num)
-    print("throughput", num/runtime, "/sec")
+    print(run, "runtime", runtime, num/runtime, "/sec", o:packets())
+end
+
+if getopt:val("t") then
+    print("zero:receiver() -> thread:receiver() -> null:receive()")
+    local run
+    for run = 1, runs do
+        local i = require("dnsjit.input.zero").new()
+        local t = require("dnsjit.filter.thread").new()
+        local o = require("dnsjit.output.null").new()
+
+        t:receiver(o)
+        i:receiver(t)
+        t:start()
+        i:use_shared(true)
+        local start_sec, start_nsec = clock:monotonic()
+        i:run(num)
+        t:stop()
+        local end_sec, end_nsec = clock:monotonic()
+
+        local runtime = 0
+        if end_sec > start_sec then
+            runtime = ((end_sec - start_sec) - 1) + ((1000000000 - start_nsec + end_nsec)/1000000000)
+        elseif end_sec == start_sec and end_nsec > start_nsec then
+            runtime = (end_nsec - start_nsec) / 1000000000
+        end
+
+        print(run, "runtime", runtime, num/runtime, "/sec", o:packets())
+    end
+
+    print("zero:receiver() -> thread:receiver() -> null:receive() x2")
+    local run
+    for run = 1, runs do
+        local i = require("dnsjit.input.zero").new()
+        local t = require("dnsjit.filter.thread").new()
+        local o1 = require("dnsjit.output.null").new()
+        local o2 = require("dnsjit.output.null").new()
+
+        t:receiver(o1)
+        t:receiver(o2)
+        i:receiver(t)
+        t:start()
+        i:use_shared(true)
+        local start_sec, start_nsec = clock:monotonic()
+        i:run(num)
+        t:stop()
+        local end_sec, end_nsec = clock:monotonic()
+
+        local runtime = 0
+        if end_sec > start_sec then
+            runtime = ((end_sec - start_sec) - 1) + ((1000000000 - start_nsec + end_nsec)/1000000000)
+        elseif end_sec == start_sec and end_nsec > start_nsec then
+            runtime = (end_nsec - start_nsec) / 1000000000
+        end
+
+        print(run, "runtime", runtime, num/runtime, "/sec", o1:packets() + o2:packets(), o1:packets(), o2:packets())
+    end
+
+    print("zero:receiver() -> thread:receiver() -> null:receive() x4")
+    local run
+    for run = 1, runs do
+        local i = require("dnsjit.input.zero").new()
+        local t = require("dnsjit.filter.thread").new()
+        local o1 = require("dnsjit.output.null").new()
+        local o2 = require("dnsjit.output.null").new()
+        local o3 = require("dnsjit.output.null").new()
+        local o4 = require("dnsjit.output.null").new()
+
+        t:receiver(o1)
+        t:receiver(o2)
+        t:receiver(o3)
+        t:receiver(o4)
+        i:receiver(t)
+        t:start()
+        i:use_shared(true)
+        local start_sec, start_nsec = clock:monotonic()
+        i:run(num)
+        t:stop()
+        local end_sec, end_nsec = clock:monotonic()
+
+        local runtime = 0
+        if end_sec > start_sec then
+            runtime = ((end_sec - start_sec) - 1) + ((1000000000 - start_nsec + end_nsec)/1000000000)
+        elseif end_sec == start_sec and end_nsec > start_nsec then
+            runtime = (end_nsec - start_nsec) / 1000000000
+        end
+
+        print(run, "runtime", runtime, num/runtime, "/sec", o1:packets() + o2:packets() + o3:packets() + o4:packets(), o1:packets(), o2:packets(), o3:packets(), o4:packets())
+    end
+end
+
+if getopt:val("s") then
+    print("zero:receiver() -> split:receiver() -> null:receive() x2")
+    local run
+    for run = 1, runs do
+        local i = require("dnsjit.input.zero").new()
+        local s = require("dnsjit.filter.split").new()
+        local o1 = require("dnsjit.output.null").new()
+        local o2 = require("dnsjit.output.null").new()
+
+        s:receiver(o1)
+        s:receiver(o2)
+        i:receiver(s)
+        local start_sec, start_nsec = clock:monotonic()
+        i:run(num)
+        local end_sec, end_nsec = clock:monotonic()
+
+        local runtime = 0
+        if end_sec > start_sec then
+            runtime = ((end_sec - start_sec) - 1) + ((1000000000 - start_nsec + end_nsec)/1000000000)
+        elseif end_sec == start_sec and end_nsec > start_nsec then
+            runtime = (end_nsec - start_nsec) / 1000000000
+        end
+
+        print(run, "runtime", runtime, num/runtime, "/sec", o1:packets() + o2:packets(), o1:packets(), o2:packets())
+    end
+end
+
+if getopt:val("s") and getopt:val("t") then
+    print("zero:receiver() -> split:receiver() -> thread:receiver() x2 -> null:receive() x2")
+    local run
+    for run = 1, runs do
+        local i = require("dnsjit.input.zero").new()
+        local s = require("dnsjit.filter.split").new()
+        local t1 = require("dnsjit.filter.thread").new()
+        local o1 = require("dnsjit.output.null").new()
+        local t2 = require("dnsjit.filter.thread").new()
+        local o2 = require("dnsjit.output.null").new()
+
+        t1:receiver(o1)
+        t1:start()
+        t2:receiver(o2)
+        t2:start()
+
+        s:receiver(t1)
+        s:receiver(t2)
+        i:receiver(s)
+        i:use_shared(true)
+        local start_sec, start_nsec = clock:monotonic()
+        i:run(num)
+        t1:stop()
+        t2:stop()
+        local end_sec, end_nsec = clock:monotonic()
+
+        local runtime = 0
+        if end_sec > start_sec then
+            runtime = ((end_sec - start_sec) - 1) + ((1000000000 - start_nsec + end_nsec)/1000000000)
+        elseif end_sec == start_sec and end_nsec > start_nsec then
+            runtime = (end_nsec - start_nsec) / 1000000000
+        end
+
+        print(run, "runtime", runtime, num/runtime, "/sec", o1:packets() + o2:packets(), o1:packets(), o2:packets())
+    end
+end
+
+if getopt:val("c") then
+    print("zero:receiver() -> coro:receiver() -> null:receive()")
+    local run
+    for run = 1, runs do
+        local i = require("dnsjit.input.zero").new()
+        local c = require("dnsjit.filter.coro").new()
+        local o = require("dnsjit.output.null").new()
+
+        c:receiver(o)
+        c:func(function(c,obj)
+            c:send(obj)
+        end)
+        i:receiver(c)
+        local start_sec, start_nsec = clock:monotonic()
+        i:run(num)
+        local end_sec, end_nsec = clock:monotonic()
+
+        local runtime = 0
+        if end_sec > start_sec then
+            runtime = ((end_sec - start_sec) - 1) + ((1000000000 - start_nsec + end_nsec)/1000000000)
+        elseif end_sec == start_sec and end_nsec > start_nsec then
+            runtime = (end_nsec - start_nsec) / 1000000000
+        end
+
+        print(run, "runtime", runtime, num/runtime, "/sec", o:packets())
+    end
+end
+
+print("zero:produce() <- null:producer()")
+local run
+for run = 1, runs do
+    local i = require("dnsjit.input.zero").new()
+    local o = require("dnsjit.output.null").new()
+
+    local start_sec, start_nsec = clock:monotonic()
+    o:producer(i)
+    o:run(num)
+    local end_sec, end_nsec = clock:monotonic()
+
+    local runtime = 0
+    if end_sec > start_sec then
+        runtime = ((end_sec - start_sec) - 1) + ((1000000000 - start_nsec + end_nsec)/1000000000)
+    elseif end_sec == start_sec and end_nsec > start_nsec then
+        runtime = (end_nsec - start_nsec) / 1000000000
+    end
+
+    print(run, "runtime", runtime, num/runtime, "/sec", o:packets())
+end
+
+print("zero:produce() <- lua -> null:receive()")
+local run
+for run = 1, runs do
+    local i = require("dnsjit.input.zero").new()
+    local o = require("dnsjit.output.null").new()
+    local prod, pctx = i:produce()
+    local recv, rctx = o:receive()
+
+    local start_sec, start_nsec = clock:monotonic()
+    for n = 1, num do
+       recv(rctx, prod(pctx))
+    end
+    local end_sec, end_nsec = clock:monotonic()
+
+    local runtime = 0
+    if end_sec > start_sec then
+        runtime = ((end_sec - start_sec) - 1) + ((1000000000 - start_nsec + end_nsec)/1000000000)
+    elseif end_sec == start_sec and end_nsec > start_nsec then
+        runtime = (end_nsec - start_nsec) / 1000000000
+    end
+
+    print(run, "runtime", runtime, num/runtime, "/sec", num)
 end

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -26,7 +26,7 @@ AM_CFLAGS = -I$(srcdir) \
   $(PTHREAD_CFLAGS) \
   $(luajit_CFLAGS)
 
-EXTRA_DIST = gen-compat.lua gen-manpage.lua dnsjit.1in
+EXTRA_DIST = gen-manpage.lua gen-compat.lua dnsjit.1in
 
 bin_PROGRAMS = dnsjit
 
@@ -43,16 +43,16 @@ lua_objects = core.luao lib.luao input.luao filter.luao output.luao
 dnsjit_LDADD = $(PTHREAD_LIBS) $(luajit_LIBS)
 
 # C source and headers
-dnsjit_SOURCES += core/log.c core/receiver.c core/object.c core/object/ip.c core/object/tcp.c core/object/pcap.c core/object/dns.c core/object/icmp6.c core/object/ieee802.c core/object/udp.c core/object/loop.c core/object/packet.c core/object/ip6.c core/object/gre.c core/object/linuxsll.c core/object/icmp.c core/object/null.c core/object/ether.c core/tracking.c core/mutex.c input/zero.c input/pcap.c input/fpcap.c input/mmpcap.c input/pcapthread.c filter/lua.c filter/split.c filter/thread.c filter/timing.c filter/coro.c filter/layer.c output/udpcli.c output/cpool.c output/cpool/client_pool.c output/cpool/client.c output/null.c
-dist_dnsjit_SOURCES += core/mutex.h core/receiver.h core/object.h core/log.h core/timespec.h core/tracking.h core/object/icmp.h core/object/ip.h core/object/loop.h core/object/dns.h core/object/ip6.h core/object/null.h core/object/tcp.h core/object/udp.h core/object/packet.h core/object/icmp6.h core/object/ether.h core/object/pcap.h core/object/ieee802.h core/object/linuxsll.h core/object/gre.h input/zero.h input/fpcap.h input/pcap.h input/mmpcap.h input/pcapthread.h filter/lua.h filter/split.h filter/layer.h filter/timing.h filter/thread.h filter/coro.h output/null.h output/cpool/client_pool.h output/cpool/client.h output/cpool.h output/udpcli.h
+dnsjit_SOURCES += core/producer.c core/log.c core/receiver.c core/object.c core/object/ip.c core/object/tcp.c core/object/pcap.c core/object/dns.c core/object/icmp6.c core/object/ieee802.c core/object/udp.c core/object/loop.c core/object/packet.c core/object/ip6.c core/object/gre.c core/object/linuxsll.c core/object/icmp.c core/object/null.c core/object/ether.c core/tracking.c core/mutex.c lib/clock.c input/zero.c input/pcap.c input/fpcap.c input/mmpcap.c input/pcapthread.c filter/lua.c filter/split.c filter/thread.c filter/timing.c filter/coro.c filter/layer.c output/udpcli.c output/cpool.c output/cpool/client_pool.c output/cpool/client.c output/null.c
+dist_dnsjit_SOURCES += core/mutex.h core/receiver.h core/object.h core/log.h core/timespec.h core/producer.h core/tracking.h core/object/icmp.h core/object/ip.h core/object/loop.h core/object/dns.h core/object/ip6.h core/object/null.h core/object/tcp.h core/object/udp.h core/object/packet.h core/object/icmp6.h core/object/ether.h core/object/pcap.h core/object/ieee802.h core/object/linuxsll.h core/object/gre.h lib/clock.h input/zero.h input/fpcap.h input/pcap.h input/mmpcap.h input/pcapthread.h filter/lua.h filter/split.h filter/layer.h filter/timing.h filter/thread.h filter/coro.h output/null.h output/cpool/client_pool.h output/cpool/client.h output/cpool.h output/udpcli.h
 
 # Lua headers
-dist_dnsjit_SOURCES += core/timespec.hh core/mutex.hh core/tracking.hh core/object/loop.hh core/object/gre.hh core/object/linuxsll.hh core/object/tcp.hh core/object/ether.hh core/object/icmp.hh core/object/ieee802.hh core/object/ip6.hh core/object/udp.hh core/object/packet.hh core/object/dns.hh core/object/pcap.hh core/object/icmp6.hh core/object/ip.hh core/object/null.hh core/receiver.hh core/object.hh core/log.hh input/zero.hh input/mmpcap.hh input/pcap.hh input/fpcap.hh input/pcapthread.hh filter/layer.hh filter/coro.hh filter/lua.hh filter/thread.hh filter/timing.hh filter/split.hh output/udpcli.hh output/cpool.hh output/null.hh
-lua_hobjects += core/timespec.luaho core/mutex.luaho core/tracking.luaho core/object/loop.luaho core/object/gre.luaho core/object/linuxsll.luaho core/object/tcp.luaho core/object/ether.luaho core/object/icmp.luaho core/object/ieee802.luaho core/object/ip6.luaho core/object/udp.luaho core/object/packet.luaho core/object/dns.luaho core/object/pcap.luaho core/object/icmp6.luaho core/object/ip.luaho core/object/null.luaho core/receiver.luaho core/object.luaho core/log.luaho input/zero.luaho input/mmpcap.luaho input/pcap.luaho input/fpcap.luaho input/pcapthread.luaho filter/layer.luaho filter/coro.luaho filter/lua.luaho filter/thread.luaho filter/timing.luaho filter/split.luaho output/udpcli.luaho output/cpool.luaho output/null.luaho
+dist_dnsjit_SOURCES += core/timespec.hh core/mutex.hh core/tracking.hh core/object/loop.hh core/object/gre.hh core/object/linuxsll.hh core/object/tcp.hh core/object/ether.hh core/object/icmp.hh core/object/ieee802.hh core/object/ip6.hh core/object/udp.hh core/object/packet.hh core/object/dns.hh core/object/pcap.hh core/object/icmp6.hh core/object/ip.hh core/object/null.hh core/producer.hh core/receiver.hh core/object.hh core/log.hh lib/clock.hh input/zero.hh input/mmpcap.hh input/pcap.hh input/fpcap.hh input/pcapthread.hh filter/layer.hh filter/coro.hh filter/lua.hh filter/thread.hh filter/timing.hh filter/split.hh output/udpcli.hh output/cpool.hh output/null.hh
+lua_hobjects += core/timespec.luaho core/mutex.luaho core/tracking.luaho core/object/loop.luaho core/object/gre.luaho core/object/linuxsll.luaho core/object/tcp.luaho core/object/ether.luaho core/object/icmp.luaho core/object/ieee802.luaho core/object/ip6.luaho core/object/udp.luaho core/object/packet.luaho core/object/dns.luaho core/object/pcap.luaho core/object/icmp6.luaho core/object/ip.luaho core/object/null.luaho core/producer.luaho core/receiver.luaho core/object.luaho core/log.luaho lib/clock.luaho input/zero.luaho input/mmpcap.luaho input/pcap.luaho input/fpcap.luaho input/pcapthread.luaho filter/layer.luaho filter/coro.luaho filter/lua.luaho filter/thread.luaho filter/timing.luaho filter/split.luaho output/udpcli.luaho output/cpool.luaho output/null.luaho
 
 # Lua sources
-dist_dnsjit_SOURCES += core/mutex.lua core/log.lua core/tracking.lua core/timespec.lua core/object/pcap.lua core/object/icmp6.lua core/object/gre.lua core/object/ether.lua core/object/ip.lua core/object/ieee802.lua core/object/tcp.lua core/object/ip6.lua core/object/linuxsll.lua core/object/null.lua core/object/loop.lua core/object/icmp.lua core/object/packet.lua core/object/dns.lua core/object/udp.lua core/receiver.lua core/object.lua lib/getopt.lua lib/parseconf.lua input/pcapthread.lua input/fpcap.lua input/pcap.lua input/zero.lua input/mmpcap.lua filter/coro.lua filter/timing.lua filter/split.lua filter/layer.lua filter/thread.lua filter/lua.lua output/cpool.lua output/null.lua output/udpcli.lua
-lua_objects += core/mutex.luao core/log.luao core/tracking.luao core/timespec.luao core/object/pcap.luao core/object/icmp6.luao core/object/gre.luao core/object/ether.luao core/object/ip.luao core/object/ieee802.luao core/object/tcp.luao core/object/ip6.luao core/object/linuxsll.luao core/object/null.luao core/object/loop.luao core/object/icmp.luao core/object/packet.luao core/object/dns.luao core/object/udp.luao core/receiver.luao core/object.luao lib/getopt.luao lib/parseconf.luao input/pcapthread.luao input/fpcap.luao input/pcap.luao input/zero.luao input/mmpcap.luao filter/coro.luao filter/timing.luao filter/split.luao filter/layer.luao filter/thread.luao filter/lua.luao output/cpool.luao output/null.luao output/udpcli.luao
+dist_dnsjit_SOURCES += core/mutex.lua core/log.lua core/tracking.lua core/timespec.lua core/producer.lua core/object/pcap.lua core/object/icmp6.lua core/object/gre.lua core/object/ether.lua core/object/ip.lua core/object/ieee802.lua core/object/tcp.lua core/object/ip6.lua core/object/linuxsll.lua core/object/null.lua core/object/loop.lua core/object/icmp.lua core/object/packet.lua core/object/dns.lua core/object/udp.lua core/receiver.lua core/object.lua lib/getopt.lua lib/clock.lua lib/parseconf.lua input/pcapthread.lua input/fpcap.lua input/pcap.lua input/zero.lua input/mmpcap.lua filter/coro.lua filter/timing.lua filter/split.lua filter/layer.lua filter/thread.lua filter/lua.lua output/cpool.lua output/null.lua output/udpcli.lua
+lua_objects += core/mutex.luao core/log.luao core/tracking.luao core/timespec.luao core/producer.luao core/object/pcap.luao core/object/icmp6.luao core/object/gre.luao core/object/ether.luao core/object/ip.luao core/object/ieee802.luao core/object/tcp.luao core/object/ip6.luao core/object/linuxsll.luao core/object/null.luao core/object/loop.luao core/object/icmp.luao core/object/packet.luao core/object/dns.luao core/object/udp.luao core/receiver.luao core/object.luao lib/getopt.luao lib/clock.luao lib/parseconf.luao input/pcapthread.luao input/fpcap.luao input/pcap.luao input/zero.luao input/mmpcap.luao filter/coro.luao filter/timing.luao filter/split.luao filter/layer.luao filter/thread.luao filter/lua.luao output/cpool.luao output/null.luao output/udpcli.luao
 
 dnsjit_LDFLAGS = -Wl,-E
 dnsjit_LDADD += $(lua_hobjects) $(lua_objects)
@@ -62,7 +62,7 @@ man1_MANS = dnsjit.1
 CLEANFILES += $(man1_MANS)
 
 man3_MANS = dnsjit.core.3 dnsjit.lib.3 dnsjit.input.3 dnsjit.filter.3 dnsjit.output.3
-man3_MANS += dnsjit.core.mutex.3 dnsjit.core.log.3 dnsjit.core.tracking.3 dnsjit.core.timespec.3 dnsjit.core.object.pcap.3 dnsjit.core.object.icmp6.3 dnsjit.core.object.gre.3 dnsjit.core.object.ether.3 dnsjit.core.object.ip.3 dnsjit.core.object.ieee802.3 dnsjit.core.object.tcp.3 dnsjit.core.object.ip6.3 dnsjit.core.object.linuxsll.3 dnsjit.core.object.null.3 dnsjit.core.object.loop.3 dnsjit.core.object.icmp.3 dnsjit.core.object.packet.3 dnsjit.core.object.dns.3 dnsjit.core.object.udp.3 dnsjit.core.receiver.3 dnsjit.core.object.3 dnsjit.lib.getopt.3 dnsjit.lib.parseconf.3 dnsjit.input.pcapthread.3 dnsjit.input.fpcap.3 dnsjit.input.pcap.3 dnsjit.input.zero.3 dnsjit.input.mmpcap.3 dnsjit.filter.coro.3 dnsjit.filter.timing.3 dnsjit.filter.split.3 dnsjit.filter.layer.3 dnsjit.filter.thread.3 dnsjit.filter.3.3 dnsjit.output.cpool.3 dnsjit.output.null.3 dnsjit.output.udpcli.3
+man3_MANS += dnsjit.core.mutex.3 dnsjit.core.log.3 dnsjit.core.tracking.3 dnsjit.core.timespec.3 dnsjit.core.producer.3 dnsjit.core.object.pcap.3 dnsjit.core.object.icmp6.3 dnsjit.core.object.gre.3 dnsjit.core.object.ether.3 dnsjit.core.object.ip.3 dnsjit.core.object.ieee802.3 dnsjit.core.object.tcp.3 dnsjit.core.object.ip6.3 dnsjit.core.object.linuxsll.3 dnsjit.core.object.null.3 dnsjit.core.object.loop.3 dnsjit.core.object.icmp.3 dnsjit.core.object.packet.3 dnsjit.core.object.dns.3 dnsjit.core.object.udp.3 dnsjit.core.receiver.3 dnsjit.core.object.3 dnsjit.lib.getopt.3 dnsjit.lib.clock.3 dnsjit.lib.parseconf.3 dnsjit.input.pcapthread.3 dnsjit.input.fpcap.3 dnsjit.input.pcap.3 dnsjit.input.zero.3 dnsjit.input.mmpcap.3 dnsjit.filter.coro.3 dnsjit.filter.timing.3 dnsjit.filter.split.3 dnsjit.filter.layer.3 dnsjit.filter.thread.3 dnsjit.filter.3.3 dnsjit.output.cpool.3 dnsjit.output.null.3 dnsjit.output.udpcli.3
 CLEANFILES += *.3in $(man3_MANS)
 
 .lua.luao:
@@ -124,6 +124,9 @@ dnsjit.core.tracking.3in: core/tracking.lua gen-manpage.lua
 dnsjit.core.timespec.3in: core/timespec.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/timespec.lua" > "$@"
 
+dnsjit.core.producer.3in: core/producer.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/producer.lua" > "$@"
+
 dnsjit.core.object.pcap.3in: core/object/pcap.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/pcap.lua" > "$@"
 
@@ -177,6 +180,9 @@ dnsjit.core.object.3in: core/object.lua gen-manpage.lua
 
 dnsjit.lib.getopt.3in: lib/getopt.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/lib/getopt.lua" > "$@"
+
+dnsjit.lib.clock.3in: lib/clock.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/lib/clock.lua" > "$@"
 
 dnsjit.lib.parseconf.3in: lib/parseconf.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/lib/parseconf.lua" > "$@"

--- a/src/core.lua
+++ b/src/core.lua
@@ -36,6 +36,7 @@ module(...,package.seeall)
 -- dnsjit.core.log (3),
 -- dnsjit.core.mutex (3),
 -- dnsjit.core.object (3),
+-- dnsjit.core.producer (3),
 -- dnsjit.core.receiver (3),
 -- dnsjit.core.timespec (3),
 -- dnsjit.core.tracking (3)

--- a/src/core/object.lua
+++ b/src/core/object.lua
@@ -52,6 +52,7 @@ require("dnsjit.core.object.tcp_h")
 require("dnsjit.core.object.packet_h")
 require("dnsjit.core.object.dns_h")
 local ffi = require("ffi")
+local C = ffi.C
 
 local t_name = "core_object_t"
 local core_object_t
@@ -74,40 +75,28 @@ local Object = {
     CORE_OBJECT_DNS = 40
 }
 
+local _type = {}
+_type[Object.CORE_OBJECT_PCAP] = "pcap"
+_type[Object.CORE_OBJECT_ETHER] = "ether"
+_type[Object.CORE_OBJECT_NULL] = "null"
+_type[Object.CORE_OBJECT_LOOP] = "loop"
+_type[Object.CORE_OBJECT_LINUXSLL] = "linuxsll"
+_type[Object.CORE_OBJECT_IEEE802] = "ieee802"
+_type[Object.CORE_OBJECT_GRE] = "gre"
+_type[Object.CORE_OBJECT_IP] = "ip"
+_type[Object.CORE_OBJECT_IP6] = "ip6"
+_type[Object.CORE_OBJECT_ICMP] = "icmp"
+_type[Object.CORE_OBJECT_ICMP6] = "icmp6"
+_type[Object.CORE_OBJECT_UDP] = "udp"
+_type[Object.CORE_OBJECT_TCP] = "tcp"
+_type[Object.CORE_OBJECT_PACKET] = "packet"
+_type[Object.CORE_OBJECT_DNS] = "dns"
+
+_type[Object.CORE_OBJECT_NONE] = "none"
+
 -- Return the textual type of the object.
 function Object:type()
-    if self.obj_type == Object.CORE_OBJECT_PCAP then
-        return "pcap"
-    elseif self.obj_type == Object.CORE_OBJECT_ETHER then
-        return "ether"
-    elseif self.obj_type == Object.CORE_OBJECT_NULL then
-        return "null"
-    elseif self.obj_type == Object.CORE_OBJECT_LOOP then
-        return "loop"
-    elseif self.obj_type == Object.CORE_OBJECT_LINUXSLL then
-        return "linuxsll"
-    elseif self.obj_type == Object.CORE_OBJECT_IEEE802 then
-        return "ieee802"
-    elseif self.obj_type == Object.CORE_OBJECT_GRE then
-        return "gre"
-    elseif self.obj_type == Object.CORE_OBJECT_IP then
-        return "ip"
-    elseif self.obj_type == Object.CORE_OBJECT_IP6 then
-        return "ip6"
-    elseif self.obj_type == Object.CORE_OBJECT_ICMP then
-        return "icmp"
-    elseif self.obj_type == Object.CORE_OBJECT_ICMP6 then
-        return "icmp6"
-    elseif self.obj_type == Object.CORE_OBJECT_UDP then
-        return "udp"
-    elseif self.obj_type == Object.CORE_OBJECT_TCP then
-        return "tcp"
-    elseif self.obj_type == Object.CORE_OBJECT_PACKET then
-        return "packet"
-    elseif self.obj_type == Object.CORE_OBJECT_DNS then
-        return "dns"
-    end
-    return "none"
+    return ffi.cast(_type[self.obj_type], self)
 end
 
 -- Return the previous object.
@@ -115,39 +104,26 @@ function Object:prev()
     return self.obj_prev
 end
 
+local _cast = {}
+_cast[Object.CORE_OBJECT_PCAP] = "core_object_pcap_t*"
+_cast[Object.CORE_OBJECT_ETHER] = "core_object_ether_t*"
+_cast[Object.CORE_OBJECT_NULL] = "core_object_null_t*"
+_cast[Object.CORE_OBJECT_LOOP] = "core_object_loop_t*"
+_cast[Object.CORE_OBJECT_LINUXSLL] = "core_object_linuxsll_t*"
+_cast[Object.CORE_OBJECT_IEEE802] = "core_object_ieee802_t*"
+_cast[Object.CORE_OBJECT_GRE] = "core_object_gre_t*"
+_cast[Object.CORE_OBJECT_IP] = "core_object_ip_t*"
+_cast[Object.CORE_OBJECT_IP6] = "core_object_ip6_t*"
+_cast[Object.CORE_OBJECT_ICMP] = "core_object_icmp_t*"
+_cast[Object.CORE_OBJECT_ICMP6] = "core_object_icmp6_t*"
+_cast[Object.CORE_OBJECT_UDP] = "core_object_udp_t*"
+_cast[Object.CORE_OBJECT_TCP] = "core_object_tcp_t*"
+_cast[Object.CORE_OBJECT_PACKET] = "core_object_packet_t*"
+_cast[Object.CORE_OBJECT_DNS] = "core_object_dns_t*"
+
 -- Cast the object to the underlining object module and return it.
 function Object:cast()
-    if self.obj_type == Object.CORE_OBJECT_PCAP then
-        return ffi.cast("core_object_pcap_t*", self)
-    elseif self.obj_type == Object.CORE_OBJECT_ETHER then
-        return ffi.cast("core_object_ether_t*", self)
-    elseif self.obj_type == Object.CORE_OBJECT_NULL then
-        return ffi.cast("core_object_null_t*", self)
-    elseif self.obj_type == Object.CORE_OBJECT_LOOP then
-        return ffi.cast("core_object_loop_t*", self)
-    elseif self.obj_type == Object.CORE_OBJECT_LINUXSLL then
-        return ffi.cast("core_object_linuxsll_t*", self)
-    elseif self.obj_type == Object.CORE_OBJECT_IEEE802 then
-        return ffi.cast("core_object_ieee802_t*", self)
-    elseif self.obj_type == Object.CORE_OBJECT_GRE then
-        return ffi.cast("core_object_gre_t*", self)
-    elseif self.obj_type == Object.CORE_OBJECT_IP then
-        return ffi.cast("core_object_ip_t*", self)
-    elseif self.obj_type == Object.CORE_OBJECT_IP6 then
-        return ffi.cast("core_object_ip6_t*", self)
-    elseif self.obj_type == Object.CORE_OBJECT_ICMP then
-        return ffi.cast("core_object_icmp_t*", self)
-    elseif self.obj_type == Object.CORE_OBJECT_ICMP6 then
-        return ffi.cast("core_object_icmp6_t*", self)
-    elseif self.obj_type == Object.CORE_OBJECT_UDP then
-        return ffi.cast("core_object_udp_t*", self)
-    elseif self.obj_type == Object.CORE_OBJECT_TCP then
-        return ffi.cast("core_object_tcp_t*", self)
-    elseif self.obj_type == Object.CORE_OBJECT_PACKET then
-        return ffi.cast("core_object_packet_t*", self)
-    elseif self.obj_type == Object.CORE_OBJECT_DNS then
-        return ffi.cast("core_object_dns_t*", self)
-    end
+    return ffi.cast(_cast[self.obj_type], self)
 end
 
 core_object_t = ffi.metatype(t_name, { __index = Object })

--- a/src/core/producer.c
+++ b/src/core/producer.c
@@ -18,16 +18,6 @@
  * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "core/log.h"
-#include "core/receiver.h"
+#include "config.h"
+
 #include "core/producer.h"
-
-#ifndef __dnsjit_output_null_h
-#define __dnsjit_output_null_h
-
-#include <stddef.h>
-#include <stdint.h>
-
-#include "output/null.hh"
-
-#endif

--- a/src/core/producer.h
+++ b/src/core/producer.h
@@ -18,16 +18,11 @@
  * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "core/log.h"
-#include "core/receiver.h"
-#include "core/producer.h"
+#include "core/object.h"
 
-#ifndef __dnsjit_output_null_h
-#define __dnsjit_output_null_h
+#ifndef __dnsjit_core_producer_h
+#define __dnsjit_core_producer_h
 
-#include <stddef.h>
-#include <stdint.h>
-
-#include "output/null.hh"
+#include "core/producer.hh"
 
 #endif

--- a/src/core/producer.hh
+++ b/src/core/producer.hh
@@ -18,16 +18,6 @@
  * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "core/log.h"
-#include "core/receiver.h"
-#include "core/producer.h"
+//lua:require("dnsjit.core.object_h")
 
-#ifndef __dnsjit_output_null_h
-#define __dnsjit_output_null_h
-
-#include <stddef.h>
-#include <stdint.h>
-
-#include "output/null.hh"
-
-#endif
+typedef const core_object_t* (*core_producer_t)(void* ctx);

--- a/src/core/producer.lua
+++ b/src/core/producer.lua
@@ -16,11 +16,11 @@
 -- You should have received a copy of the GNU General Public License
 -- along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
 
--- dnsjit.core.receiver
--- Receiver interfaces
---   require("dnsjit.core.receiver_h")
+-- dnsjit.core.producer
+-- Producer interfaces
+--   require("dnsjit.core.producer_h")
 --
--- Receiver interfaces are used by input, filter and output modules to pass
+-- Producer interfaces are used by input, filter and output modules to pass
 -- objects for processing.
 module(...,package.seeall)
 

--- a/src/core/receiver.c
+++ b/src/core/receiver.c
@@ -21,12 +21,3 @@
 #include "config.h"
 
 #include "core/receiver.h"
-
-int core_receiver_call(core_receiver_t recv, void* ctx, const core_object_t* obj)
-{
-    if (!recv) {
-        return 1;
-    }
-
-    return recv(ctx, obj);
-}

--- a/src/core/receiver.hh
+++ b/src/core/receiver.hh
@@ -21,5 +21,3 @@
 //lua:require("dnsjit.core.object_h")
 
 typedef int (*core_receiver_t)(void* ctx, const core_object_t* obj);
-
-int core_receiver_call(core_receiver_t recv, void* ctx, const core_object_t* obj);

--- a/src/filter/coro.lua
+++ b/src/filter/coro.lua
@@ -97,7 +97,7 @@ function Coro:receive()
     return C.filter_coro_receiver(), self.obj
 end
 
--- Set the receiver to pass queries to.
+-- Set the receiver to pass objects to.
 function Coro:receiver(o)
     self.obj._log:debug("receiver()")
     self.obj.recv, self.obj.ctx = o:receive()
@@ -107,7 +107,7 @@ end
 -- Used from the Lua function to send objects to the next receiver,
 -- returns 0 on success.
 function Coro:send(object)
-    return C.core_receiver_call(self.obj.recv, self.obj.ctx, object)
+    return self.obj.recv(self.obj.ctx, object)
 end
 
 -- dnsjit.core.object (3),

--- a/src/filter/layer.lua
+++ b/src/filter/layer.lua
@@ -60,7 +60,7 @@ function Layer:receive()
     return C.filter_layer_receiver(), self.obj
 end
 
--- Set the receiver to pass queries to.
+-- Set the receiver to pass objects to.
 function Layer:receiver(o)
     self.obj._log:debug("receiver()")
     self.obj.recv, self.obj.ctx = o:receive()

--- a/src/filter/lua.lua
+++ b/src/filter/lua.lua
@@ -148,7 +148,7 @@ function Lua:send(object)
     if not self.ishandler then
         error("not handler")
     end
-    return C.core_receiver_call(self._recv, self._ctx, object)
+    return self._recv(self._ctx, object)
 end
 
 -- dnsjit.core.object (3),

--- a/src/filter/thread.hh
+++ b/src/filter/thread.hh
@@ -29,20 +29,29 @@ typedef struct filter_thread_work {
     char            end;
 } filter_thread_work_t;
 
-typedef struct filter_thread {
-    core_log_t      _log;
-    core_receiver_t recv;
-    void*           ctx;
+typedef struct filter_thread_recv filter_thread_recv_t;
 
-    pthread_t             tid;
+typedef struct filter_thread {
+    core_log_t            _log;
+    filter_thread_recv_t* recv;
+
     filter_thread_work_t* work;
     size_t                works, at;
 } filter_thread_t;
+
+struct filter_thread_recv {
+    filter_thread_t*      self;
+    filter_thread_recv_t* next;
+    core_receiver_t       recv;
+    void*                 ctx;
+    pthread_t             tid;
+};
 
 core_log_t* filter_thread_log();
 
 int filter_thread_init(filter_thread_t* self, size_t queue_size);
 int filter_thread_destroy(filter_thread_t* self);
+int filter_thread_add(filter_thread_t* self, core_receiver_t recv, void* ctx);
 int filter_thread_start(filter_thread_t* self);
 int filter_thread_stop(filter_thread_t* self);
 

--- a/src/filter/timing.lua
+++ b/src/filter/timing.lua
@@ -17,7 +17,7 @@
 -- along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
 
 -- dnsjit.filter.timing
--- Filter to pass queries to the next receiver based on timing between packets
+-- Filter to pass objects to the next receiver based on timing between packets
 --   local filter = require("dnsjit.filter.timing").new()
 --   ...
 --   filter:receiver(...)
@@ -82,7 +82,7 @@ function Timing:receive()
     return C.filter_timing_receiver(), self.obj
 end
 
--- Set the receiver to pass queries to.
+-- Set the receiver to pass objects to.
 function Timing:receiver(o)
     self.obj._log:debug("receiver()")
     self.obj.recv, self.obj.ctx = o:receive()

--- a/src/gen-makefile.sh
+++ b/src/gen-makefile.sh
@@ -28,7 +28,7 @@ AM_CFLAGS = -I$(srcdir) \
   $(PTHREAD_CFLAGS) \
   $(luajit_CFLAGS)
 
-EXTRA_DIST = gen-manpage.lua dnsjit.1in
+EXTRA_DIST = gen-manpage.lua gen-compat.lua dnsjit.1in
 
 bin_PROGRAMS = dnsjit
 

--- a/src/input/fpcap.c
+++ b/src/input/fpcap.c
@@ -23,7 +23,6 @@
 #include "input/fpcap.h"
 #include "core/object/pcap.h"
 
-#include <time.h>
 #include <stdio.h>
 #include <pthread.h>
 
@@ -32,8 +31,9 @@ static input_fpcap_t _defaults = {
     LOG_T_INIT_OBJ("input.fpcap"),
     0, 0,
     0, 0, 0,
+    CORE_OBJECT_PCAP_INIT(0), 0,
     0, 10000, 100,
-    0, { 0, 0 }, { 0, 0 }, 0, 0, 0,
+    0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0
 };
 
@@ -41,6 +41,26 @@ struct _ctx {
     pthread_mutex_t m;
     pthread_cond_t  c;
     size_t          ref;
+};
+
+struct _prod_ctx {
+    struct {
+        uint32_t ts_sec;
+        uint32_t ts_usec;
+        uint32_t incl_len;
+        uint32_t orig_len;
+    } hdr;
+    struct _ctx    ctx;
+    size_t         n, m, buf_left;
+    uint8_t*       bufp;
+    unsigned short wait : 1;
+    unsigned short conthdr : 1;
+};
+static struct _prod_ctx _prod_ctx_defaults = {
+    { 0, 0, 0, 0 },
+    { PTHREAD_MUTEX_INITIALIZER, PTHREAD_COND_INITIALIZER, 0 },
+    0, 0, 0, 0,
+    0, 0
 };
 
 static void _ref(core_object_t* obj, core_object_reference_t ref)
@@ -65,11 +85,15 @@ core_log_t* input_fpcap_log()
 
 int input_fpcap_init(input_fpcap_t* self)
 {
-    if (!self) {
+    struct _prod_ctx* ctx = malloc(sizeof(struct _prod_ctx));
+
+    if (!self || !ctx) {
         return 1;
     }
 
-    *self = _defaults;
+    *self          = _defaults;
+    *ctx           = _prod_ctx_defaults;
+    self->prod_ctx = (void*)ctx;
 
     ldebug("init");
 
@@ -89,6 +113,7 @@ int input_fpcap_destroy(input_fpcap_t* self)
     }
     free(self->buf);
     free(self->shared_pkts);
+    free(self->prod_ctx);
 
     return 0;
 }
@@ -174,13 +199,24 @@ int input_fpcap_open(input_fpcap_t* self, const char* file)
                 self->shared_pkts[n].bytes      = 0;
                 self->shared_pkts[n].is_swapped = self->is_swapped;
                 self->shared_pkts[n].obj_ref    = _ref;
+
+                self->shared_pkts[n].obj_refctx  = &((struct _prod_ctx*)self->prod_ctx)->ctx;
+                self->shared_pkts[n].is_multiple = 1;
             }
+
+            ((struct _prod_ctx*)self->prod_ctx)->bufp     = self->buf;
+            ((struct _prod_ctx*)self->prod_ctx)->buf_left = self->buf_size;
         } else {
             if (!(self->buf = malloc(self->snaplen))) {
                 fclose(self->file);
                 self->file = 0;
                 return 1;
             }
+
+            self->prod_pkt.snaplen    = self->snaplen;
+            self->prod_pkt.linktype   = self->network;
+            self->prod_pkt.bytes      = (unsigned char*)self->buf;
+            self->prod_pkt.is_swapped = self->is_swapped;
         }
         ldebug("pcap v%u.%u snaplen:%lu %s", self->version_major, self->version_minor, self->snaplen, self->is_swapped ? " swapped" : "");
         return 0;
@@ -331,26 +367,157 @@ static int _run_shared(input_fpcap_t* self)
 
 int input_fpcap_run(input_fpcap_t* self)
 {
-    struct timespec ts;
-    int             ret;
-
     if (!self || !self->file || !self->recv) {
         return 1;
     }
 
-    clock_gettime(CLOCK_MONOTONIC, &ts);
-    self->ts.sec  = ts.tv_sec;
-    self->ts.nsec = ts.tv_nsec;
-
     if (self->use_shared) {
-        ret = _run_shared(self);
-    } else {
-        ret = _run(self);
+        return _run_shared(self);
+    }
+    return _run(self);
+}
+
+static const core_object_t* _produce(void* ctx)
+{
+    input_fpcap_t* self = (input_fpcap_t*)ctx;
+    struct {
+        uint32_t ts_sec;
+        uint32_t ts_usec;
+        uint32_t incl_len;
+        uint32_t orig_len;
+    } hdr;
+
+    if (!self) {
+        return 0;
     }
 
-    clock_gettime(CLOCK_MONOTONIC, &ts);
-    self->te.sec  = ts.tv_sec;
-    self->te.nsec = ts.tv_nsec;
+    if (fread(&hdr, 1, 16, self->file) == 16) {
+        if (self->is_swapped) {
+            hdr.ts_sec   = _flip32(hdr.ts_sec);
+            hdr.ts_usec  = _flip32(hdr.ts_usec);
+            hdr.incl_len = _flip32(hdr.incl_len);
+            hdr.orig_len = _flip32(hdr.orig_len);
+        }
+        if (hdr.incl_len > self->snaplen) {
+            return 0;
+        }
+        if (fread(self->buf, 1, hdr.incl_len, self->file) != hdr.incl_len) {
+            return 0;
+        }
 
-    return ret;
+        self->pkts++;
+
+        self->prod_pkt.ts.sec = hdr.ts_sec;
+        if (self->is_nanosec) {
+            self->prod_pkt.ts.nsec = hdr.ts_usec;
+        } else {
+            self->prod_pkt.ts.nsec = hdr.ts_usec * 1000;
+        }
+        self->prod_pkt.caplen = hdr.incl_len;
+        self->prod_pkt.len    = hdr.orig_len;
+
+        return (core_object_t*)&self->prod_pkt;
+    }
+
+    return 0;
+}
+
+static const core_object_t* _produce_shared(void* self_ctx)
+{
+    input_fpcap_t*    self = (input_fpcap_t*)self_ctx;
+    struct _prod_ctx* ctx;
+
+    if (!self) {
+        return 0;
+    }
+    ctx = (struct _prod_ctx*)self->prod_ctx;
+    if (!ctx) {
+        return 0;
+    }
+
+    if (ctx->wait) {
+        pthread_mutex_lock(&ctx->ctx.m);
+        while (ctx->ctx.ref) {
+            pthread_cond_wait(&ctx->ctx.c, &ctx->ctx.m);
+        }
+        pthread_mutex_unlock(&ctx->ctx.m);
+
+        ctx->n        = 0;
+        ctx->m        = 0;
+        ctx->bufp     = self->buf;
+        ctx->buf_left = self->buf_size;
+        ctx->wait     = 0;
+    }
+
+    if (ctx->conthdr || fread(&ctx->hdr, 1, 16, self->file) == 16) {
+        ctx->conthdr = 0;
+
+        if (self->is_swapped) {
+            ctx->hdr.ts_sec   = _flip32(ctx->hdr.ts_sec);
+            ctx->hdr.ts_usec  = _flip32(ctx->hdr.ts_usec);
+            ctx->hdr.incl_len = _flip32(ctx->hdr.incl_len);
+            ctx->hdr.orig_len = _flip32(ctx->hdr.orig_len);
+        }
+        if (ctx->hdr.incl_len > ctx->buf_left || ctx->n == self->num_shared_pkts) {
+            ctx->wait    = 1;
+            ctx->conthdr = 1;
+            return (core_object_t*)&self->shared_pkts[ctx->n - 1];
+        }
+        if (fread(ctx->bufp, 1, ctx->hdr.incl_len, self->file) != ctx->hdr.incl_len) {
+            return 0;
+        }
+
+        self->pkts++;
+
+        self->shared_pkts[ctx->n].ts.sec = ctx->hdr.ts_sec;
+        if (self->is_nanosec) {
+            self->shared_pkts[ctx->n].ts.nsec = ctx->hdr.ts_usec;
+        } else {
+            self->shared_pkts[ctx->n].ts.nsec = ctx->hdr.ts_usec * 1000;
+        }
+        self->shared_pkts[ctx->n].caplen = ctx->hdr.incl_len;
+        self->shared_pkts[ctx->n].len    = ctx->hdr.orig_len;
+        self->shared_pkts[ctx->n].bytes  = ctx->bufp;
+
+        if (!ctx->m) {
+            self->shared_pkts[ctx->n].obj_prev = 0;
+        } else {
+            self->shared_pkts[ctx->n].obj_prev = (core_object_t*)&self->shared_pkts[ctx->n - 1];
+        }
+        ctx->m++;
+        if (ctx->m == self->num_multiple_pkts) {
+            size_t n = ctx->n;
+
+            ctx->m = 0;
+            ctx->bufp += ctx->hdr.incl_len;
+            ctx->buf_left -= ctx->hdr.incl_len;
+            ctx->n++;
+            return (core_object_t*)&self->shared_pkts[n];
+        }
+
+        ctx->bufp += ctx->hdr.incl_len;
+        ctx->buf_left -= ctx->hdr.incl_len;
+        ctx->n++;
+    }
+
+    if (ctx->m) {
+        ctx->wait = 1;
+        return (core_object_t*)&self->shared_pkts[ctx->n - 1];
+    }
+
+    pthread_mutex_lock(&ctx->ctx.m);
+    while (ctx->ctx.ref) {
+        pthread_cond_wait(&ctx->ctx.c, &ctx->ctx.m);
+    }
+    pthread_mutex_unlock(&ctx->ctx.m);
+
+    return 0;
+}
+
+core_producer_t input_fpcap_producer(input_fpcap_t* self)
+{
+    if (self && self->use_shared) {
+        return _produce_shared;
+    }
+    return _produce;
 }

--- a/src/input/fpcap.h
+++ b/src/input/fpcap.h
@@ -20,7 +20,7 @@
 
 #include "core/log.h"
 #include "core/receiver.h"
-#include "core/timespec.h"
+#include "core/producer.h"
 #include "core/object/pcap.h"
 
 #ifndef __dnsjit_input_fpcap_h

--- a/src/input/fpcap.hh
+++ b/src/input/fpcap.hh
@@ -20,7 +20,7 @@
 
 //lua:require("dnsjit.core.log")
 //lua:require("dnsjit.core.receiver_h")
-//lua:require("dnsjit.core.timespec_h")
+//lua:require("dnsjit.core.producer_h")
 //lua:require("dnsjit.core.object.pcap_h")
 
 typedef struct input_fpcap {
@@ -32,15 +32,17 @@ typedef struct input_fpcap {
     unsigned short is_nanosec : 1;
     unsigned short use_shared : 1;
 
+    core_object_pcap_t prod_pkt;
+    void*              prod_ctx;
+
     core_object_pcap_t* shared_pkts;
     size_t              num_shared_pkts;
     size_t              num_multiple_pkts;
 
-    void*           file;
-    core_timespec_t ts, te;
-    size_t          pkts;
-    uint8_t*        buf;
-    size_t          buf_size;
+    void*    file;
+    size_t   pkts;
+    uint8_t* buf;
+    size_t   buf_size;
 
     uint32_t magic_number;
     uint16_t version_major;
@@ -57,3 +59,5 @@ int input_fpcap_init(input_fpcap_t* self);
 int input_fpcap_destroy(input_fpcap_t* self);
 int input_fpcap_open(input_fpcap_t* self, const char* file);
 int input_fpcap_run(input_fpcap_t* self);
+
+core_producer_t input_fpcap_producer(input_fpcap_t* self);

--- a/src/input/fpcap.lua
+++ b/src/input/fpcap.lua
@@ -85,11 +85,16 @@ function Fpcap:log()
     return self.obj._log
 end
 
--- Set the receiver to pass queries to.
+-- Set the receiver to pass objects to.
 function Fpcap:receiver(o)
     self.obj._log:debug("receiver()")
     self.obj.recv, self.obj.ctx = o:receive()
     self._receiver = o
+end
+
+-- Return the C functions and context for producing objects.
+function Fpcap:produce()
+    return C.input_fpcap_producer(self.obj), self.obj
 end
 
 -- Open a PCAP file for processing and read the PCAP header.
@@ -119,18 +124,6 @@ end
 -- Returns 0 on success.
 function Fpcap:run()
     return C.input_fpcap_run(self.obj)
-end
-
--- Return the seconds and nanoseconds (as a list) of the start time for
--- .BR Fpcap:run() .
-function Fpcap:start_time()
-    return tonumber(self.obj.ts.sec), tonumber(self.obj.ts.nsec)
-end
-
--- Return the seconds and nanoseconds (as a list) of the stop time for
--- .BR Fpcap:run() .
-function Fpcap:end_time()
-    return tonumber(self.obj.te.sec), tonumber(self.obj.te.nsec)
 end
 
 -- Return the number of packets seen.

--- a/src/input/mmpcap.c
+++ b/src/input/mmpcap.c
@@ -23,7 +23,6 @@
 #include "input/mmpcap.h"
 #include "core/object/pcap.h"
 
-#include <time.h>
 #include <sys/mman.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -37,8 +36,9 @@ static input_mmpcap_t _defaults = {
     LOG_T_INIT_OBJ("input.mmpcap"),
     0, 0,
     0, 0, 0,
+    CORE_OBJECT_PCAP_INIT(0), 0,
     0, 10000, 100,
-    -1, 0, 0, { 0, 0 }, { 0, 0 }, 0, 0,
+    -1, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0
 };
 
@@ -46,6 +46,25 @@ struct _ctx {
     pthread_mutex_t m;
     pthread_cond_t  c;
     size_t          ref;
+};
+
+struct _prod_ctx {
+    struct {
+        uint32_t ts_sec;
+        uint32_t ts_usec;
+        uint32_t incl_len;
+        uint32_t orig_len;
+    } hdr;
+    struct _ctx    ctx;
+    size_t         n, m;
+    unsigned short wait : 1;
+    unsigned short conthdr : 1;
+};
+static struct _prod_ctx _prod_ctx_defaults = {
+    { 0, 0, 0, 0 },
+    { PTHREAD_MUTEX_INITIALIZER, PTHREAD_COND_INITIALIZER, 0 },
+    0, 0,
+    0, 0
 };
 
 static void _ref(core_object_t* obj, core_object_reference_t ref)
@@ -70,11 +89,15 @@ core_log_t* input_mmpcap_log()
 
 int input_mmpcap_init(input_mmpcap_t* self)
 {
-    if (!self) {
+    struct _prod_ctx* ctx = malloc(sizeof(struct _prod_ctx));
+
+    if (!self || !ctx) {
         return 1;
     }
 
-    *self = _defaults;
+    *self          = _defaults;
+    *ctx           = _prod_ctx_defaults;
+    self->prod_ctx = (void*)ctx;
 
     ldebug("init");
 
@@ -96,6 +119,7 @@ int input_mmpcap_destroy(input_mmpcap_t* self)
         close(self->fd);
     }
     free(self->shared_pkts);
+    free(self->prod_ctx);
 
     return 0;
 }
@@ -197,7 +221,14 @@ int input_mmpcap_open(input_mmpcap_t* self, const char* file)
                 self->shared_pkts[n].bytes      = 0;
                 self->shared_pkts[n].is_swapped = self->is_swapped;
                 self->shared_pkts[n].obj_ref    = _ref;
+
+                self->shared_pkts[n].obj_refctx  = &((struct _prod_ctx*)self->prod_ctx)->ctx;
+                self->shared_pkts[n].is_multiple = 1;
             }
+        } else {
+            self->prod_pkt.snaplen    = self->snaplen;
+            self->prod_pkt.linktype   = self->network;
+            self->prod_pkt.is_swapped = self->is_swapped;
         }
 
         ldebug("pcap v%u.%u snaplen:%lu %s", self->version_major, self->version_minor, self->snaplen, self->is_swapped ? " swapped" : "");
@@ -351,26 +382,159 @@ static int _run_shared(input_mmpcap_t* self)
 
 int input_mmpcap_run(input_mmpcap_t* self)
 {
-    struct timespec ts;
-    int             ret;
-
     if (!self || !self->buf || !self->recv) {
         return 1;
     }
 
-    clock_gettime(CLOCK_MONOTONIC, &ts);
-    self->ts.sec  = ts.tv_sec;
-    self->ts.nsec = ts.tv_nsec;
-
     if (self->use_shared) {
-        ret = _run_shared(self);
-    } else {
-        ret = _run(self);
+        return _run_shared(self);
+    }
+    return _run(self);
+}
+
+static const core_object_t* _produce(void* ctx)
+{
+    input_mmpcap_t* self = (input_mmpcap_t*)ctx;
+    struct {
+        uint32_t ts_sec;
+        uint32_t ts_usec;
+        uint32_t incl_len;
+        uint32_t orig_len;
+    } hdr;
+
+    if (!self) {
+        return 0;
     }
 
-    clock_gettime(CLOCK_MONOTONIC, &ts);
-    self->te.sec  = ts.tv_sec;
-    self->te.nsec = ts.tv_nsec;
+    if (self->len - self->at > 16) {
+        memcpy(&hdr, &self->buf[self->at], 16);
+        self->at += 16;
+        if (self->is_swapped) {
+            hdr.ts_sec   = _flip32(hdr.ts_sec);
+            hdr.ts_usec  = _flip32(hdr.ts_usec);
+            hdr.incl_len = _flip32(hdr.incl_len);
+            hdr.orig_len = _flip32(hdr.orig_len);
+        }
+        if (hdr.incl_len > self->snaplen) {
+            return 0;
+        }
+        if (self->len - self->at < hdr.incl_len) {
+            return 0;
+        }
 
-    return ret;
+        self->pkts++;
+
+        self->prod_pkt.ts.sec = hdr.ts_sec;
+        if (self->is_nanosec) {
+            self->prod_pkt.ts.nsec = hdr.ts_usec;
+        } else {
+            self->prod_pkt.ts.nsec = hdr.ts_usec * 1000;
+        }
+        self->prod_pkt.bytes  = (unsigned char*)&self->buf[self->at];
+        self->prod_pkt.caplen = hdr.incl_len;
+        self->prod_pkt.len    = hdr.orig_len;
+
+        self->at += hdr.incl_len;
+        return (core_object_t*)&self->prod_pkt;
+    }
+
+    return 0;
+}
+
+static const core_object_t* _produce_shared(void* self_ctx)
+{
+    input_mmpcap_t*   self = (input_mmpcap_t*)self_ctx;
+    struct _prod_ctx* ctx;
+
+    if (!self) {
+        return 0;
+    }
+    ctx = (struct _prod_ctx*)self->prod_ctx;
+    if (!ctx) {
+        return 0;
+    }
+
+    if (ctx->wait) {
+        pthread_mutex_lock(&ctx->ctx.m);
+        while (ctx->ctx.ref) {
+            pthread_cond_wait(&ctx->ctx.c, &ctx->ctx.m);
+        }
+        pthread_mutex_unlock(&ctx->ctx.m);
+
+        ctx->n    = 0;
+        ctx->m    = 0;
+        ctx->wait = 0;
+    }
+
+    if (ctx->conthdr || self->len - self->at > 16) {
+        ctx->conthdr = 0;
+
+        memcpy(&ctx->hdr, &self->buf[self->at], 16);
+        self->at += 16;
+        if (self->is_swapped) {
+            ctx->hdr.ts_sec   = _flip32(ctx->hdr.ts_sec);
+            ctx->hdr.ts_usec  = _flip32(ctx->hdr.ts_usec);
+            ctx->hdr.incl_len = _flip32(ctx->hdr.incl_len);
+            ctx->hdr.orig_len = _flip32(ctx->hdr.orig_len);
+        }
+        if (ctx->n == self->num_shared_pkts) {
+            ctx->wait    = 1;
+            ctx->conthdr = 1;
+            return (core_object_t*)&self->shared_pkts[ctx->n - 1];
+        }
+        if (self->len - self->at < ctx->hdr.incl_len) {
+            return 0;
+        }
+
+        self->pkts++;
+
+        self->shared_pkts[ctx->n].ts.sec = ctx->hdr.ts_sec;
+        if (self->is_nanosec) {
+            self->shared_pkts[ctx->n].ts.nsec = ctx->hdr.ts_usec;
+        } else {
+            self->shared_pkts[ctx->n].ts.nsec = ctx->hdr.ts_usec * 1000;
+        }
+        self->shared_pkts[ctx->n].bytes  = (unsigned char*)&self->buf[self->at];
+        self->shared_pkts[ctx->n].caplen = ctx->hdr.incl_len;
+        self->shared_pkts[ctx->n].len    = ctx->hdr.orig_len;
+
+        if (!ctx->m) {
+            self->shared_pkts[ctx->n].obj_prev = 0;
+        } else {
+            self->shared_pkts[ctx->n].obj_prev = (core_object_t*)&self->shared_pkts[ctx->n - 1];
+        }
+        ctx->m++;
+        if (ctx->m == self->num_multiple_pkts) {
+            size_t n = ctx->n;
+
+            ctx->m = 0;
+            ctx->n++;
+            self->at += ctx->hdr.incl_len;
+            return (core_object_t*)&self->shared_pkts[n];
+        }
+
+        ctx->n++;
+        self->at += ctx->hdr.incl_len;
+    }
+
+    if (ctx->m) {
+        ctx->wait = 1;
+        return (core_object_t*)&self->shared_pkts[ctx->n - 1];
+    }
+
+    pthread_mutex_lock(&ctx->ctx.m);
+    while (ctx->ctx.ref) {
+        pthread_cond_wait(&ctx->ctx.c, &ctx->ctx.m);
+    }
+    pthread_mutex_unlock(&ctx->ctx.m);
+
+    return 0;
+}
+
+core_producer_t input_mmpcap_producer(input_mmpcap_t* self)
+{
+    if (self && self->use_shared) {
+        return _produce_shared;
+    }
+    return _produce;
 }

--- a/src/input/mmpcap.h
+++ b/src/input/mmpcap.h
@@ -20,7 +20,7 @@
 
 #include "core/log.h"
 #include "core/receiver.h"
-#include "core/timespec.h"
+#include "core/producer.h"
 #include "core/object/pcap.h"
 
 #ifndef __dnsjit_input_mmpcap_h

--- a/src/input/mmpcap.hh
+++ b/src/input/mmpcap.hh
@@ -20,7 +20,7 @@
 
 //lua:require("dnsjit.core.log")
 //lua:require("dnsjit.core.receiver_h")
-//lua:require("dnsjit.core.timespec_h")
+//lua:require("dnsjit.core.producer_h")
 //lua:require("dnsjit.core.object.pcap_h")
 
 typedef struct input_mmpcap {
@@ -32,15 +32,17 @@ typedef struct input_mmpcap {
     unsigned short is_nanosec : 1;
     unsigned short use_shared : 1;
 
+    core_object_pcap_t prod_pkt;
+    void*              prod_ctx;
+
     core_object_pcap_t* shared_pkts;
     size_t              num_shared_pkts;
     size_t              num_multiple_pkts;
 
-    int             fd;
-    size_t          len, at;
-    core_timespec_t ts, te;
-    size_t          pkts;
-    uint8_t*        buf;
+    int      fd;
+    size_t   len, at;
+    size_t   pkts;
+    uint8_t* buf;
 
     uint32_t magic_number;
     uint16_t version_major;
@@ -57,3 +59,5 @@ int input_mmpcap_init(input_mmpcap_t* self);
 int input_mmpcap_destroy(input_mmpcap_t* self);
 int input_mmpcap_open(input_mmpcap_t* self, const char* file);
 int input_mmpcap_run(input_mmpcap_t* self);
+
+core_producer_t input_mmpcap_producer(input_mmpcap_t* self);

--- a/src/input/mmpcap.lua
+++ b/src/input/mmpcap.lua
@@ -85,11 +85,16 @@ function Mmpcap:log()
     return self.obj._log
 end
 
--- Set the receiver to pass queries to.
+-- Set the receiver to pass objects to.
 function Mmpcap:receiver(o)
     self.obj._log:debug("receiver()")
     self.obj.recv, self.obj.ctx = o:receive()
     self._receiver = o
+end
+
+-- Return the C functions and context for producing objects.
+function Mmpcap:produce()
+    return C.input_mmpcap_producer(self.obj), self.obj
 end
 
 -- Open a PCAP file for processing and read the PCAP header.
@@ -119,18 +124,6 @@ end
 -- Returns 0 on success.
 function Mmpcap:run()
     return C.input_mmpcap_run(self.obj)
-end
-
--- Return the seconds and nanoseconds (as a list) of the start time for
--- .BR Mmpcap:run() .
-function Mmpcap:start_time()
-    return tonumber(self.obj.ts.sec), tonumber(self.obj.ts.nsec)
-end
-
--- Return the seconds and nanoseconds (as a list) of the stop time for
--- .BR Mmpcap:run() .
-function Mmpcap:end_time()
-    return tonumber(self.obj.te.sec), tonumber(self.obj.te.nsec)
 end
 
 -- Return the number of packets seen.

--- a/src/input/pcap.h
+++ b/src/input/pcap.h
@@ -20,7 +20,8 @@
 
 #include "core/log.h"
 #include "core/receiver.h"
-#include "core/timespec.h"
+#include "core/producer.h"
+#include "core/object/pcap.h"
 
 #ifndef __dnsjit_input_pcap_h
 #define __dnsjit_input_pcap_h

--- a/src/input/pcap.hh
+++ b/src/input/pcap.hh
@@ -24,7 +24,8 @@ typedef struct pcap {} pcap_t;
 
 //lua:require("dnsjit.core.log")
 //lua:require("dnsjit.core.receiver_h")
-//lua:require("dnsjit.core.timespec_h")
+//lua:require("dnsjit.core.producer_h")
+//lua:require("dnsjit.core.object.pcap_h")
 
 typedef struct input_pcap {
     core_log_t      _log;
@@ -33,9 +34,10 @@ typedef struct input_pcap {
 
     unsigned short is_swapped : 1;
 
-    pcap_t*         pcap;
-    core_timespec_t ts, te;
-    size_t          pkts;
+    core_object_pcap_t prod_pkt;
+
+    pcap_t* pcap;
+    size_t  pkts;
 
     size_t   snaplen;
     uint32_t linktype;
@@ -48,3 +50,5 @@ int input_pcap_destroy(input_pcap_t* self);
 int input_pcap_open_offline(input_pcap_t* self, const char* file);
 int input_pcap_loop(input_pcap_t* self, int cnt);
 int input_pcap_dispatch(input_pcap_t* self, int cnt);
+
+core_producer_t input_pcap_producer();

--- a/src/input/pcap.lua
+++ b/src/input/pcap.lua
@@ -53,11 +53,16 @@ function Pcap:log()
     return self.obj._log
 end
 
--- Set the receiver to pass queries to.
+-- Set the receiver to pass objects to.
 function Pcap:receiver(o)
     self.obj._log:debug("receiver()")
     self.obj.recv, self.obj.ctx = o:receive()
     self._receiver = o
+end
+
+-- Return the C functions and context for producing objects.
+function Pcap:produce()
+    return C.input_pcap_producer(), self.obj
 end
 
 -- Open a PCAP file for processing.
@@ -88,18 +93,6 @@ function Pcap:dispatch(cnt)
         cnt = -1
     end
     return C.input_pcap_dispatch(self.obj, cnt)
-end
-
--- Return the seconds and nanoseconds (as a list) of the start time for
--- .BR Pcap:run() .
-function Pcap:start_time()
-    return tonumber(self.obj.ts.sec), tonumber(self.obj.ts.nsec)
-end
-
--- Return the seconds and nanoseconds (as a list) of the stop time for
--- .BR Pcap:run() .
-function Pcap:end_time()
-    return tonumber(self.obj.te.sec), tonumber(self.obj.te.nsec)
 end
 
 -- Return the number of packets seen.

--- a/src/input/pcapthread.c
+++ b/src/input/pcapthread.c
@@ -31,7 +31,6 @@ static input_pcapthread_t _defaults = {
     LOG_T_INIT_OBJ("input.pcapthread"),
     0, 0,
     0, 0, 0,
-    { 0, 0 }, { 0, 0 },
     0, 0, 0, 0,
     PCAP_THREAD_OK,
     0, 1
@@ -245,23 +244,15 @@ int input_pcapthread_open_offline(input_pcapthread_t* self, const char* file)
 
 int input_pcapthread_run(input_pcapthread_t* self)
 {
-    struct timespec ts, te;
     if (!self || !self->setup_ok || !self->recv) {
         return 1;
     }
 
     ldebug("run");
 
-    clock_gettime(CLOCK_MONOTONIC, &ts);
     if ((self->err = pcap_thread_run(self->pt)) != PCAP_THREAD_OK) {
         return 1;
     }
-    clock_gettime(CLOCK_MONOTONIC, &te);
-
-    self->ts.sec  = ts.tv_sec;
-    self->ts.nsec = ts.tv_nsec;
-    self->te.sec  = te.tv_sec;
-    self->te.nsec = te.tv_nsec;
 
     return 0;
 }

--- a/src/input/pcapthread.h
+++ b/src/input/pcapthread.h
@@ -22,7 +22,6 @@
 #include "pcap-thread/pcap_thread.h"
 #include "core/log.h"
 #include "core/receiver.h"
-#include "core/timespec.h"
 
 #ifndef __dnsjit_input_pcapthread_h
 #define __dnsjit_input_pcapthread_h

--- a/src/input/pcapthread.hh
+++ b/src/input/pcapthread.hh
@@ -45,7 +45,6 @@ int pcap_thread_set_filter_netmask(pcap_thread_t* pcap_thread, const uint32_t fi
 
 //lua:require("dnsjit.core.log")
 //lua:require("dnsjit.core.receiver_h")
-//lua:require("dnsjit.core.timespec_h")
 
 typedef struct input_pcapthread {
     core_log_t      _log;
@@ -54,7 +53,6 @@ typedef struct input_pcapthread {
     pcap_thread_t*  pt;
     core_receiver_t recv;
     void*           ctx;
-    core_timespec_t ts, te;
     size_t          pkts, drop, ignore, queries;
     int             err;
     uint64_t        src_id;

--- a/src/input/pcapthread.lua
+++ b/src/input/pcapthread.lua
@@ -53,7 +53,7 @@ function Pcapthread:log()
     return self.obj._log
 end
 
--- Set the receiver to pass queries to.
+-- Set the receiver to pass objects to.
 function Pcapthread:receiver(o)
     self.obj._log:debug("receiver()")
     self.obj.recv, self.obj.ctx = o:receive()
@@ -288,18 +288,6 @@ function Pcapthread:strerr(err)
         return ffi.string(C.input_pcapthread_strerr(self.obj.err))
     end
     return ffi.string(C.input_pcapthread_strerr(err))
-end
-
--- Return the seconds and nanoseconds (as a list) of the start time for
--- .BR Pcapthread:run() .
-function Pcapthread:start_time()
-    return tonumber(self.obj.ts.sec), tonumber(self.obj.ts.nsec)
-end
-
--- Return the seconds and nanoseconds (as a list) of the stop time for
--- .BR Pcapthread:run() .
-function Pcapthread:end_time()
-    return tonumber(self.obj.te.sec), tonumber(self.obj.te.nsec)
 end
 
 -- Return the number of packets seen.

--- a/src/input/zero.h
+++ b/src/input/zero.h
@@ -20,10 +20,12 @@
 
 #include "core/log.h"
 #include "core/receiver.h"
-#include "core/timespec.h"
+#include "core/producer.h"
 
 #ifndef __dnsjit_input_zero_h
 #define __dnsjit_input_zero_h
+
+#include <stdint.h>
 
 #include "input/zero.hh"
 

--- a/src/input/zero.hh
+++ b/src/input/zero.hh
@@ -20,14 +20,12 @@
 
 //lua:require("dnsjit.core.log")
 //lua:require("dnsjit.core.receiver_h")
-//lua:require("dnsjit.core.timespec_h")
+//lua:require("dnsjit.core.producer_h")
 
 typedef struct input_zero {
     core_log_t      _log;
     core_receiver_t recv;
     void*           ctx;
-
-    core_timespec_t ts, te;
 
     unsigned short use_shared : 1;
 } input_zero_t;
@@ -37,3 +35,5 @@ core_log_t* input_zero_log();
 int input_zero_init(input_zero_t* self);
 int input_zero_destroy(input_zero_t* self);
 int input_zero_run(input_zero_t* self, uint64_t num);
+
+core_producer_t input_zero_producer(input_zero_t* self);

--- a/src/input/zero.lua
+++ b/src/input/zero.lua
@@ -17,12 +17,12 @@
 -- along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
 
 -- dnsjit.input.zero
--- Generate empty queries (/dev/zero)
+-- Generate empty packets (/dev/zero)
 --   local input = require("dnsjit.input.zero").new()
 --   input:receiver(filter_or_output)
 --   input:run(10000000)
 --
--- Input module for generating empty queries, mostly used for testing.
+-- Input module for generating empty packets, mostly used for testing.
 module(...,package.seeall)
 
 require("dnsjit.input.zero_h")
@@ -52,11 +52,16 @@ function Zero:log()
     return self.obj._log
 end
 
--- Set the receiver to pass queries to.
+-- Set the receiver to pass objects to.
 function Zero:receiver(o)
     self.obj._log:debug("receiver()")
     self.obj.recv, self.obj.ctx = o:receive()
     self._receiver = o
+end
+
+-- Return the C functions and context for producing objects.
+function Zero:produce()
+    return C.input_zero_producer(self.obj), self.obj
 end
 
 -- Enable (true) or disable (false) usage of shared objects, if
@@ -78,21 +83,9 @@ end
 
 -- Generate
 -- .I num
--- empty queries and send them to the receiver, return 0 if successful.
+-- empty packets and send them to the receiver, return 0 if successful.
 function Zero:run(num)
     return C.input_zero_run(self.obj, num)
-end
-
--- Return the seconds and nanoseconds (as a list) of the start time for
--- .BR Zero:run() .
-function Zero:start_time()
-    return tonumber(self.obj.ts.sec), tonumber(self.obj.ts.nsec)
-end
-
--- Return the seconds and nanoseconds (as a list) of the stop time for
--- .BR Zero:run() .
-function Zero:end_time()
-    return tonumber(self.obj.te.sec), tonumber(self.obj.te.nsec)
 end
 
 return Zero

--- a/src/lib.lua
+++ b/src/lib.lua
@@ -20,6 +20,7 @@
 -- Various Lua libraries or C library bindings
 module(...,package.seeall)
 
+-- dnsjit.lib.clock (3),
 -- dnsjit.lib.getopt (3),
 -- dnsjit.lib.parseconf (3)
 return

--- a/src/lib/clock.c
+++ b/src/lib/clock.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2018, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "lib/clock.h"
+
+#include <time.h>
+
+core_timespec_t lib_clock_getres(lib_clock_clkid_t clkid)
+{
+    struct timespec ts;
+    core_timespec_t ret = { 0, 0 };
+    clockid_t clk_id;
+
+    switch (clkid) {
+    case LIB_CLOCK_REALTIME:
+        clk_id = CLOCK_REALTIME;
+        break;
+    case LIB_CLOCK_MONOTONIC:
+        clk_id = CLOCK_MONOTONIC;
+        break;
+    default:
+        return ret;
+    }
+
+    if (!clock_getres(clk_id, &ts)) {
+        ret.sec  = ts.tv_sec;
+        ret.nsec = ts.tv_nsec;
+    }
+
+    return ret;
+}
+
+core_timespec_t lib_clock_gettime(lib_clock_clkid_t clkid)
+{
+    struct timespec ts;
+    core_timespec_t ret = { 0, 0 };
+    clockid_t clk_id;
+
+    switch (clkid) {
+    case LIB_CLOCK_REALTIME:
+        clk_id = CLOCK_REALTIME;
+        break;
+    case LIB_CLOCK_MONOTONIC:
+        clk_id = CLOCK_MONOTONIC;
+        break;
+    default:
+        return ret;
+    }
+
+    if (!clock_gettime(clk_id, &ts)) {
+        ret.sec  = ts.tv_sec;
+        ret.nsec = ts.tv_nsec;
+    }
+
+    return ret;
+}

--- a/src/lib/clock.h
+++ b/src/lib/clock.h
@@ -18,16 +18,11 @@
  * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "core/log.h"
-#include "core/receiver.h"
-#include "core/producer.h"
+#include "core/timespec.h"
 
-#ifndef __dnsjit_output_null_h
-#define __dnsjit_output_null_h
+#ifndef __dnsjit_lib_clock_h
+#define __dnsjit_lib_clock_h
 
-#include <stddef.h>
-#include <stdint.h>
-
-#include "output/null.hh"
+#include "lib/clock.hh"
 
 #endif

--- a/src/lib/clock.hh
+++ b/src/lib/clock.hh
@@ -18,16 +18,12 @@
  * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "core/log.h"
-#include "core/receiver.h"
-#include "core/producer.h"
+//lua:require("dnsjit.core.timespec_h")
 
-#ifndef __dnsjit_output_null_h
-#define __dnsjit_output_null_h
+typedef enum lib_clock_clkid {
+    LIB_CLOCK_REALTIME,
+    LIB_CLOCK_MONOTONIC
+} lib_clock_clkid_t;
 
-#include <stddef.h>
-#include <stdint.h>
-
-#include "output/null.hh"
-
-#endif
+core_timespec_t lib_clock_getres(lib_clock_clkid_t clkid);
+core_timespec_t lib_clock_gettime(lib_clock_clkid_t clkid);

--- a/src/lib/clock.lua
+++ b/src/lib/clock.lua
@@ -16,13 +16,32 @@
 -- You should have received a copy of the GNU General Public License
 -- along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
 
--- dnsjit.core.receiver
--- Receiver interfaces
---   require("dnsjit.core.receiver_h")
+-- dnsjit.lib.clock
+-- Clock and time functions
+--   local clock = require("dnsjit.lib.clock")
+--   local sec, nsec = clock.monotonic()
 --
--- Receiver interfaces are used by input, filter and output modules to pass
--- objects for processing.
+-- Functions to get the time from system-wide clocks.
 module(...,package.seeall)
 
--- dnsjit.core.object (3)
-return
+require("dnsjit.lib.clock_h")
+local C = require("ffi").C
+
+Clock = {}
+
+-- Return the current seconds and nanoseconds (as a list) from the realtime
+-- clock.
+function Clock.realtime()
+    local ts = C.lib_clock_gettime("LIB_CLOCK_REALTIME")
+    return tonumber(ts.sec), tonumber(ts.nsec)
+end
+
+-- Return the current seconds and nanoseconds (as a list) from the monotonic
+-- clock.
+function Clock.monotonic()
+    local ts = C.lib_clock_gettime("LIB_CLOCK_MONOTONIC")
+    return tonumber(ts.sec), tonumber(ts.nsec)
+end
+
+-- clock_gettime (2)
+return Clock

--- a/src/output/null.hh
+++ b/src/output/null.hh
@@ -18,10 +18,20 @@
  * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+//lua:require("dnsjit.core.log")
 //lua:require("dnsjit.core.receiver_h")
+//lua:require("dnsjit.core.producer_h")
 
 typedef struct output_null {
-    size_t pkts;
+    core_log_t      _log;
+    core_producer_t prod;
+    void*           ctx;
+    size_t          pkts;
 } output_null_t;
+
+core_log_t* output_null_log();
+int output_null_init(output_null_t* self);
+int output_null_destroy(output_null_t* self);
+int output_null_run(output_null_t* self, uint64_t num);
 
 core_receiver_t output_null_receiver();


### PR DESCRIPTION
- Add producer interface `core.producer`, a much faster way to pull objects into Lua
- Add `examples/readme.lua`, same example as in `README.md`
- Add `lib.clock`
- Use `lib.clock` in examples and remove `timespec` from inputs
- `examples/test_throughput.lua`: Add more tests using `filter.thread`, `filter.coro` and `filter.split`
- `core.object`: Use local hash for types and cast, x3 faster
- `core.receiver`: Remove `core_receiver_call()`, use the returned function instead
- `filter.thread`: Add multiple receiver support, each receiver in it's own thread
- `input.fpcap`: Implement producer
- `input.mmpcap`: Implement producer
- `input.pcap`: Implement producer
- `input.zero`: Implement producer
- `output.zero`:
  - Add logging
  - Add support for producer
  - Add `run(num)` to pull objects from a producer
- `gen-makefile.sh`: Add `gen-compat.lua`