### PR TITLE
Thread writers

### DIFF
--- a/examples/test_throughput.lua
+++ b/examples/test_throughput.lua
@@ -2,6 +2,7 @@
 local clock = require("dnsjit.lib.clock")
 local getopt = require("dnsjit.lib.getopt").new({
     { "t", "thread", false, "Test also with dnsjit.filter.thread", "?" },
+    { nil, "thread-writers", false, "Use writers for thread", "?" },
     { "c", "coro", false, "Test also with dnsjit.filter.coro", "?" },
     { "s", "split", false, "Test also with dnsjit.filter.split", "?" }
 })
@@ -53,6 +54,10 @@ if getopt:val("t") then
         local t = require("dnsjit.filter.thread").new()
         local o = require("dnsjit.output.null").new()
 
+        if getopt:val("thread-writers") then
+            t.obj.use_writers = 1
+        end
+
         t:receiver(o)
         i:receiver(t)
         t:start()
@@ -79,6 +84,10 @@ if getopt:val("t") then
         local t = require("dnsjit.filter.thread").new()
         local o1 = require("dnsjit.output.null").new()
         local o2 = require("dnsjit.output.null").new()
+
+        if getopt:val("thread-writers") then
+            t:use_writers(true)
+        end
 
         t:receiver(o1)
         t:receiver(o2)
@@ -109,6 +118,10 @@ if getopt:val("t") then
         local o2 = require("dnsjit.output.null").new()
         local o3 = require("dnsjit.output.null").new()
         local o4 = require("dnsjit.output.null").new()
+
+        if getopt:val("thread-writers") then
+            t:use_writers(true)
+        end
 
         t:receiver(o1)
         t:receiver(o2)
@@ -170,6 +183,11 @@ if getopt:val("s") and getopt:val("t") then
         local o1 = require("dnsjit.output.null").new()
         local t2 = require("dnsjit.filter.thread").new()
         local o2 = require("dnsjit.output.null").new()
+
+        if getopt:val("thread-writers") then
+            t1:use_writers(true)
+            t2:use_writers(true)
+        end
 
         t1:receiver(o1)
         t1:start()

--- a/src/filter/thread.c
+++ b/src/filter/thread.c
@@ -26,12 +26,61 @@ static core_log_t      _log      = LOG_T_INIT("filter.thread");
 static filter_thread_t _defaults = {
     LOG_T_INIT_OBJ("filter.thread"),
     0,
-    0, 0, 0
+    0, 0, 0,
+    0
 };
 
 core_log_t* filter_thread_log()
 {
     return &_log;
+}
+
+void* _thread_writers(void* user)
+{
+    filter_thread_recv_t* recv = (filter_thread_recv_t*)user;
+    filter_thread_t*      self = (filter_thread_t*)recv->self;
+    size_t                ends = 0, at = 0;
+    core_object_t*        obj = 0;
+
+    while (ends < self->works) {
+        filter_thread_work_t* w = &self->work[at];
+        pthread_mutex_lock(&w->mutex);
+        if (!w->end) {
+            while (!w->end && !w->obj) {
+                if (!w->writers) {
+                    pthread_mutex_unlock(&w->mutex);
+                    at++;
+                    if (at == self->works)
+                        at = 0;
+                    w      = &self->work[at];
+                    pthread_mutex_lock(&w->mutex);
+                    continue;
+                }
+                pthread_cond_wait(&w->read, &w->mutex);
+            }
+        }
+        if (w->obj) {
+            obj    = w->obj;
+            w->obj = 0;
+            pthread_cond_signal(&w->write);
+        }
+        if (w->end) {
+            ends++;
+        }
+        pthread_mutex_unlock(&w->mutex);
+
+        if (obj) {
+            recv->recv(recv->ctx, obj);
+            core_object_free(obj);
+            obj = 0;
+        }
+
+        at++;
+        if (at == self->works)
+            at = 0;
+    }
+
+    return 0;
 }
 
 void* _thread(void* user)
@@ -75,7 +124,7 @@ void* _thread(void* user)
 
 int filter_thread_init(filter_thread_t* self, size_t queue_size)
 {
-    filter_thread_work_t defwork = { 0, PTHREAD_MUTEX_INITIALIZER, PTHREAD_COND_INITIALIZER, PTHREAD_COND_INITIALIZER, 0 };
+    filter_thread_work_t defwork = { 0, PTHREAD_MUTEX_INITIALIZER, PTHREAD_COND_INITIALIZER, PTHREAD_COND_INITIALIZER, 0, 0 };
     size_t               n;
 
     if (!self || !queue_size) {
@@ -94,6 +143,7 @@ int filter_thread_init(filter_thread_t* self, size_t queue_size)
     for (n = 0; n < self->works; n++) {
         self->work[n] = defwork;
     }
+    self->work[n].writers = 1;
 
     return 0;
 }
@@ -148,6 +198,12 @@ int filter_thread_start(filter_thread_t* self)
     }
 
     for (r = self->recv; r; r = r->next) {
+        if (self->use_writers) {
+            if (pthread_create(&r->tid, 0, _thread_writers, (void*)r)) {
+                return 2;
+            }
+            continue;
+        }
         if (pthread_create(&r->tid, 0, _thread, (void*)r)) {
             return 2;
         }
@@ -183,6 +239,39 @@ int filter_thread_stop(filter_thread_t* self)
     return 0;
 }
 
+static int _receive_writers(void* ctx, const core_object_t* obj)
+{
+    filter_thread_t*      self = (filter_thread_t*)ctx;
+    core_object_t*        copy = core_object_copy(obj);
+    filter_thread_work_t* w;
+
+    if (!self || !copy || !self->recv) {
+        return 1;
+    }
+
+    w = &self->work[self->at];
+    pthread_mutex_lock(&w->mutex);
+    w->writers = 1;
+    while (w->obj) {
+        pthread_cond_wait(&w->write, &w->mutex);
+    }
+    w->writers = 0;
+    w->obj     = copy;
+
+    self->at++;
+    if (self->at == self->works)
+        self->at = 0;
+
+    pthread_mutex_lock(&self->work[self->at].mutex);
+    self->work[self->at].writers = 1;
+    pthread_mutex_unlock(&self->work[self->at].mutex);
+
+    pthread_cond_broadcast(&w->read);
+    pthread_mutex_unlock(&w->mutex);
+
+    return 0;
+}
+
 static int _receive(void* ctx, const core_object_t* obj)
 {
     filter_thread_t*      self = (filter_thread_t*)ctx;
@@ -198,7 +287,7 @@ static int _receive(void* ctx, const core_object_t* obj)
     while (w->obj) {
         pthread_cond_wait(&w->write, &w->mutex);
     }
-    w->obj = copy;
+    w->obj     = copy;
     pthread_cond_signal(&w->read);
     pthread_mutex_unlock(&w->mutex);
 
@@ -209,7 +298,10 @@ static int _receive(void* ctx, const core_object_t* obj)
     return 0;
 }
 
-core_receiver_t filter_thread_receiver()
+core_receiver_t filter_thread_receiver(filter_thread_t* self)
 {
+    if (self && self->use_writers) {
+        return _receive_writers;
+    }
     return _receive;
 }

--- a/src/filter/thread.hh
+++ b/src/filter/thread.hh
@@ -26,6 +26,7 @@ typedef struct filter_thread_work {
     core_object_t*  obj;
     pthread_mutex_t mutex;
     pthread_cond_t  read, write;
+    uint8_t         writers;
     char            end;
 } filter_thread_work_t;
 
@@ -37,6 +38,7 @@ typedef struct filter_thread {
 
     filter_thread_work_t* work;
     size_t                works, at;
+    unsigned short use_writers : 1;
 } filter_thread_t;
 
 struct filter_thread_recv {
@@ -55,4 +57,4 @@ int filter_thread_add(filter_thread_t* self, core_receiver_t recv, void* ctx);
 int filter_thread_start(filter_thread_t* self);
 int filter_thread_stop(filter_thread_t* self);
 
-core_receiver_t filter_thread_receiver();
+core_receiver_t filter_thread_receiver(filter_thread_t* self);

--- a/src/filter/thread.lua
+++ b/src/filter/thread.lua
@@ -64,6 +64,21 @@ function Thread:log()
     return self.obj._log
 end
 
+-- Control if writers marker should be used, can improve performance if the
+-- work load in the threads are high.
+function Thread:use_writers(bool)
+    if bool == nil then
+        if self.obj.use_writers == 1 then
+            return true
+        end
+        return false
+    elseif bool == true then
+        self.obj.use_writers = 1
+    else
+        self.obj.use_writers = 0
+    end
+end
+
 -- Start the thread(s), returns 0 on success.
 function Thread:start()
     return C.filter_thread_start(self.obj)
@@ -77,7 +92,7 @@ end
 -- Return the C functions and context for receiving objects.
 function Thread:receive()
     self.obj._log:debug("receive()")
-    return C.filter_thread_receiver(), self.obj
+    return C.filter_thread_receiver(self.obj), self.obj
 end
 
 -- Set the receiver to pass objects to, this can be called multiple times to


### PR DESCRIPTION
- `filter.thread`:
  - Add marker for writers so all readers can move to where data will appear
  - Add `use_writers()` to control this function
- `examples/test_throughput.lua`: Add option `--thread-writers` to enable writers marker