### PR TITLE
Coverity

### DIFF
--- a/src/core/object.c
+++ b/src/core/object.c
@@ -44,6 +44,10 @@ core_object_t* core_object_copy(const core_object_t* obj)
         core_object_pcap_t* pcap = (core_object_pcap_t*)obj;
         core_object_pcap_t* copy = malloc(sizeof(core_object_pcap_t) + pcap->caplen);
 
+        if (!copy) {
+            return 0;
+        }
+
         memcpy(copy, pcap, sizeof(core_object_pcap_t));
         copy->obj_prev = 0;
 

--- a/src/filter/thread.c
+++ b/src/filter/thread.c
@@ -143,7 +143,7 @@ int filter_thread_init(filter_thread_t* self, size_t queue_size)
     for (n = 0; n < self->works; n++) {
         self->work[n] = defwork;
     }
-    self->work[n].writers = 1;
+    self->work[0].writers = 1;
 
     return 0;
 }

--- a/src/input/mmpcap.c
+++ b/src/input/mmpcap.c
@@ -92,6 +92,7 @@ int input_mmpcap_init(input_mmpcap_t* self)
     struct _prod_ctx* ctx = malloc(sizeof(struct _prod_ctx));
 
     if (!self || !ctx) {
+        free(ctx);
         return 1;
     }
 


### PR DESCRIPTION
- `core.object`: Fix CID 279302
- `filter.thread`: Fix CID 279297
- `input.fpcap`: Fix CID 279304, 279298, 279296
- `input.mmpcap`: Fix CID 279303