### PR TITLE
Timing, receiver/producer

### DIFF
--- a/src/filter/layer.c
+++ b/src/filter/layer.c
@@ -642,9 +642,8 @@ static inline int _link(filter_layer_t* self, const core_object_pcap_t* pcap)
     return 0;
 }
 
-static void _receive(void* ctx, const core_object_t* obj)
+static void _receive(filter_layer_t* self, const core_object_t* obj)
 {
-    filter_layer_t* self = (filter_layer_t*)ctx;
     mlassert_self();
     lassert(obj, "obj is nil");
 
@@ -662,12 +661,11 @@ static void _receive(void* ctx, const core_object_t* obj)
 
 core_receiver_t filter_layer_receiver()
 {
-    return _receive;
+    return (core_receiver_t)_receive;
 }
 
-static const core_object_t* _produce(void* ctx)
+static const core_object_t* _produce(filter_layer_t* self)
 {
-    filter_layer_t*      self = (filter_layer_t*)ctx;
     const core_object_t* obj;
     mlassert_self();
 
@@ -687,5 +685,5 @@ core_producer_t filter_layer_producer(filter_layer_t* self)
         lfatal("no producer set");
     }
 
-    return _produce;
+    return (core_producer_t)_produce;
 }

--- a/src/filter/split.c
+++ b/src/filter/split.c
@@ -74,18 +74,16 @@ void filter_split_add(filter_split_t* self, core_receiver_t recv, void* ctx)
     }
 }
 
-static void _roundrobin(void* ctx, const core_object_t* obj)
+static void _roundrobin(filter_split_t* self, const core_object_t* obj)
 {
-    filter_split_t* self = (filter_split_t*)ctx;
     mlassert_self();
 
     self->recv->recv(self->recv->ctx, obj);
     self->recv = self->recv->next;
 }
 
-static void _sendall(void* ctx, const core_object_t* obj)
+static void _sendall(filter_split_t* self, const core_object_t* obj)
 {
-    filter_split_t*      self = (filter_split_t*)ctx;
     filter_split_recv_t* r;
     mlassert_self();
 
@@ -106,9 +104,9 @@ core_receiver_t filter_split_receiver(filter_split_t* self)
 
     switch (self->mode) {
     case FILTER_SPLIT_MODE_ROUNDROBIN:
-        return _roundrobin;
+        return (core_receiver_t)_roundrobin;
     case FILTER_SPLIT_MODE_SENDALL:
-        return _sendall;
+        return (core_receiver_t)_sendall;
     default:
         lfatal("invalid split mode");
     }

--- a/src/filter/timing.h
+++ b/src/filter/timing.h
@@ -20,6 +20,7 @@
 
 #include "core/log.h"
 #include "core/receiver.h"
+#include "core/producer.h"
 
 #ifndef __dnsjit_filter_timing_h
 #define __dnsjit_filter_timing_h

--- a/src/filter/timing.hh
+++ b/src/filter/timing.hh
@@ -20,6 +20,7 @@
 
 //lua:require("dnsjit.core.log")
 //lua:require("dnsjit.core.receiver_h")
+//lua:require("dnsjit.core.producer_h")
 //lua:require("dnsjit.core.timespec_h")
 
 typedef struct filter_timing {
@@ -30,10 +31,14 @@ typedef struct filter_timing {
         TIMING_MODE_KEEP     = 0,
         TIMING_MODE_INCREASE = 1,
         TIMING_MODE_REDUCE   = 2,
-        TIMING_MODE_MULTIPLY = 3
+        TIMING_MODE_MULTIPLY = 3,
+        TIMING_MODE_FIXED    = 4
     } mode;
-    size_t inc, red;
+    size_t inc, red, fixed;
     float  mul;
+
+    core_producer_t prod;
+    void*           prod_ctx;
 } filter_timing_t;
 
 core_log_t* filter_timing_log();
@@ -42,3 +47,4 @@ filter_timing_t* filter_timing_new();
 void filter_timing_free(filter_timing_t* self);
 
 core_receiver_t filter_timing_receiver(filter_timing_t* self);
+core_producer_t filter_timing_producer(filter_timing_t* self);

--- a/src/filter/timing.lua
+++ b/src/filter/timing.lua
@@ -76,6 +76,12 @@ function Timing:multiply(factor)
     self.obj.mul = factor
 end
 
+-- Set the timing mode to a fixed number of nanoseconds between packets.
+function Timing:fixed(ns)
+    self.obj.mode = "TIMING_MODE_FIXED"
+    self.obj.fixed = ns
+end
+
 -- Return the C functions and context for receiving objects.
 function Timing:receive()
     return C.filter_timing_receiver(), self.obj
@@ -85,6 +91,17 @@ end
 function Timing:receiver(o)
     self.obj.recv, self.obj.ctx = o:receive()
     self._receiver = o
+end
+
+-- Return the C functions and context for producing objects.
+function Timing:produce()
+    return C.filter_timing_producer(self.obj), self.obj
+end
+
+-- Set the producer to get objects from.
+function Timing:producer(o)
+    self.obj.prod, self.obj.prod_ctx = o:produce()
+    self._producer = o
 end
 
 return Timing

--- a/src/input/fpcap.c
+++ b/src/input/fpcap.c
@@ -205,9 +205,8 @@ int input_fpcap_run(input_fpcap_t* self)
     return 0;
 }
 
-static const core_object_t* _produce(void* ctx)
+static const core_object_t* _produce(input_fpcap_t* self)
 {
-    input_fpcap_t* self = (input_fpcap_t*)ctx;
     struct {
         uint32_t ts_sec;
         uint32_t ts_usec;
@@ -269,5 +268,5 @@ core_producer_t input_fpcap_producer(input_fpcap_t* self)
         lfatal("no PCAP opened");
     }
 
-    return _produce;
+    return (core_producer_t)_produce;
 }

--- a/src/input/mmpcap.c
+++ b/src/input/mmpcap.c
@@ -220,9 +220,8 @@ int input_mmpcap_run(input_mmpcap_t* self)
     return 0;
 }
 
-static const core_object_t* _produce(void* ctx)
+static const core_object_t* _produce(input_mmpcap_t* self)
 {
-    input_mmpcap_t* self = (input_mmpcap_t*)ctx;
     struct {
         uint32_t ts_sec;
         uint32_t ts_usec;
@@ -287,5 +286,5 @@ core_producer_t input_mmpcap_producer(input_mmpcap_t* self)
         lfatal("no PCAP opened");
     }
 
-    return _produce;
+    return (core_producer_t)_produce;
 }

--- a/src/input/pcap.c
+++ b/src/input/pcap.c
@@ -131,9 +131,8 @@ int input_pcap_dispatch(input_pcap_t* self, int cnt)
     return pcap_dispatch(self->pcap, cnt, _handler, (void*)self);
 }
 
-static const core_object_t* _produce(void* ctx)
+static const core_object_t* _produce(input_pcap_t* self)
 {
-    input_pcap_t*       self = (input_pcap_t*)ctx;
     struct pcap_pkthdr* h;
     const u_char*       bytes;
     int                 ret = 0;
@@ -161,5 +160,5 @@ core_producer_t input_pcap_producer(input_pcap_t* self)
         lfatal("no PCAP opened");
     }
 
-    return _produce;
+    return (core_producer_t)_produce;
 }

--- a/src/output/null.c
+++ b/src/output/null.c
@@ -47,9 +47,8 @@ void output_null_destroy(output_null_t* self)
     mlassert_self();
 }
 
-static void _receive(void* ctx, const core_object_t* obj)
+static void _receive(output_null_t* self, const core_object_t* obj)
 {
-    output_null_t* self = (output_null_t*)ctx;
     mlassert_self();
 
     self->pkts++;
@@ -57,7 +56,7 @@ static void _receive(void* ctx, const core_object_t* obj)
 
 core_receiver_t output_null_receiver()
 {
-    return _receive;
+    return (core_receiver_t)_receive;
 }
 
 void output_null_run(output_null_t* self, int64_t num)

--- a/src/output/respdiff.c
+++ b/src/output/respdiff.c
@@ -177,9 +177,8 @@ void output_respdiff_commit(output_respdiff_t* self, const char* origname, const
 }
 
 #ifdef HAVE_LMDB_H
-static void _receive(void* ctx, const core_object_t* obj)
+static void _receive(output_respdiff_t* self, const core_object_t* obj)
 {
-    output_respdiff_t*           self = (output_respdiff_t*)ctx;
     const core_object_payload_t *query, *original, *response;
     MDB_val                      k, v;
     uint8_t                      responses[132096];
@@ -241,7 +240,7 @@ core_receiver_t output_respdiff_receiver(output_respdiff_t* self)
         lfatal("no LMDB opened");
     }
 
-    return _receive;
+    return (core_receiver_t)_receive;
 }
 #else
 core_receiver_t output_respdiff_receiver(output_respdiff_t* self)

--- a/src/output/tcpcli.c
+++ b/src/output/tcpcli.c
@@ -146,12 +146,11 @@ int output_tcpcli_set_nonblocking(output_tcpcli_t* self, int nonblocking)
     return 0;
 }
 
-static void _receive(void* ctx, const core_object_t* obj)
+static void _receive(output_tcpcli_t* self, const core_object_t* obj)
 {
-    output_tcpcli_t* self = (output_tcpcli_t*)ctx;
-    const uint8_t*   payload;
-    size_t           len, sent;
-    uint16_t         dnslen;
+    const uint8_t* payload;
+    size_t         len, sent;
+    uint16_t       dnslen;
     mlassert_self();
 
     for (; obj;) {
@@ -230,14 +229,13 @@ core_receiver_t output_tcpcli_receiver(output_tcpcli_t* self)
         lfatal("not connected");
     }
 
-    return _receive;
+    return (core_receiver_t)_receive;
 }
 
-static const core_object_t* _produce(void* ctx)
+static const core_object_t* _produce(output_tcpcli_t* self)
 {
-    output_tcpcli_t* self = (output_tcpcli_t*)ctx;
-    ssize_t          n, recv;
-    uint16_t         dnslen;
+    ssize_t  n, recv;
+    uint16_t dnslen;
     mlassert_self();
 
     if (!self->have_dnslen) {
@@ -312,5 +310,5 @@ core_producer_t output_tcpcli_producer(output_tcpcli_t* self)
         lfatal("not connected");
     }
 
-    return _produce;
+    return (core_producer_t)_produce;
 }

--- a/src/output/udpcli.c
+++ b/src/output/udpcli.c
@@ -139,11 +139,10 @@ int output_udpcli_set_nonblocking(output_udpcli_t* self, int nonblocking)
     return 0;
 }
 
-static void _receive(void* ctx, const core_object_t* obj)
+static void _receive(output_udpcli_t* self, const core_object_t* obj)
 {
-    output_udpcli_t* self = (output_udpcli_t*)ctx;
-    const uint8_t*   payload;
-    size_t           len, sent;
+    const uint8_t* payload;
+    size_t         len, sent;
     mlassert_self();
 
     for (; obj;) {
@@ -197,13 +196,12 @@ core_receiver_t output_udpcli_receiver(output_udpcli_t* self)
         lfatal("not connected");
     }
 
-    return _receive;
+    return (core_receiver_t)_receive;
 }
 
-static const core_object_t* _produce(void* ctx)
+static const core_object_t* _produce(output_udpcli_t* self)
 {
-    output_udpcli_t* self = (output_udpcli_t*)ctx;
-    ssize_t          n;
+    ssize_t n;
     mlassert_self();
 
     for (;;) {
@@ -240,5 +238,5 @@ core_producer_t output_udpcli_producer(output_udpcli_t* self)
         lfatal("not connected");
     }
 
-    return _produce;
+    return (core_producer_t)_produce;
 }


### PR DESCRIPTION
- Rework receiver/producer usage
- `filter.timing`:
  - Fix display of nanoseconds
  - Issue #42: Add producer interface
  - Issue #42: Add fixed mode