### PR TITLE
Timeout

### DIFF
--- a/examples/dumpdns-qr.lua
+++ b/examples/dumpdns-qr.lua
@@ -29,14 +29,14 @@ while true do
     local pl = obj:cast()
     if obj:type() == "payload" and pl.len > 0 then
         local transport = obj.obj_prev
-        while transport do
+        while transport ~= nil do
             if transport.obj_type == object.IP or transport.obj_type == object.IP6 then
                 break
             end
             transport = transport.obj_prev
         end
         local protocol = obj.obj_prev
-        while protocol do
+        while protocol ~= nil do
             if protocol.obj_type == object.UDP or protocol.obj_type == object.TCP then
                 break
             end

--- a/examples/dumpdns.lua
+++ b/examples/dumpdns.lua
@@ -21,14 +21,14 @@ while true do
     local pl = obj:cast()
     if obj:type() == "payload" and pl.len > 0 then
         local transport = obj.obj_prev
-        while transport do
+        while transport ~= nil do
             if transport.obj_type == object.IP or transport.obj_type == object.IP6 then
                 break
             end
             transport = transport.obj_prev
         end
         local protocol = obj.obj_prev
-        while protocol do
+        while protocol ~= nil do
             if protocol.obj_type == object.UDP or protocol.obj_type == object.TCP then
                 break
             end

--- a/examples/filter_rcode.lua
+++ b/examples/filter_rcode.lua
@@ -22,7 +22,7 @@ while true do
     local pl = obj:cast()
     if obj:type() == "payload" and pl.len > 0 then
         local transport = obj.obj_prev
-        while transport do
+        while transport ~= nil do
             if transport.obj_type == object.IP or transport.obj_type == object.IP6 then
                 break
             end

--- a/examples/replay.lua
+++ b/examples/replay.lua
@@ -67,15 +67,17 @@ if printdns then
 
                 recv(rctx, obj)
 
-                local resp = nil
-                while resp == nil do
-                    resp = oprod(opctx)
+                local response = oprod(opctx)
+                if response == nil then
+                    log.fatal("producer error")
                 end
-                while resp ~= nil do
+                local payload = response:cast()
+                if payload.len == 0 then
+                    print("timed out")
+                else
                     dns.obj_prev = resp
                     print("response:")
                     dns:print()
-                    resp = oprod(opctx)
                 end
             end
         end

--- a/src/core/object/dns.lua
+++ b/src/core/object/dns.lua
@@ -671,44 +671,52 @@ function Dns:print(num_labels)
     print("", "nscount:", self.nscount)
     print("", "arcount:", self.arcount)
 
-    print("", "questions:")
-    for n = 1, self.qdcount do
-        if C.core_object_dns_parse_q(self, q, labels, num_labels) ~= 0 then
-            return
-        end
-        print("", "", Dns.class_tostring(q.class), Dns.type_tostring(q.type), label.tooffstr(self, labels, num_labels))
-    end
-    print("", "answers:")
-    for n = 1, self.ancount do
-        if C.core_object_dns_parse_rr(self, rr, labels, num_labels) ~= 0 then
-            return
-        end
-        if rr.rdata_labels == 0 then
-            print("", "", Dns.class_tostring(rr.class), Dns.type_tostring(rr.type), rr.ttl, label.tooffstr(self, labels, rr.labels))
-        else
-            print("", "", Dns.class_tostring(rr.class), Dns.type_tostring(rr.type), rr.ttl, label.tooffstr(self, labels, rr.labels), label.tooffstr(self, labels, rr.rdata_labels, rr.labels))
+    if self.qdcount > 0 then
+        print("questions:", "class", "type", "labels")
+        for n = 1, self.qdcount do
+            if C.core_object_dns_parse_q(self, q, labels, num_labels) ~= 0 then
+                return
+            end
+            print("", Dns.class_tostring(q.class), Dns.type_tostring(q.type), label.tooffstr(self, labels, num_labels))
         end
     end
-    print("", "authorities:")
-    for n = 1, self.nscount do
-        if C.core_object_dns_parse_rr(self, rr, labels, num_labels) ~= 0 then
-            return
-        end
-        if rr.rdata_labels == 0 then
-            print("", "", Dns.class_tostring(rr.class), Dns.type_tostring(rr.type), rr.ttl, label.tooffstr(self, labels, rr.labels))
-        else
-            print("", "", Dns.class_tostring(rr.class), Dns.type_tostring(rr.type), rr.ttl, label.tooffstr(self, labels, rr.labels), label.tooffstr(self, labels, rr.rdata_labels, rr.labels))
+    if self.ancount > 0 then
+        print("answers:", "class", "type", "ttl", "labels", "RR labels")
+        for n = 1, self.ancount do
+            if C.core_object_dns_parse_rr(self, rr, labels, num_labels) ~= 0 then
+                return
+            end
+            if rr.rdata_labels == 0 then
+                print("", Dns.class_tostring(rr.class), Dns.type_tostring(rr.type), rr.ttl, label.tooffstr(self, labels, rr.labels))
+            else
+                print("", Dns.class_tostring(rr.class), Dns.type_tostring(rr.type), rr.ttl, label.tooffstr(self, labels, rr.labels), label.tooffstr(self, labels, rr.rdata_labels, rr.labels))
+            end
         end
     end
-    print("", "additionals:")
-    for n = 1, self.arcount do
-        if C.core_object_dns_parse_rr(self, rr, labels, num_labels) ~= 0 then
-            return
+    if self.nscount > 0 then
+        print("authorities:", "class", "type", "ttl", "labels", "RR labels")
+        for n = 1, self.nscount do
+            if C.core_object_dns_parse_rr(self, rr, labels, num_labels) ~= 0 then
+                return
+            end
+            if rr.rdata_labels == 0 then
+                print("", Dns.class_tostring(rr.class), Dns.type_tostring(rr.type), rr.ttl, label.tooffstr(self, labels, rr.labels))
+            else
+                print("", Dns.class_tostring(rr.class), Dns.type_tostring(rr.type), rr.ttl, label.tooffstr(self, labels, rr.labels), label.tooffstr(self, labels, rr.rdata_labels, rr.labels))
+            end
         end
-        if rr.rdata_labels == 0 then
-            print("", "", Dns.class_tostring(rr.class), Dns.type_tostring(rr.type), rr.ttl, label.tooffstr(self, labels, rr.labels))
-        else
-            print("", "", Dns.class_tostring(rr.class), Dns.type_tostring(rr.type), rr.ttl, label.tooffstr(self, labels, rr.labels), label.tooffstr(self, labels, rr.rdata_labels, rr.labels))
+    end
+    if self.arcount > 0 then
+        print("additionals:", "class", "type", "ttl", "labels", "RR labels")
+        for n = 1, self.arcount do
+            if C.core_object_dns_parse_rr(self, rr, labels, num_labels) ~= 0 then
+                return
+            end
+            if rr.rdata_labels == 0 then
+                print("", Dns.class_tostring(rr.class), Dns.type_tostring(rr.type), rr.ttl, label.tooffstr(self, labels, rr.labels))
+            else
+                print("", Dns.class_tostring(rr.class), Dns.type_tostring(rr.type), rr.ttl, label.tooffstr(self, labels, rr.labels), label.tooffstr(self, labels, rr.rdata_labels, rr.labels))
+            end
         end
     end
 end

--- a/src/output/tcpcli.h
+++ b/src/output/tcpcli.h
@@ -22,6 +22,7 @@
 #include "core/receiver.h"
 #include "core/producer.h"
 #include "core/object/payload.h"
+#include "core/timespec.h"
 
 #ifndef __dnsjit_output_tcpcli_h
 #define __dnsjit_output_tcpcli_h

--- a/src/output/tcpcli.hh
+++ b/src/output/tcpcli.hh
@@ -22,17 +22,21 @@
 //lua:require("dnsjit.core.receiver_h")
 //lua:require("dnsjit.core.producer_h")
 //lua:require("dnsjit.core.object.payload_h")
+//lua:require("dnsjit.core.timespec_h")
 
 typedef struct output_tcpcli {
     core_log_t _log;
     size_t     pkts, errs;
     int        fd;
 
-    uint8_t               recvbuf[4 * 1024];
+    uint8_t               recvbuf[64 * 1024];
     core_object_payload_t pkt;
     uint16_t              dnslen;
-    unsigned short        have_dnslen;
-    size_t                recv;
+    uint8_t               have_dnslen;
+    size_t                recv, pkts_recv;
+
+    core_timespec_t timeout;
+    int8_t          blocking;
 } output_tcpcli_t;
 
 core_log_t* output_tcpcli_log();

--- a/src/output/udpcli.h
+++ b/src/output/udpcli.h
@@ -22,6 +22,7 @@
 #include "core/receiver.h"
 #include "core/producer.h"
 #include "core/object/payload.h"
+#include "core/timespec.h"
 
 #ifndef __dnsjit_output_udpcli_h
 #define __dnsjit_output_udpcli_h

--- a/src/output/udpcli.hh
+++ b/src/output/udpcli.hh
@@ -23,6 +23,7 @@
 //lua:require("dnsjit.core.receiver_h")
 //lua:require("dnsjit.core.producer_h")
 //lua:require("dnsjit.core.object.payload_h")
+//lua:require("dnsjit.core.timespec_h")
 
 typedef struct output_udpcli {
     core_log_t _log;
@@ -34,6 +35,10 @@ typedef struct output_udpcli {
 
     uint8_t               recvbuf[4 * 1024];
     core_object_payload_t pkt;
+    size_t                pkts_recv;
+
+    core_timespec_t timeout;
+    int8_t          blocking;
 } output_udpcli_t;
 
 core_log_t* output_udpcli_log();


### PR DESCRIPTION
- `examples/*`: Fix handling of previous objects, need to explicitly check for not nil on cdata
- `examples/replay.lua`: Handle timeouts
- `examples/respdiff.lua`: Handle timeouts
- `examples/test_throughput.lua`: Add tests for splitting in Lua
- `core.object.dns`: Add column names in `print()` for resource records
- `core.output.tcpcli`:
  - Issue #47: Remove DNS query check
  - Add timeout support, see `timeout()`
  - Continue parsing if we received more then needed
  - Add `received()` for the number of payloads received
  - Documentation
- `core.output.udpcli`:
  - Issue #46: Remove DNS query check
  - Add timeout support, see `timeout()`
  - Add `received()` for the number of payloads received
  - Documentation