### PR TITLE
core.log

### DIFF
--- a/src/core/log.hh
+++ b/src/core/log.hh
@@ -27,7 +27,7 @@ typedef struct core_log_settings {
 } core_log_settings_t;
 
 typedef struct core_log {
-    const char*                name;
+    char                       name[32];
     uint8_t                    is_obj;
     core_log_settings_t        settings;
     const core_log_settings_t* module;

--- a/src/core/log.lua
+++ b/src/core/log.lua
@@ -212,10 +212,21 @@ local Log = {}
 -- .I module
 -- Log object.
 function Log.new(name, module)
+    local self
     if ffi.istype(t_name, module) then
-        return core_log_t({ name = name, is_obj = 1, module = module.settings })
+        self = core_log_t({ is_obj = 1, module = module.settings })
+    else
+        self = core_log_t()
     end
-    return core_log_t({ name = name })
+
+    local len = #name
+    if len > 31 then
+        len = 31
+    end
+    ffi.copy(self.name, name, len)
+    self.name[len] = 0
+
+    return self
 end
 
 -- Enable specified log level.


### PR DESCRIPTION
- `core.log`: Fix bug with name, copy instead of referring to it since the variable can disappear