### PR TITLE
Respdiff, fixes, v0.9.6

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -17,10 +17,10 @@
 # along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
 
 AC_PREREQ(2.64)
-AC_INIT([dnsjit], [0.9.5], [admin@dns-oarc.net], [dnsjit], [https://github.com/DNS-OARC/dnsjit/issues])
+AC_INIT([dnsjit], [0.9.6], [admin@dns-oarc.net], [dnsjit], [https://github.com/DNS-OARC/dnsjit/issues])
 AC_DEFINE([PACKAGE_MAJOR_VERSION], [0], [Define to the major version of this package.])
 AC_DEFINE([PACKAGE_MINOR_VERSION], [9], [Define to the minor version of this package.])
-AC_DEFINE([PACKAGE_PATCH_VERSION], [5], [Define to the patch version of this package.])
+AC_DEFINE([PACKAGE_PATCH_VERSION], [6], [Define to the patch version of this package.])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
 AC_CONFIG_SRCDIR([src/dnsjit.c])
 AC_CONFIG_HEADER([src/config.h])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-dnsjit (0.9.5-1~unstable+1) unstable; urgency=low
+dnsjit (0.9.6-1~unstable+1) unstable; urgency=low
 
-  * Alpha release 0.9.5
+  * Alpha release 0.9.6
 
- -- Jerry Lundström <lundstrom.jerry@gmail.com>  Thu, 19 Jul 2018 11:07:58 +0200
+ -- Jerry Lundström <lundstrom.jerry@gmail.com>  Wed, 01 Aug 2018 11:20:22 +0200

--- a/examples/dumpdns-qr.lua
+++ b/examples/dumpdns-qr.lua
@@ -44,7 +44,7 @@ while true do
         end
 
         dns.obj_prev = obj
-        if transport and protocol and dns:parse_header() == 0 then
+        if transport ~= nil and protocol ~= nil and dns:parse_header() == 0 then
             transport = transport:cast()
             protocol = protocol:cast()
 

--- a/examples/dumpdns.lua
+++ b/examples/dumpdns.lua
@@ -36,7 +36,7 @@ while true do
         end
 
         dns.obj_prev = obj
-        if transport and protocol then
+        if transport ~= nil and protocol ~= nil then
             transport = transport:cast()
             protocol = protocol:cast()
             print(protocol:type().." "..transport:source()..":"..tonumber(protocol.sport).." -> "..transport:destination()..":"..tonumber(protocol.dport))

--- a/examples/respdiff.lua
+++ b/examples/respdiff.lua
@@ -80,7 +80,7 @@ while true do
                 protocol = protocol.obj_prev
             end
 
-            if transport and protocol then
+            if transport ~= nil and protocol ~= nil then
                 transport = transport:cast()
                 protocol = protocol:cast()
 

--- a/rpm/dnsjit.spec
+++ b/rpm/dnsjit.spec
@@ -1,5 +1,5 @@
 Name:           dnsjit
-Version:        0.9.5
+Version:        0.9.6
 Release:        1%{?dist}
 Summary:        Engine for capturing, parsing and replaying DNS
 Group:          Productivity/Networking/DNS/Utilities
@@ -55,5 +55,5 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
-* Thu Jul 19 2018 Jerry Lundström <lundstrom.jerry@gmail.com> 0.9.5-1
-- Alpha release 0.9.5
+* Wed Aug 01 2018 Jerry Lundström <lundstrom.jerry@gmail.com> 0.9.6-1
+- Alpha release 0.9.6

--- a/src/output/respdiff.hh
+++ b/src/output/respdiff.hh
@@ -29,7 +29,7 @@ typedef struct output_respdiff {
 } output_respdiff_t;
 
 core_log_t* output_respdiff_log();
-void output_respdiff_init(output_respdiff_t* self, const char* path);
+void output_respdiff_init(output_respdiff_t* self, const char* path, size_t mapsize);
 void output_respdiff_destroy(output_respdiff_t* self);
 void output_respdiff_commit(output_respdiff_t* self, const char* origname, const char* recvname, uint64_t start_time, uint64_t end_time);
 

--- a/src/output/respdiff.lua
+++ b/src/output/respdiff.lua
@@ -48,14 +48,20 @@ local Respdiff = {}
 -- are used to populate the meta table, these names should be the same as
 -- what is configured in
 -- .IR respdiff.cfg .
-function Respdiff.new(path, origname, recvname)
+-- Optional
+-- .I mapsize
+-- can be given to increase the database size beyond the default size of 10MB.
+function Respdiff.new(path, origname, recvname, mapsize)
+    if mapsize == nil then
+        mapsize = 10485760
+    end
     local self = {
         obj = output_respdiff_t(),
         path = path,
         origname = origname,
         recvname = recvname,
     }
-    C.output_respdiff_init(self.obj, path)
+    C.output_respdiff_init(self.obj, path, mapsize)
     ffi.gc(self.obj, C.output_respdiff_destroy)
     return setmetatable(self, { __index = Respdiff })
 end


### PR DESCRIPTION
- `examples`: Fix check of `transport` and `protocol`
- `output.respdiff`:
  - Fix #92: Add option for mapsize (database size)
  - Add fatal information if database is full
- Alpha v0.9.6