### PR TITLE
examples/replay.lua

### DIFF
--- a/examples/replay.lua
+++ b/examples/replay.lua
@@ -75,7 +75,7 @@ if printdns then
                 if payload.len == 0 then
                     print("timed out")
                 else
-                    dns.obj_prev = resp
+                    dns.obj_prev = response
                     print("response:")
                     dns:print()
                 end


### PR DESCRIPTION
Fix typo in variable name when printing responses with -R.