### PR TITLE
Copyright, FreeBSD dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Debian/Ubuntu: `apt-get install libluajit-5.1-dev libpcap-dev luajit liblmdb-dev
 
 CentOS: `yum install luajit-devel libpcap-devel lmdb-devel ck-devel gnutls-devel`
 
-FreeBSD: `pkg install luajit libpcap lmdb gnutls` + manual install of libck
+FreeBSD: `pkg install luajit libpcap lmdb gnutls concurrencykit`
 
 OpenBSD: `pkg_add luajit gnutls` + manual install of libpcap, liblmdb and libck
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -3,7 +3,7 @@ Upstream-Name: dnsjit
 Source: https://github.com/DNS-OARC/dnsjit
 
 Files: *
-Copyright: 2018 OARC, Inc.
+Copyright: 2018-2019 OARC, Inc.
 License: GPLv3
 
 License: GPLv3


### PR DESCRIPTION
- Update copyright (missed in previous commit)
- Fix #105: Use FreeBSD package for concurrency kit