### PR TITLE
output.dnscli

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -104,6 +104,7 @@ AC_CHECK_SIZEOF([ck_ring_buffer_t],,[#if defined(__GNUC__) || defined(__SUNPRO_C
 #include <ck_ring.h>])
 AC_CHECK_SIZEOF([gnutls_session_t],,[#include <gnutls/gnutls.h>])
 AC_CHECK_SIZEOF([gnutls_certificate_credentials_t],,[#include <gnutls/gnutls.h>])
+AC_CHECK_SIZEOF([struct pollfd],,[#include <poll.h>])
 
 # Output Makefiles
 AC_CONFIG_FILES([

--- a/examples/replay_multicli.lua
+++ b/examples/replay_multicli.lua
@@ -1,0 +1,192 @@
+#!/usr/bin/env dnsjit
+local clock = require("dnsjit.lib.clock")
+local log = require("dnsjit.core.log")
+local getopt = require("dnsjit.lib.getopt").new({
+    { "c", "clients", 10, "Number of clients run", "?" },
+    { "v", "verbose", 0, "Enable and increase verbosity for each time given", "?+" },
+    { "R", "responses", false, "Wait for responses to the queries and print both", "?" },
+    { "t", "tcp", false, "Use TCP instead of UDP", "?"},
+    { "T", "tls", false, "Use TLS instead of UDP/TCP", "?"},
+})
+local pcap, host, port = unpack(getopt:parse())
+if getopt:val("help") then
+    getopt:usage()
+    return
+end
+local v = getopt:val("v")
+if v > 0 then
+    log.enable("warning")
+end
+if v > 1 then
+    log.enable("notice")
+end
+if v > 2 then
+    log.enable("info")
+end
+if v > 3 then
+    log.enable("debug")
+end
+
+if pcap == nil or host == nil or port == nil then
+    print("usage: "..arg[1].." <pcap> <host> <port>")
+    return
+end
+
+local ffi = require("ffi")
+
+require("dnsjit.core.objects")
+local input = require("dnsjit.input.mmpcap").new()
+local layer = require("dnsjit.filter.layer").new()
+
+input:open(pcap)
+layer:producer(input)
+
+local query = require("dnsjit.core.object.dns").new()
+local response = require("dnsjit.core.object.dns").new()
+
+local dnscli = require("dnsjit.output.dnscli")
+
+local clients = {}
+local last_client = nil
+local num_clients = getopt:val("c")
+for n = 1, num_clients do
+    local output
+    if getopt:val("t") then
+        output = dnscli.new(dnscli.TCP + dnscli.NONBLOCKING)
+    elseif getopt:val("T") then
+        output = dnscli.new(dnscli.TLS + dnscli.NONBLOCKING)
+    else
+        output = dnscli.new(dnscli.UDP + dnscli.NONBLOCKING)
+    end
+    output:connect(host, port)
+
+    local recv, rctx = output:receive()
+    local prod, pctx = output:produce()
+    local client = {
+        output = output,
+        last = last_client,
+        busy = false,
+        recv = recv, rctx = rctx,
+        prod = prod, pctx = pctx,
+        id = nil,
+        done = false,
+    }
+    table.insert(clients, client)
+    last_client = client
+end
+local output = clients[1]
+output.last = last_client
+
+if getopt:val("t") then
+    response.includes_dnslen = 1
+elseif getopt:val("T") then
+    response.includes_dnslen = 1
+end
+
+local printdns = false
+if getopt:val("responses") then
+    printdns = true
+end
+
+local prod, pctx = layer:produce()
+local start_sec, start_nsec = clock:monotonic()
+
+local done = false
+while true do
+    output = output.last
+    if printdns and output.busy then
+        local pobj = output.prod(output.pctx)
+        if pobj == nil then
+            log.fatal("producer error")
+        end
+        local rpl = pobj:cast()
+        if rpl.len == 0 then
+            -- print(output, "busy")
+        else
+            response.obj_prev = pobj
+            if response:parse_header() == 0 and response.qr == 1 and response.id == output.id then
+                print("response:")
+                response:print()
+                output.busy = false
+            end
+        end
+    end
+    if not output.busy then
+        while true do
+            local obj = prod(pctx)
+            if obj == nil then
+                done = true
+                break
+            end
+            local pl = obj:cast()
+            if obj:type() == "payload" and pl.len > 0 then
+                query.obj_prev = obj
+
+                local trs = pl.obj_prev:cast()
+                if trs:type() == "tcp" then
+                    query.includes_dnslen = 1
+                else
+                    query.includes_dnslen = 0
+                end
+
+                if query:parse_header() == 0 and query.qr == 0 then
+                    output.recv(output.rctx, query:uncast())
+                    if printdns then
+                        print("query:")
+                        query:print()
+                        output.busy = true
+                        output.id = query.id
+                    end
+                    break
+                end
+            end
+        end
+    end
+    if done then break end
+end
+
+local queries, timeouts, errors = 0, 0, 0
+done = 0
+while true do
+    output = output.last
+    if printdns and output.busy then
+        local pobj = output.prod(output.pctx)
+        if pobj == nil then
+            log.fatal("producer error")
+        end
+        local rpl = pobj:cast()
+        if rpl.len == 0 then
+            -- print(output, "busy")
+        else
+            response.obj_prev = pobj
+            if response:parse_header() == 0 and response.qr == 1 and response.id == output.id then
+                print("response:")
+                response:print()
+                output.busy = false
+            end
+        end
+    end
+    if not output.busy and not output.done then
+        output.done = true
+        done = done + 1
+        queries = queries + output.output:packets()
+        timeouts = timeouts + output.output:timeouts()
+        errors = errors + output.output:errors()
+    end
+    if done >= num_clients then break end
+end
+
+local end_sec, end_nsec = clock:monotonic()
+
+local runtime = 0
+if end_sec > start_sec then
+    runtime = ((end_sec - start_sec) - 1) + ((1000000000 - start_nsec + end_nsec)/1000000000)
+elseif end_sec == start_sec and end_nsec > start_nsec then
+    runtime = (end_nsec - start_nsec) / 1000000000
+end
+
+print("runtime", runtime)
+print("packets", input:packets(), input:packets()/runtime, "/pps")
+print("queries", queries, queries/runtime, "/qps")
+print("timeouts", timeouts)
+print("errors", errors)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -41,16 +41,16 @@ lua_objects = core.luao lib.luao input.luao filter.luao output.luao
 dnsjit_LDADD = $(PTHREAD_LIBS) $(luajit_LIBS)
 
 # C source and headers
-dnsjit_SOURCES += core/producer.c core/log.c core/receiver.c core/object.c core/object/ip.c core/object/tcp.c core/object/pcap.c core/object/dns.c core/object/icmp6.c core/object/ieee802.c core/object/udp.c core/object/payload.c core/object/loop.c core/object/ip6.c core/object/gre.c core/object/linuxsll.c core/object/icmp.c core/object/null.c core/object/ether.c core/channel.c core/thread.c core/compat.c lib/clock.c input/zero.c input/pcap.c input/fpcap.c input/mmpcap.c filter/split.c filter/timing.c filter/layer.c output/udpcli.c output/respdiff.c output/tcpcli.c output/tlscli.c output/null.c
-dist_dnsjit_SOURCES += core/receiver.h core/channel.h core/assert.h core/object.h core/log.h core/timespec.h core/producer.h core/object/icmp.h core/object/ip.h core/object/loop.h core/object/dns.h core/object/ip6.h core/object/null.h core/object/tcp.h core/object/payload.h core/object/udp.h core/object/icmp6.h core/object/ether.h core/object/pcap.h core/object/ieee802.h core/object/linuxsll.h core/object/gre.h core/thread.h lib/clock.h input/zero.h input/fpcap.h input/pcap.h input/mmpcap.h filter/split.h filter/layer.h filter/timing.h output/respdiff.h output/null.h output/tlscli.h output/tcpcli.h output/udpcli.h
+dnsjit_SOURCES += core/producer.c core/compat.c core/channel.c core/object/pcap.c core/object/loop.c core/object/ether.c core/object/dns.c core/object/payload.c core/object/null.c core/object/ip6.c core/object/gre.c core/object/icmp.c core/object/icmp6.c core/object/ieee802.c core/object/linuxsll.c core/object/udp.c core/object/ip.c core/object/tcp.c core/log.c core/receiver.c core/object.c core/thread.c lib/clock.c input/pcap.c input/mmpcap.c input/fpcap.c input/zero.c filter/layer.c filter/split.c filter/timing.c output/tlscli.c output/tcpcli.c output/udpcli.c output/null.c output/respdiff.c output/dnscli.c
+dist_dnsjit_SOURCES += core/object.h core/producer.h core/channel.h core/object/icmp.h core/object/icmp6.h core/object/pcap.h core/object/gre.h core/object/ip.h core/object/linuxsll.h core/object/payload.h core/object/udp.h core/object/ether.h core/object/tcp.h core/object/null.h core/object/ip6.h core/object/dns.h core/object/loop.h core/object/ieee802.h core/thread.h core/receiver.h core/assert.h core/timespec.h core/log.h lib/clock.h input/pcap.h input/zero.h input/mmpcap.h input/fpcap.h filter/layer.h filter/timing.h filter/split.h output/dnscli.h output/null.h output/tlscli.h output/tcpcli.h output/respdiff.h output/udpcli.h
 
 # Lua headers
-dist_dnsjit_SOURCES += core/channel.hh core/timespec.hh core/thread.hh core/object/loop.hh core/object/gre.hh core/object/linuxsll.hh core/object/tcp.hh core/object/ether.hh core/object/icmp.hh core/object/ieee802.hh core/object/ip6.hh core/object/udp.hh core/object/dns.hh core/object/pcap.hh core/object/payload.hh core/object/icmp6.hh core/object/ip.hh core/object/null.hh core/producer.hh core/receiver.hh core/object.hh core/log.hh lib/clock.hh input/zero.hh input/mmpcap.hh input/pcap.hh input/fpcap.hh filter/layer.hh filter/timing.hh filter/split.hh output/tlscli.hh output/udpcli.hh output/respdiff.hh output/tcpcli.hh output/null.hh
-lua_hobjects += core/channel.luaho core/timespec.luaho core/thread.luaho core/object/loop.luaho core/object/gre.luaho core/object/linuxsll.luaho core/object/tcp.luaho core/object/ether.luaho core/object/icmp.luaho core/object/ieee802.luaho core/object/ip6.luaho core/object/udp.luaho core/object/dns.luaho core/object/pcap.luaho core/object/payload.luaho core/object/icmp6.luaho core/object/ip.luaho core/object/null.luaho core/producer.luaho core/receiver.luaho core/object.luaho core/log.luaho lib/clock.luaho input/zero.luaho input/mmpcap.luaho input/pcap.luaho input/fpcap.luaho filter/layer.luaho filter/timing.luaho filter/split.luaho output/tlscli.luaho output/udpcli.luaho output/respdiff.luaho output/tcpcli.luaho output/null.luaho
+dist_dnsjit_SOURCES += core/log.hh core/receiver.hh core/producer.hh core/object/linuxsll.hh core/object/udp.hh core/object/icmp.hh core/object/ip6.hh core/object/loop.hh core/object/null.hh core/object/ieee802.hh core/object/ip.hh core/object/ether.hh core/object/tcp.hh core/object/icmp6.hh core/object/gre.hh core/object/pcap.hh core/object/dns.hh core/object/payload.hh core/thread.hh core/timespec.hh core/channel.hh core/object.hh lib/clock.hh input/mmpcap.hh input/fpcap.hh input/pcap.hh input/zero.hh filter/layer.hh filter/split.hh filter/timing.hh output/dnscli.hh output/udpcli.hh output/respdiff.hh output/null.hh output/tcpcli.hh output/tlscli.hh
+lua_hobjects += core/log.luaho core/receiver.luaho core/producer.luaho core/object/linuxsll.luaho core/object/udp.luaho core/object/icmp.luaho core/object/ip6.luaho core/object/loop.luaho core/object/null.luaho core/object/ieee802.luaho core/object/ip.luaho core/object/ether.luaho core/object/tcp.luaho core/object/icmp6.luaho core/object/gre.luaho core/object/pcap.luaho core/object/dns.luaho core/object/payload.luaho core/thread.luaho core/timespec.luaho core/channel.luaho core/object.luaho lib/clock.luaho input/mmpcap.luaho input/fpcap.luaho input/pcap.luaho input/zero.luaho filter/layer.luaho filter/split.luaho filter/timing.luaho output/dnscli.luaho output/udpcli.luaho output/respdiff.luaho output/null.luaho output/tcpcli.luaho output/tlscli.luaho
 
 # Lua sources
-dist_dnsjit_SOURCES += core/channel.lua core/log.lua core/timespec.lua core/compat.lua core/producer.lua core/objects.lua core/thread.lua core/object/pcap.lua core/object/icmp6.lua core/object/gre.lua core/object/ether.lua core/object/dns/q.lua core/object/dns/label.lua core/object/dns/rr.lua core/object/ip.lua core/object/ieee802.lua core/object/tcp.lua core/object/payload.lua core/object/ip6.lua core/object/linuxsll.lua core/object/null.lua core/object/loop.lua core/object/icmp.lua core/object/dns.lua core/object/udp.lua core/receiver.lua core/object.lua lib/getopt.lua lib/clock.lua lib/parseconf.lua input/fpcap.lua input/pcap.lua input/zero.lua input/mmpcap.lua filter/timing.lua filter/split.lua filter/layer.lua output/tcpcli.lua output/respdiff.lua output/tlscli.lua output/null.lua output/udpcli.lua
-lua_objects += core/channel.luao core/log.luao core/timespec.luao core/compat.luao core/producer.luao core/objects.luao core/thread.luao core/object/pcap.luao core/object/icmp6.luao core/object/gre.luao core/object/ether.luao core/object/dns/q.luao core/object/dns/label.luao core/object/dns/rr.luao core/object/ip.luao core/object/ieee802.luao core/object/tcp.luao core/object/payload.luao core/object/ip6.luao core/object/linuxsll.luao core/object/null.luao core/object/loop.luao core/object/icmp.luao core/object/dns.luao core/object/udp.luao core/receiver.luao core/object.luao lib/getopt.luao lib/clock.luao lib/parseconf.luao input/fpcap.luao input/pcap.luao input/zero.luao input/mmpcap.luao filter/timing.luao filter/split.luao filter/layer.luao output/tcpcli.luao output/respdiff.luao output/tlscli.luao output/null.luao output/udpcli.luao
+dist_dnsjit_SOURCES += core/objects.lua core/object/null.lua core/object/icmp.lua core/object/payload.lua core/object/icmp6.lua core/object/ieee802.lua core/object/ip6.lua core/object/tcp.lua core/object/ip.lua core/object/loop.lua core/object/linuxsll.lua core/object/udp.lua core/object/dns/label.lua core/object/dns/q.lua core/object/dns/rr.lua core/object/pcap.lua core/object/ether.lua core/object/dns.lua core/object/gre.lua core/thread.lua core/channel.lua core/log.lua core/compat.lua core/object.lua core/timespec.lua core/producer.lua core/receiver.lua lib/parseconf.lua lib/getopt.lua lib/clock.lua input/zero.lua input/fpcap.lua input/pcap.lua input/mmpcap.lua filter/timing.lua filter/layer.lua filter/split.lua output/null.lua output/udpcli.lua output/tcpcli.lua output/tlscli.lua output/dnscli.lua output/respdiff.lua
+lua_objects += core/objects.luao core/object/null.luao core/object/icmp.luao core/object/payload.luao core/object/icmp6.luao core/object/ieee802.luao core/object/ip6.luao core/object/tcp.luao core/object/ip.luao core/object/loop.luao core/object/linuxsll.luao core/object/udp.luao core/object/dns/label.luao core/object/dns/q.luao core/object/dns/rr.luao core/object/pcap.luao core/object/ether.luao core/object/dns.luao core/object/gre.luao core/thread.luao core/channel.luao core/log.luao core/compat.luao core/object.luao core/timespec.luao core/producer.luao core/receiver.luao lib/parseconf.luao lib/getopt.luao lib/clock.luao input/zero.luao input/fpcap.luao input/pcap.luao input/mmpcap.luao filter/timing.luao filter/layer.luao filter/split.luao output/null.luao output/udpcli.luao output/tcpcli.luao output/tlscli.luao output/dnscli.luao output/respdiff.luao
 
 dnsjit_LDFLAGS = -Wl,-E
 dnsjit_LDADD += $(lua_hobjects) $(lua_objects)
@@ -60,7 +60,7 @@ man1_MANS = dnsjit.1
 CLEANFILES += $(man1_MANS)
 
 man3_MANS = dnsjit.core.3 dnsjit.lib.3 dnsjit.input.3 dnsjit.filter.3 dnsjit.output.3
-man3_MANS += dnsjit.core.channel.3 dnsjit.core.log.3 dnsjit.core.timespec.3 dnsjit.core.compat.3 dnsjit.core.producer.3 dnsjit.core.objects.3 dnsjit.core.thread.3 dnsjit.core.object.pcap.3 dnsjit.core.object.icmp6.3 dnsjit.core.object.gre.3 dnsjit.core.object.ether.3 dnsjit.core.object.dns.q.3 dnsjit.core.object.dns.label.3 dnsjit.core.object.dns.rr.3 dnsjit.core.object.ip.3 dnsjit.core.object.ieee802.3 dnsjit.core.object.tcp.3 dnsjit.core.object.payload.3 dnsjit.core.object.ip6.3 dnsjit.core.object.linuxsll.3 dnsjit.core.object.null.3 dnsjit.core.object.loop.3 dnsjit.core.object.icmp.3 dnsjit.core.object.dns.3 dnsjit.core.object.udp.3 dnsjit.core.receiver.3 dnsjit.core.object.3 dnsjit.lib.getopt.3 dnsjit.lib.clock.3 dnsjit.lib.parseconf.3 dnsjit.input.fpcap.3 dnsjit.input.pcap.3 dnsjit.input.zero.3 dnsjit.input.mmpcap.3 dnsjit.filter.timing.3 dnsjit.filter.split.3 dnsjit.filter.layer.3 dnsjit.output.tcpcli.3 dnsjit.output.respdiff.3 dnsjit.output.tlscli.3 dnsjit.output.null.3 dnsjit.output.udpcli.3
+man3_MANS += dnsjit.core.objects.3 dnsjit.core.object.null.3 dnsjit.core.object.icmp.3 dnsjit.core.object.payload.3 dnsjit.core.object.icmp6.3 dnsjit.core.object.ieee802.3 dnsjit.core.object.ip6.3 dnsjit.core.object.tcp.3 dnsjit.core.object.ip.3 dnsjit.core.object.loop.3 dnsjit.core.object.linuxsll.3 dnsjit.core.object.udp.3 dnsjit.core.object.dns.label.3 dnsjit.core.object.dns.q.3 dnsjit.core.object.dns.rr.3 dnsjit.core.object.pcap.3 dnsjit.core.object.ether.3 dnsjit.core.object.dns.3 dnsjit.core.object.gre.3 dnsjit.core.thread.3 dnsjit.core.channel.3 dnsjit.core.log.3 dnsjit.core.compat.3 dnsjit.core.object.3 dnsjit.core.timespec.3 dnsjit.core.producer.3 dnsjit.core.receiver.3 dnsjit.lib.parseconf.3 dnsjit.lib.getopt.3 dnsjit.lib.clock.3 dnsjit.input.zero.3 dnsjit.input.fpcap.3 dnsjit.input.pcap.3 dnsjit.input.mmpcap.3 dnsjit.filter.timing.3 dnsjit.filter.layer.3 dnsjit.filter.split.3 dnsjit.output.null.3 dnsjit.output.udpcli.3 dnsjit.output.tcpcli.3 dnsjit.output.tlscli.3 dnsjit.output.dnscli.3 dnsjit.output.respdiff.3
 CLEANFILES += *.3in $(man3_MANS)
 
 .lua.luao:
@@ -113,86 +113,89 @@ dnsjit.filter.3in: filter.lua gen-manpage.lua
 dnsjit.output.3in: output.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output.lua" > "$@"
 
+dnsjit.core.objects.3in: core/objects.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/objects.lua" > "$@"
+
+dnsjit.core.object.null.3in: core/object/null.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/null.lua" > "$@"
+
+dnsjit.core.object.icmp.3in: core/object/icmp.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/icmp.lua" > "$@"
+
+dnsjit.core.object.payload.3in: core/object/payload.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/payload.lua" > "$@"
+
+dnsjit.core.object.icmp6.3in: core/object/icmp6.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/icmp6.lua" > "$@"
+
+dnsjit.core.object.ieee802.3in: core/object/ieee802.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/ieee802.lua" > "$@"
+
+dnsjit.core.object.ip6.3in: core/object/ip6.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/ip6.lua" > "$@"
+
+dnsjit.core.object.tcp.3in: core/object/tcp.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/tcp.lua" > "$@"
+
+dnsjit.core.object.ip.3in: core/object/ip.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/ip.lua" > "$@"
+
+dnsjit.core.object.loop.3in: core/object/loop.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/loop.lua" > "$@"
+
+dnsjit.core.object.linuxsll.3in: core/object/linuxsll.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/linuxsll.lua" > "$@"
+
+dnsjit.core.object.udp.3in: core/object/udp.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/udp.lua" > "$@"
+
+dnsjit.core.object.dns.label.3in: core/object/dns/label.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/dns/label.lua" > "$@"
+
+dnsjit.core.object.dns.q.3in: core/object/dns/q.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/dns/q.lua" > "$@"
+
+dnsjit.core.object.dns.rr.3in: core/object/dns/rr.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/dns/rr.lua" > "$@"
+
+dnsjit.core.object.pcap.3in: core/object/pcap.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/pcap.lua" > "$@"
+
+dnsjit.core.object.ether.3in: core/object/ether.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/ether.lua" > "$@"
+
+dnsjit.core.object.dns.3in: core/object/dns.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/dns.lua" > "$@"
+
+dnsjit.core.object.gre.3in: core/object/gre.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/gre.lua" > "$@"
+
+dnsjit.core.thread.3in: core/thread.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/thread.lua" > "$@"
+
 dnsjit.core.channel.3in: core/channel.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/channel.lua" > "$@"
 
 dnsjit.core.log.3in: core/log.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/log.lua" > "$@"
 
-dnsjit.core.timespec.3in: core/timespec.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/timespec.lua" > "$@"
-
 dnsjit.core.compat.3in: core/compat.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/compat.lua" > "$@"
+
+dnsjit.core.object.3in: core/object.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object.lua" > "$@"
+
+dnsjit.core.timespec.3in: core/timespec.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/timespec.lua" > "$@"
 
 dnsjit.core.producer.3in: core/producer.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/producer.lua" > "$@"
 
-dnsjit.core.objects.3in: core/objects.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/objects.lua" > "$@"
-
-dnsjit.core.thread.3in: core/thread.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/thread.lua" > "$@"
-
-dnsjit.core.object.pcap.3in: core/object/pcap.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/pcap.lua" > "$@"
-
-dnsjit.core.object.icmp6.3in: core/object/icmp6.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/icmp6.lua" > "$@"
-
-dnsjit.core.object.gre.3in: core/object/gre.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/gre.lua" > "$@"
-
-dnsjit.core.object.ether.3in: core/object/ether.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/ether.lua" > "$@"
-
-dnsjit.core.object.dns.q.3in: core/object/dns/q.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/dns/q.lua" > "$@"
-
-dnsjit.core.object.dns.label.3in: core/object/dns/label.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/dns/label.lua" > "$@"
-
-dnsjit.core.object.dns.rr.3in: core/object/dns/rr.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/dns/rr.lua" > "$@"
-
-dnsjit.core.object.ip.3in: core/object/ip.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/ip.lua" > "$@"
-
-dnsjit.core.object.ieee802.3in: core/object/ieee802.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/ieee802.lua" > "$@"
-
-dnsjit.core.object.tcp.3in: core/object/tcp.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/tcp.lua" > "$@"
-
-dnsjit.core.object.payload.3in: core/object/payload.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/payload.lua" > "$@"
-
-dnsjit.core.object.ip6.3in: core/object/ip6.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/ip6.lua" > "$@"
-
-dnsjit.core.object.linuxsll.3in: core/object/linuxsll.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/linuxsll.lua" > "$@"
-
-dnsjit.core.object.null.3in: core/object/null.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/null.lua" > "$@"
-
-dnsjit.core.object.loop.3in: core/object/loop.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/loop.lua" > "$@"
-
-dnsjit.core.object.icmp.3in: core/object/icmp.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/icmp.lua" > "$@"
-
-dnsjit.core.object.dns.3in: core/object/dns.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/dns.lua" > "$@"
-
-dnsjit.core.object.udp.3in: core/object/udp.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/udp.lua" > "$@"
-
 dnsjit.core.receiver.3in: core/receiver.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/receiver.lua" > "$@"
 
-dnsjit.core.object.3in: core/object.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object.lua" > "$@"
+dnsjit.lib.parseconf.3in: lib/parseconf.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/lib/parseconf.lua" > "$@"
 
 dnsjit.lib.getopt.3in: lib/getopt.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/lib/getopt.lua" > "$@"
@@ -200,8 +203,8 @@ dnsjit.lib.getopt.3in: lib/getopt.lua gen-manpage.lua
 dnsjit.lib.clock.3in: lib/clock.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/lib/clock.lua" > "$@"
 
-dnsjit.lib.parseconf.3in: lib/parseconf.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/lib/parseconf.lua" > "$@"
+dnsjit.input.zero.3in: input/zero.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/input/zero.lua" > "$@"
 
 dnsjit.input.fpcap.3in: input/fpcap.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/input/fpcap.lua" > "$@"
@@ -209,32 +212,32 @@ dnsjit.input.fpcap.3in: input/fpcap.lua gen-manpage.lua
 dnsjit.input.pcap.3in: input/pcap.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/input/pcap.lua" > "$@"
 
-dnsjit.input.zero.3in: input/zero.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/input/zero.lua" > "$@"
-
 dnsjit.input.mmpcap.3in: input/mmpcap.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/input/mmpcap.lua" > "$@"
 
 dnsjit.filter.timing.3in: filter/timing.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/filter/timing.lua" > "$@"
 
-dnsjit.filter.split.3in: filter/split.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/filter/split.lua" > "$@"
-
 dnsjit.filter.layer.3in: filter/layer.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/filter/layer.lua" > "$@"
 
-dnsjit.output.tcpcli.3in: output/tcpcli.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output/tcpcli.lua" > "$@"
-
-dnsjit.output.respdiff.3in: output/respdiff.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output/respdiff.lua" > "$@"
-
-dnsjit.output.tlscli.3in: output/tlscli.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output/tlscli.lua" > "$@"
+dnsjit.filter.split.3in: filter/split.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/filter/split.lua" > "$@"
 
 dnsjit.output.null.3in: output/null.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output/null.lua" > "$@"
 
 dnsjit.output.udpcli.3in: output/udpcli.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output/udpcli.lua" > "$@"
+
+dnsjit.output.tcpcli.3in: output/tcpcli.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output/tcpcli.lua" > "$@"
+
+dnsjit.output.tlscli.3in: output/tlscli.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output/tlscli.lua" > "$@"
+
+dnsjit.output.dnscli.3in: output/dnscli.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output/dnscli.lua" > "$@"
+
+dnsjit.output.respdiff.3in: output/respdiff.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output/respdiff.lua" > "$@"

--- a/src/core/object/dns.c
+++ b/src/core/object/dns.c
@@ -165,6 +165,10 @@ int core_object_dns_parse_header(core_object_dns_t* self)
     self->len = self->left = payload->len;
 
     for (;;) {
+        if (self->includes_dnslen) {
+            need16(self->dnslen, self->at, self->left);
+            self->have_dnslen = 1;
+        }
         need16(self->id, self->at, self->left);
         self->have_id = 1;
 

--- a/src/core/object/dns.h
+++ b/src/core/object/dns.h
@@ -29,13 +29,13 @@
 
 #include "core/object/dns.hh"
 
-#define CORE_OBJECT_DNS_INIT(prev)                       \
-    {                                                    \
-        CORE_OBJECT_INIT(CORE_OBJECT_DNS, prev)          \
-        ,                                                \
-            0, 0, 0, 0,                                  \
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+#define CORE_OBJECT_DNS_INIT(prev)                          \
+    {                                                       \
+        CORE_OBJECT_INIT(CORE_OBJECT_DNS, prev)             \
+        ,                                                   \
+            0, 0, 0, 0, 0,                                  \
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
     }
 
 /*

--- a/src/core/object/dns.hh
+++ b/src/core/object/dns.hh
@@ -68,9 +68,11 @@ typedef struct core_object_dns {
     const core_object_t* obj_prev;
     int32_t              obj_type;
 
+    int            includes_dnslen;
     const uint8_t *payload, *at;
     size_t         len, left;
 
+    uint8_t have_dnslen;
     uint8_t have_id;
     uint8_t have_qr;
     uint8_t have_opcode;
@@ -87,6 +89,7 @@ typedef struct core_object_dns {
     uint8_t have_nscount;
     uint8_t have_arcount;
 
+    uint16_t dnslen;
     uint16_t id;
     int8_t   qr;
     uint8_t  opcode;

--- a/src/core/object/dns.lua
+++ b/src/core/object/dns.lua
@@ -43,6 +43,13 @@
 -- The object that describes a DNS message.
 -- .SS Attributes
 -- .TP
+-- includes_dnslen
+-- If non-zero then this indicates that the DNS length is included in the
+-- payload (for example if the transport is TCP) and will affect parsing of it.
+-- .TP
+-- have_dnslen
+-- Set if the dnslen was included in the payload and could be read.
+-- .TP
 -- have_id
 -- Set if there is a DNS ID.
 -- .TP
@@ -87,6 +94,9 @@
 -- .TP
 -- have_arcount
 -- Set if there is an ARCOUNT.
+-- .TP
+-- dnslen
+-- The DNS length found in the payload.
 -- .TP
 -- id
 -- The DNS ID.

--- a/src/gen-compat.lua
+++ b/src/gen-compat.lua
@@ -10,7 +10,7 @@ for line in io.lines("config.h") do
             print("typedef struct "..n:sub(1,-3).." { uint64_t a["..s.."]; } "..n..";")
         elseif n:match("^STRUCT") then
             n = n:match("^STRUCT_(%S*)")
-            if n == "SOCKADDR_STORAGE" then
+            if n == "SOCKADDR_STORAGE" or n == "POLLFD" then
                 print("#if !defined(SIZEOF_STRUCT_"..n..") || SIZEOF_STRUCT_"..n.." == 0")
                 print("#error \""..n.." is undefined or zero\"")
                 print("#endif")

--- a/src/gen-makefile.sh
+++ b/src/gen-makefile.sh
@@ -44,18 +44,18 @@ dnsjit_LDADD = $(PTHREAD_LIBS) $(luajit_LIBS)
 
 # C source and headers';
 
-echo "dnsjit_SOURCES +=`find core lib input filter output -type f -name '*.c' -printf ' %p'`"
-echo "dist_dnsjit_SOURCES +=`find core lib input filter output -type f -name '*.h' -printf ' %p'`"
+echo "dnsjit_SOURCES +=`find core lib input filter output -type f -name '*.c' -printf ' %p'|sort`"
+echo "dist_dnsjit_SOURCES +=`find core lib input filter output -type f -name '*.h' -printf ' %p'|sort`"
 
 echo '
 # Lua headers'
-echo "dist_dnsjit_SOURCES +=`find core lib input filter output -type f -name '*.hh' -printf ' %p'`"
-echo "lua_hobjects +=`find core lib input filter output -type f -name '*.hh' -printf ' %p'|sed -e 's%.hh%.luaho%g'`"
+echo "dist_dnsjit_SOURCES +=`find core lib input filter output -type f -name '*.hh' -printf ' %p'|sort`"
+echo "lua_hobjects +=`find core lib input filter output -type f -name '*.hh' -printf ' %p'|sed -e 's%.hh%.luaho%g'|sort`"
 
 echo '
 # Lua sources'
-echo "dist_dnsjit_SOURCES +=`find core lib input filter output -type f -name '*.lua' -printf ' %p'`"
-echo "lua_objects +=`find core lib input filter output -type f -name '*.lua' -printf ' %p '|sed -e 's%.lua %.luao%g'`"
+echo "dist_dnsjit_SOURCES +=`find core lib input filter output -type f -name '*.lua' -printf ' %p'|sort`"
+echo "lua_objects +=`find core lib input filter output -type f -name '*.lua' -printf ' %p '|sed -e 's%.lua %.luao%g'|sort`"
 
 echo '
 dnsjit_LDFLAGS = -Wl,-E
@@ -66,7 +66,7 @@ man1_MANS = dnsjit.1
 CLEANFILES += $(man1_MANS)
 
 man3_MANS = dnsjit.core.3 dnsjit.lib.3 dnsjit.input.3 dnsjit.filter.3 dnsjit.output.3';
-echo "man3_MANS +=`find core lib input filter output -type f -name '*.lua' -printf ' dnsjit.%p'|sed -e 's%.lua%.3%g'|sed -e 's%/%.%g'`"
+echo "man3_MANS +=`find core lib input filter output -type f -name '*.lua' -printf ' dnsjit.%p'|sed -e 's%.lua%.3%g'|sed -e 's%/%.%g'|sort`"
 
 echo 'CLEANFILES += *.3in $(man3_MANS)
 

--- a/src/output.lua
+++ b/src/output.lua
@@ -23,6 +23,7 @@
 -- replay them against other targets.
 module(...,package.seeall)
 
+-- dnsjit.output.dnscli (3),
 -- dnsjit.output.null (3),
 -- dnsjit.output.respdiff (3),
 -- dnsjit.output.tcpcli (3),

--- a/src/output/dnscli.c
+++ b/src/output/dnscli.c
@@ -1,0 +1,888 @@
+/*
+ * Copyright (c) 2018-2019, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "output/dnscli.h"
+#include "core/assert.h"
+#include "core/object/dns.h"
+#include "core/object/payload.h"
+#include "core/object/udp.h"
+#include "core/object/tcp.h"
+
+#include <netdb.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <string.h>
+#ifdef HAVE_ENDIAN_H
+#include <endian.h>
+#else
+#ifdef HAVE_SYS_ENDIAN_H
+#include <sys/endian.h>
+#else
+#ifdef HAVE_MACHINE_ENDIAN_H
+#include <machine/endian.h>
+#endif
+#endif
+#endif
+#ifdef HAVE_BYTESWAP_H
+#include <byteswap.h>
+#endif
+#ifndef bswap_16
+#ifndef bswap16
+#define bswap_16(x) swap16(x)
+#define bswap_32(x) swap32(x)
+#define bswap_64(x) swap64(x)
+#else
+#define bswap_16(x) bswap16(x)
+#define bswap_32(x) bswap32(x)
+#define bswap_64(x) bswap64(x)
+#endif
+#endif
+
+static inline uint16_t _need16(const void* ptr)
+{
+    uint16_t v;
+    memcpy(&v, ptr, sizeof(v));
+    return be16toh(v);
+}
+
+static core_log_t      _log      = LOG_T_INIT("output.dnscli");
+static output_dnscli_t _defaults = {
+    LOG_T_INIT_OBJ("output.dnscli"),
+    OUTPUT_DNSCLI_MODE_NONE,
+    0, 0, 0, -1, 0, 0,
+    { 0, 0, 0 }, 0,
+    { 0 }, 0,
+    { 0 }, CORE_OBJECT_PAYLOAD_INIT(0), 0, 0, 0, 0, 0,
+    { 0, 0 },
+    0, 0
+};
+
+core_log_t* output_dnscli_log()
+{
+    return &_log;
+}
+
+void output_dnscli_init(output_dnscli_t* self, output_dnscli_mode_t mode)
+{
+    mlassert_self();
+
+    *self             = _defaults;
+    self->mode        = mode;
+    self->pkt.payload = self->recvbuf;
+
+    switch (mode & OUTPUT_DNSCLI_MODE_MODES) {
+    case OUTPUT_DNSCLI_MODE_UDP:
+    case OUTPUT_DNSCLI_MODE_TCP:
+        break;
+    case OUTPUT_DNSCLI_MODE_TLS: {
+        int err;
+        if ((err = gnutls_certificate_allocate_credentials(&self->cred)) != GNUTLS_E_SUCCESS) {
+            lfatal("gnutls_certificate_allocate_credentials() error: %s", gnutls_strerror(err));
+        } else if ((err = gnutls_init(&self->session, GNUTLS_CLIENT | ((mode & OUTPUT_DNSCLI_MODE_NONBLOCKING) ? GNUTLS_NONBLOCK : 0))) != GNUTLS_E_SUCCESS) {
+            lfatal("gnutls_init() error: %s", gnutls_strerror(err));
+        } else if ((err = gnutls_set_default_priority(self->session)) != GNUTLS_E_SUCCESS) {
+            lfatal("gnutls_set_default_priority() error: %s", gnutls_strerror(err));
+        } else if ((err = gnutls_credentials_set(self->session, GNUTLS_CRD_CERTIFICATE, self->cred)) != GNUTLS_E_SUCCESS) {
+            lfatal("gnutls_credentials_set() error: %s", gnutls_strerror(err));
+        }
+
+        gnutls_handshake_set_timeout(self->session, GNUTLS_DEFAULT_HANDSHAKE_TIMEOUT);
+        break;
+    }
+    default:
+        lfatal("Invalid mode %x", mode);
+    }
+}
+
+void output_dnscli_destroy(output_dnscli_t* self)
+{
+    mlassert_self();
+
+    if (self->fd > -1) {
+        switch (self->mode & OUTPUT_DNSCLI_MODE_MODES) {
+        case OUTPUT_DNSCLI_MODE_UDP:
+        case OUTPUT_DNSCLI_MODE_TCP:
+            shutdown(self->fd, SHUT_RDWR);
+            close(self->fd);
+            break;
+        case OUTPUT_DNSCLI_MODE_TLS:
+            if (self->session) {
+                gnutls_bye(self->session, GNUTLS_SHUT_RDWR);
+                gnutls_deinit(self->session);
+            }
+            shutdown(self->fd, SHUT_RDWR);
+            close(self->fd);
+            if (self->cred) {
+                gnutls_certificate_free_credentials(self->cred);
+            }
+            break;
+        default:
+            break;
+        }
+    }
+}
+
+int output_dnscli_connect(output_dnscli_t* self, const char* host, const char* port)
+{
+    struct addrinfo* addr;
+    int              err;
+    mlassert_self();
+    lassert(host, "host is nil");
+    lassert(port, "port is nil");
+
+    if (self->fd > -1) {
+        lfatal("already connected");
+    }
+
+    if ((err = getaddrinfo(host, port, 0, &addr))) {
+        lcritical("getaddrinfo(%s, %s) error %s", host, port, gai_strerror(err));
+        return -1;
+    }
+    if (!addr) {
+        lcritical("getaddrinfo failed, no address returned");
+        return -1;
+    }
+
+    switch (self->mode & OUTPUT_DNSCLI_MODE_MODES) {
+    case OUTPUT_DNSCLI_MODE_UDP:
+        memcpy(&self->addr, addr->ai_addr, addr->ai_addrlen);
+        self->addr_len = addr->ai_addrlen;
+        freeaddrinfo(addr);
+
+        if ((self->fd = socket(((struct sockaddr*)&self->addr)->sa_family, SOCK_DGRAM, 0)) < 0) {
+            lcritical("socket() error %s", core_log_errstr(errno));
+            return -2;
+        }
+        break;
+    case OUTPUT_DNSCLI_MODE_TCP:
+    case OUTPUT_DNSCLI_MODE_TLS:
+        if ((self->fd = socket(addr->ai_addr->sa_family, SOCK_STREAM, 0)) < 0) {
+            lcritical("socket() error %s", core_log_errstr(errno));
+            freeaddrinfo(addr);
+            return -2;
+        }
+
+        if (connect(self->fd, addr->ai_addr, addr->ai_addrlen)) {
+            lcritical("connect() error %s", core_log_errstr(errno));
+            freeaddrinfo(addr);
+            return -2;
+        }
+
+        freeaddrinfo(addr);
+        break;
+    default:
+        break;
+    }
+
+    switch (self->mode & OUTPUT_DNSCLI_MODE_MODES) {
+    case OUTPUT_DNSCLI_MODE_UDP:
+    case OUTPUT_DNSCLI_MODE_TCP:
+        if (self->mode & OUTPUT_DNSCLI_MODE_NONBLOCKING) {
+            int flags;
+
+            if ((flags = fcntl(self->fd, F_GETFL)) == -1) {
+                lcritical("fcntl(FL_GETFL) error %s", core_log_errstr(errno));
+                return -3;
+            }
+
+            if (fcntl(self->fd, F_SETFL, flags | O_NONBLOCK)) {
+                lcritical("fcntl(FL_SETFL, %x) error %s", flags, core_log_errstr(errno));
+                return -3;
+            }
+            self->nonblocking = 1;
+        }
+        if (self->timeout.sec > 0 || self->timeout.nsec > 0) {
+            self->poll.fd      = self->fd;
+            self->poll_timeout = (self->timeout.sec * 1e3) + (self->timeout.nsec / 1e6);
+            if (!self->poll_timeout) {
+                self->poll_timeout = 1;
+            }
+        }
+        break;
+    case OUTPUT_DNSCLI_MODE_TLS: {
+        unsigned int ms;
+        gnutls_transport_set_int(self->session, self->fd);
+        ms = (self->timeout.sec * 1000) + (self->timeout.nsec / 1000000);
+        if (!ms && self->timeout.nsec) {
+            ms = 1;
+        }
+        gnutls_record_set_timeout(self->session, ms);
+
+        /* Establish TLS */
+        do {
+            err = gnutls_handshake(self->session);
+        } while (err < 0 && gnutls_error_is_fatal(err) == 0);
+        if (err == GNUTLS_E_PREMATURE_TERMINATION) {
+            lcritical("gnutls_handshake() error: %s", gnutls_strerror(err));
+            return -3;
+        } else if (err < 0) {
+            lcritical("gnutls_handshake() failed: %s (%d)\n", gnutls_strerror(err), err);
+            return -3;
+        }
+        break;
+    }
+    default:
+        break;
+    }
+
+    self->conn_ok = 1;
+    return 0;
+}
+
+inline ssize_t _send_udp(output_dnscli_t* self, const uint8_t* payload, size_t len, size_t sent)
+{
+    ssize_t n;
+
+    if (self->poll_timeout) {
+        self->poll.events = POLLOUT;
+        n                 = poll(&self->poll, 1, self->poll_timeout);
+        if (n != 1 || !(self->poll.revents & POLLOUT)) {
+            if (!n) {
+                self->timeouts++;
+                return -1;
+            }
+            self->errs++;
+            return -2;
+        }
+    }
+    n = sendto(self->fd, payload + sent, len - sent, 0, (struct sockaddr*)&self->addr, self->addr_len);
+    if (n > -1) {
+        return n;
+    }
+    switch (errno) {
+    case EAGAIN:
+#if EAGAIN != EWOULDBLOCK
+    case EWOULDBLOCK:
+#endif
+    case EINTR:
+        return -1;
+    default:
+        break;
+    }
+    return -2;
+}
+
+static void _receive_udp(output_dnscli_t* self, const core_object_t* obj)
+{
+    const uint8_t* payload;
+    size_t         len, sent = 0;
+    ssize_t        n;
+    mlassert_self();
+
+    switch (obj->obj_type) {
+    case CORE_OBJECT_DNS:
+        payload = ((core_object_dns_t*)obj)->payload;
+        len     = ((core_object_dns_t*)obj)->len;
+
+        if (((core_object_dns_t*)obj)->includes_dnslen) {
+            if (len < 2) {
+                return;
+            }
+            payload += 2;
+            len -= 2;
+        }
+        break;
+    case CORE_OBJECT_PAYLOAD:
+        payload = ((core_object_payload_t*)obj)->payload;
+        len     = ((core_object_payload_t*)obj)->len;
+        break;
+    default:
+        return;
+    }
+
+    for (;;) {
+        n = _send_udp(self, payload, len, sent);
+        if (n > -1) {
+            sent += n;
+            if (sent < len) {
+                continue;
+            }
+            self->pkts++;
+            return;
+        }
+        if (n == -1) {
+            if (self->nonblocking) {
+                // TODO: warn?
+                return;
+            }
+            continue;
+        }
+        break;
+    }
+    self->errs++;
+}
+
+inline ssize_t _send_tcp(output_dnscli_t* self, const uint8_t* payload, size_t len, size_t sent)
+{
+    ssize_t n;
+
+    if (self->poll_timeout) {
+        self->poll.events = POLLOUT;
+        n                 = poll(&self->poll, 1, self->poll_timeout);
+        if (n != 1 || !(self->poll.revents & POLLOUT)) {
+            if (!n) {
+                self->timeouts++;
+                return -1;
+            }
+            self->errs++;
+            return -2;
+        }
+    }
+    n = sendto(self->fd, payload + sent, len - sent, 0, 0, 0);
+    if (n > -1) {
+        return n;
+    }
+    switch (errno) {
+    case EAGAIN:
+#if EAGAIN != EWOULDBLOCK
+    case EWOULDBLOCK:
+#endif
+    case EINTR:
+        return -1;
+    default:
+        break;
+    }
+    return -2;
+}
+
+static void _receive_tcp(output_dnscli_t* self, const core_object_t* obj)
+{
+    const uint8_t* payload;
+    size_t         len, sent = 0;
+    ssize_t        n;
+    mlassert_self();
+
+    switch (obj->obj_type) {
+    case CORE_OBJECT_DNS:
+        if (!((core_object_dns_t*)obj)->includes_dnslen) {
+            uint16_t dnslen = htons(((core_object_dns_t*)obj)->len);
+            payload         = (const uint8_t*)&dnslen;
+            len             = sizeof(dnslen);
+
+            for (;;) {
+                n = _send_tcp(self, payload, len, sent);
+                if (n > -1) {
+                    sent += n;
+                    if (sent < len) {
+                        continue;
+                    }
+                    break;
+                }
+                if (n == -1) {
+                    if (self->nonblocking) {
+                        // TODO: warn?
+                        return;
+                    }
+                    continue;
+                }
+                self->errs++;
+                return;
+            }
+            sent = 0;
+        }
+        payload = ((core_object_dns_t*)obj)->payload;
+        len     = ((core_object_dns_t*)obj)->len;
+        break;
+    case CORE_OBJECT_PAYLOAD:
+        payload = ((core_object_payload_t*)obj)->payload;
+        len     = ((core_object_payload_t*)obj)->len;
+        break;
+    default:
+        return;
+    }
+
+    for (;;) {
+        n = _send_tcp(self, payload, len, sent);
+        if (n > -1) {
+            sent += n;
+            if (sent < len) {
+                continue;
+            }
+            self->pkts++;
+            return;
+        }
+        if (n == -1) {
+            if (self->nonblocking) {
+                // TODO: warn?
+                return;
+            }
+            continue;
+        }
+        break;
+    }
+    self->errs++;
+}
+
+inline ssize_t _send_tls(output_dnscli_t* self, const uint8_t* payload, size_t len, size_t sent)
+{
+    ssize_t n;
+
+    n = gnutls_record_send(self->session, payload + sent, len - sent);
+    if (n > -1) {
+        return n;
+    }
+    switch (n) {
+    case GNUTLS_E_AGAIN:
+    case GNUTLS_E_TIMEDOUT:
+    case GNUTLS_E_INTERRUPTED:
+        return -1;
+    default:
+        break;
+    }
+    return -2;
+}
+
+static void _receive_tls(output_dnscli_t* self, const core_object_t* obj)
+{
+    const uint8_t* payload;
+    size_t         len, sent = 0;
+    ssize_t        n;
+    mlassert_self();
+
+    switch (obj->obj_type) {
+    case CORE_OBJECT_DNS:
+        if (!((core_object_dns_t*)obj)->includes_dnslen) {
+            uint16_t dnslen = htons(((core_object_dns_t*)obj)->len);
+            payload         = (const uint8_t*)&dnslen;
+            len             = sizeof(dnslen);
+
+            for (;;) {
+                n = _send_tls(self, payload, len, sent);
+                if (n > -1) {
+                    sent += n;
+                    if (sent < len) {
+                        continue;
+                    }
+                    break;
+                }
+                if (n == -1) {
+                    if (self->nonblocking) {
+                        // TODO: warn?
+                        return;
+                    }
+                    continue;
+                }
+                self->errs++;
+                return;
+            }
+            sent = 0;
+        }
+        payload = ((core_object_dns_t*)obj)->payload;
+        len     = ((core_object_dns_t*)obj)->len;
+        break;
+    case CORE_OBJECT_PAYLOAD:
+        payload = ((core_object_payload_t*)obj)->payload;
+        len     = ((core_object_payload_t*)obj)->len;
+        break;
+    default:
+        return;
+    }
+
+    for (;;) {
+        n = _send_tls(self, payload, len, sent);
+        if (n > -1) {
+            sent += n;
+            if (sent < len) {
+                continue;
+            }
+            self->pkts++;
+            return;
+        }
+        if (n == -1) {
+            if (self->nonblocking) {
+                // TODO: warn?
+                return;
+            }
+            continue;
+        }
+        break;
+    }
+    self->errs++;
+}
+
+ssize_t output_dnscli_send(output_dnscli_t* self, const core_object_t* obj, size_t sent)
+{
+    const uint8_t* payload;
+    size_t         len;
+    uint16_t       dnslen;
+    mlassert_self();
+
+    switch (self->mode & OUTPUT_DNSCLI_MODE_MODES) {
+    case OUTPUT_DNSCLI_MODE_UDP:
+        switch (obj->obj_type) {
+        case CORE_OBJECT_DNS:
+            payload = ((core_object_dns_t*)obj)->payload;
+            len     = ((core_object_dns_t*)obj)->len;
+
+            if (((core_object_dns_t*)obj)->includes_dnslen) {
+                if (len < 2) {
+                    return -2;
+                }
+                payload += 2;
+                len -= 2;
+            }
+            break;
+        case CORE_OBJECT_PAYLOAD:
+            payload = ((core_object_payload_t*)obj)->payload;
+            len     = ((core_object_payload_t*)obj)->len;
+            break;
+        default:
+            return -2;
+        }
+
+        return _send_udp(self, payload, len, sent);
+
+    case OUTPUT_DNSCLI_MODE_TCP:
+        switch (obj->obj_type) {
+        case CORE_OBJECT_DNS:
+            if (!((core_object_dns_t*)obj)->includes_dnslen) {
+                if (sent < sizeof(dnslen)) {
+                    dnslen  = htons(((core_object_dns_t*)obj)->len);
+                    payload = (const uint8_t*)&dnslen;
+                    len     = sizeof(dnslen);
+
+                    return _send_tcp(self, payload, len, sent);
+                }
+                sent -= sizeof(dnslen);
+            }
+            payload = ((core_object_dns_t*)obj)->payload;
+            len     = ((core_object_dns_t*)obj)->len;
+            break;
+        case CORE_OBJECT_PAYLOAD:
+            payload = ((core_object_payload_t*)obj)->payload;
+            len     = ((core_object_payload_t*)obj)->len;
+            break;
+        default:
+            return -2;
+        }
+
+        return _send_tcp(self, payload, len, sent);
+
+    case OUTPUT_DNSCLI_MODE_TLS:
+        switch (obj->obj_type) {
+        case CORE_OBJECT_DNS:
+            if (!((core_object_dns_t*)obj)->includes_dnslen) {
+                if (sent < sizeof(dnslen)) {
+                    dnslen  = htons(((core_object_dns_t*)obj)->len);
+                    payload = (const uint8_t*)&dnslen;
+                    len     = sizeof(dnslen);
+
+                    return _send_tls(self, payload, len, sent);
+                }
+                sent -= sizeof(dnslen);
+            }
+            payload = ((core_object_dns_t*)obj)->payload;
+            len     = ((core_object_dns_t*)obj)->len;
+            break;
+        case CORE_OBJECT_PAYLOAD:
+            payload = ((core_object_payload_t*)obj)->payload;
+            len     = ((core_object_payload_t*)obj)->len;
+            break;
+        default:
+            return -2;
+        }
+
+        return _send_tls(self, payload, len, sent);
+
+    default:
+        break;
+    }
+
+    return -2;
+}
+
+core_receiver_t output_dnscli_receiver(output_dnscli_t* self)
+{
+    mlassert_self();
+
+    if (!self->conn_ok) {
+        lfatal("not connected");
+    }
+
+    switch (self->mode & OUTPUT_DNSCLI_MODE_MODES) {
+    case OUTPUT_DNSCLI_MODE_UDP:
+        return (core_receiver_t)_receive_udp;
+    case OUTPUT_DNSCLI_MODE_TCP:
+        return (core_receiver_t)_receive_tcp;
+    case OUTPUT_DNSCLI_MODE_TLS:
+        return (core_receiver_t)_receive_tls;
+    default:
+        break;
+    }
+
+    lfatal("internal error");
+    return 0;
+}
+
+static const core_object_t* _produce_udp(output_dnscli_t* self)
+{
+    ssize_t n;
+    mlassert_self();
+
+    for (;;) {
+        if (self->poll_timeout) {
+            self->poll.events = POLLIN;
+            n                 = poll(&self->poll, 1, self->poll_timeout);
+            if (n != 1 || !(self->poll.revents & POLLIN)) {
+                if (!n) {
+                    self->timeouts++;
+                    self->pkt.len = 0;
+                    return (core_object_t*)&self->pkt;
+                } else {
+                    self->errs++;
+                }
+                return 0;
+            }
+        }
+        n = recvfrom(self->fd, self->recvbuf, sizeof(self->recvbuf), 0, 0, 0);
+        if (n > -1) {
+            break;
+        }
+        switch (errno) {
+        case EAGAIN:
+#if EAGAIN != EWOULDBLOCK
+        case EWOULDBLOCK:
+#endif
+        case EINTR:
+            if (self->nonblocking) {
+                self->pkt.len = 0;
+                return (core_object_t*)&self->pkt;
+            }
+            continue;
+        default:
+            break;
+        }
+        self->errs++;
+        break;
+    }
+
+    if (n < 1) {
+        return 0;
+    }
+
+    self->pkts_recv++;
+    self->pkt.len = n;
+    return (core_object_t*)&self->pkt;
+}
+
+static const core_object_t* _produce_tcp(output_dnscli_t* self)
+{
+    ssize_t n;
+    mlassert_self();
+
+    if (self->have_pkt) {
+        if (self->recv > self->dnslen + sizeof(self->dnslen)) {
+            self->recv -= self->dnslen + sizeof(self->dnslen);
+            memmove(self->recvbuf, self->recvbuf + self->dnslen + sizeof(self->dnslen), self->recv);
+        } else {
+            self->recv = 0;
+        }
+        self->have_pkt    = 0;
+        self->have_dnslen = 0;
+    }
+
+    if (!self->have_dnslen && self->recv >= sizeof(self->dnslen)) {
+        self->dnslen      = _need16(self->recvbuf);
+        self->have_dnslen = 1;
+    }
+    if (self->have_dnslen && self->recv >= self->dnslen + sizeof(self->dnslen)) {
+        self->pkts_recv++;
+        self->pkt.len  = self->dnslen + sizeof(self->dnslen);
+        self->have_pkt = 1;
+        return (core_object_t*)&self->pkt;
+    }
+
+    for (;;) {
+        if (self->poll_timeout) {
+            self->poll.events = POLLIN;
+            n                 = poll(&self->poll, 1, self->poll_timeout);
+            if (n != 1 || !(self->poll.revents & POLLIN)) {
+                if (!n) {
+                    self->timeouts++;
+                    self->pkt.len = 0;
+                    return (core_object_t*)&self->pkt;
+                } else {
+                    self->errs++;
+                }
+                return 0;
+            }
+        }
+        n = recvfrom(self->fd, self->recvbuf + self->recv, sizeof(self->recvbuf) - self->recv, 0, 0, 0);
+        if (n > 0) {
+            self->recv += n;
+
+            if (!self->have_dnslen && self->recv >= sizeof(self->dnslen)) {
+                self->dnslen      = _need16(self->recvbuf);
+                self->have_dnslen = 1;
+            }
+            if (self->have_dnslen && self->recv >= self->dnslen + sizeof(self->dnslen)) {
+                self->pkts_recv++;
+                self->pkt.len  = self->dnslen + sizeof(self->dnslen);
+                self->have_pkt = 1;
+                return (core_object_t*)&self->pkt;
+            }
+
+            if (self->nonblocking) {
+                break;
+            }
+            continue;
+        }
+        if (!n) {
+            break;
+        }
+        switch (errno) {
+        case EAGAIN:
+#if EAGAIN != EWOULDBLOCK
+        case EWOULDBLOCK:
+#endif
+        case EINTR:
+            if (self->nonblocking) {
+                self->pkt.len = 0;
+                return (core_object_t*)&self->pkt;
+            }
+            continue;
+        default:
+            break;
+        }
+        self->errs++;
+        break;
+    }
+
+    if (n < 1) {
+        return 0;
+    }
+
+    self->pkt.len = 0;
+    return (core_object_t*)&self->pkt;
+}
+
+static const core_object_t* _produce_tls(output_dnscli_t* self)
+{
+    ssize_t n;
+    mlassert_self();
+
+    if (self->have_pkt) {
+        if (self->recv > self->dnslen + sizeof(self->dnslen)) {
+            self->recv -= self->dnslen + sizeof(self->dnslen);
+            memmove(self->recvbuf, self->recvbuf + self->dnslen + sizeof(self->dnslen), self->recv);
+        } else {
+            self->recv = 0;
+        }
+        self->have_pkt    = 0;
+        self->have_dnslen = 0;
+    }
+
+    if (!self->have_dnslen && self->recv >= sizeof(self->dnslen)) {
+        self->dnslen      = _need16(self->recvbuf);
+        self->have_dnslen = 1;
+    }
+    if (self->have_dnslen && self->recv >= self->dnslen + sizeof(self->dnslen)) {
+        self->pkts_recv++;
+        self->pkt.len  = self->dnslen + sizeof(self->dnslen);
+        self->have_pkt = 1;
+        return (core_object_t*)&self->pkt;
+    }
+
+    for (;;) {
+        if (!gnutls_record_check_pending(self->session) && self->poll_timeout) {
+            self->poll.events = POLLIN;
+            n                 = poll(&self->poll, 1, self->poll_timeout);
+            if (n != 1 || !(self->poll.revents & POLLIN)) {
+                if (!n) {
+                    self->timeouts++;
+                    self->pkt.len = 0;
+                    return (core_object_t*)&self->pkt;
+                } else {
+                    self->errs++;
+                }
+                return 0;
+            }
+        }
+        n = gnutls_record_recv(self->session, self->recvbuf + self->recv, sizeof(self->recvbuf) - self->recv);
+        if (n > 0) {
+            self->recv += n;
+
+            if (!self->have_dnslen && self->recv >= sizeof(self->dnslen)) {
+                self->dnslen      = _need16(self->recvbuf);
+                self->have_dnslen = 1;
+            }
+            if (self->have_dnslen && self->recv >= self->dnslen + sizeof(self->dnslen)) {
+                self->pkts_recv++;
+                self->pkt.len  = self->dnslen + sizeof(self->dnslen);
+                self->have_pkt = 1;
+                return (core_object_t*)&self->pkt;
+            }
+
+            if (self->nonblocking) {
+                break;
+            }
+            continue;
+        }
+        if (!n) {
+            break;
+        }
+        switch (n) {
+        case GNUTLS_E_AGAIN:
+        case GNUTLS_E_TIMEDOUT:
+        case GNUTLS_E_INTERRUPTED:
+            if (self->nonblocking) {
+                self->pkt.len = 0;
+                return (core_object_t*)&self->pkt;
+            }
+            continue;
+        default:
+            break;
+        }
+        self->errs++;
+        break;
+    }
+
+    if (n < 1) {
+        return 0;
+    }
+
+    self->pkt.len = 0;
+    return (core_object_t*)&self->pkt;
+}
+
+core_producer_t output_dnscli_producer(output_dnscli_t* self)
+{
+    mlassert_self();
+
+    if (!self->conn_ok) {
+        lfatal("not connected");
+    }
+
+    switch (self->mode & OUTPUT_DNSCLI_MODE_MODES) {
+    case OUTPUT_DNSCLI_MODE_UDP:
+        return (core_producer_t)_produce_udp;
+    case OUTPUT_DNSCLI_MODE_TCP:
+        return (core_producer_t)_produce_tcp;
+    case OUTPUT_DNSCLI_MODE_TLS:
+        return (core_producer_t)_produce_tls;
+    default:
+        break;
+    }
+
+    lfatal("internal error");
+    return 0;
+}

--- a/src/output/dnscli.h
+++ b/src/output/dnscli.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018-2019, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "core/log.h"
+#include "core/receiver.h"
+#include "core/producer.h"
+#include "core/object/payload.h"
+#include "core/timespec.h"
+
+#ifndef __dnsjit_output_dnscli_h
+#define __dnsjit_output_dnscli_h
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <gnutls/gnutls.h>
+#include <poll.h>
+
+#include "output/dnscli.hh"
+
+#endif

--- a/src/output/dnscli.hh
+++ b/src/output/dnscli.hh
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2018-2019, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//lua:require("dnsjit.core.compat_h")
+//lua:require("dnsjit.core.log")
+//lua:require("dnsjit.core.receiver_h")
+//lua:require("dnsjit.core.producer_h")
+//lua:require("dnsjit.core.object.payload_h")
+//lua:require("dnsjit.core.timespec_h")
+
+typedef enum output_dnscli_mode {
+    OUTPUT_DNSCLI_MODE_NONE        = 0,
+    OUTPUT_DNSCLI_MODE_OPTIONS     = 0xf,
+    OUTPUT_DNSCLI_MODE_NONBLOCKING = 0x1,
+    OUTPUT_DNSCLI_MODE_MODES       = 0xf0,
+    OUTPUT_DNSCLI_MODE_UDP         = 0x10,
+    OUTPUT_DNSCLI_MODE_TCP         = 0x20,
+    OUTPUT_DNSCLI_MODE_TLS         = 0x30,
+} output_dnscli_mode_t;
+
+typedef struct output_dnscli {
+    core_log_t _log;
+
+    output_dnscli_mode_t mode;
+
+    size_t pkts, errs, timeouts;
+    int    fd, nonblocking, conn_ok;
+
+    struct pollfd poll;
+    int           poll_timeout;
+
+    struct sockaddr_storage addr;
+    size_t                  addr_len;
+
+    uint8_t               recvbuf[(64 * 1024) + 2];
+    core_object_payload_t pkt;
+    uint16_t              dnslen;
+    uint8_t               have_dnslen, have_pkt;
+    size_t                recv, pkts_recv;
+
+    core_timespec_t timeout;
+
+    gnutls_session_t                 session;
+    gnutls_certificate_credentials_t cred;
+} output_dnscli_t;
+
+core_log_t* output_dnscli_log();
+
+void output_dnscli_init(output_dnscli_t* self, output_dnscli_mode_t mode);
+void output_dnscli_destroy(output_dnscli_t* self);
+int output_dnscli_connect(output_dnscli_t* self, const char* host, const char* port);
+ssize_t output_dnscli_send(output_dnscli_t* self, const core_object_t* obj, size_t sent);
+
+core_receiver_t output_dnscli_receiver(output_dnscli_t* self);
+core_producer_t output_dnscli_producer(output_dnscli_t* self);

--- a/src/output/dnscli.lua
+++ b/src/output/dnscli.lua
@@ -1,0 +1,187 @@
+-- Copyright (c) 2018-2019, OARC, Inc.
+-- All rights reserved.
+--
+-- This file is part of dnsjit.
+--
+-- dnsjit is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- dnsjit is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+
+-- dnsjit.output.dnscli
+-- DNS aware UDP/TCP/TLS client
+--   local dnscli = require("dnsjit.output.dnscli")
+-- .SS UDP Receiver Chain
+--   local output = dnscli.new(dnscli.UDP)
+--   output:connect("127.0.0.1", "53")
+--   input:receiver(output)
+-- .SS TCP Nonblocking
+--   local output = dnscli.new(dnscli.TCP + dnscli.NONBLOCKING)
+--   output:send(object)
+--
+-- The DNS client can a
+-- .I core.object.dns
+-- or a
+-- .I core.object.payload
+-- object via the receiver interface or using
+-- .I send()
+-- and send it as DNS query after which it can receive the response by using
+-- the producer interface.
+-- If the object being sent is a
+-- .I core.object.dns
+-- then it will look at
+-- .I includes_dnslen
+-- attribute and depending on the protocol it will disregard, include or send
+-- the DNS length as an extra packet.
+-- If the object being sent is a
+-- .I core.object.payload
+-- then no special handling will be done and it will be sent as is.
+-- When receiving responses the producer interface will generate
+-- .I core.object.payload
+-- objects which may include the DNS length depending on the protocol used and
+-- must be handled by the caller.
+-- .SS MODES
+-- These transport modes and options are available when creating a new Dnscli
+-- output.
+-- .TP
+-- UDP
+-- Create an output using UDP.
+-- .TP
+-- TCP
+-- Create an output using TCP.
+-- .TP
+-- TLS
+-- Create an output using TCP and encrypt it with TLS.
+-- .TP
+-- NONBLOCKING
+-- Make the client nonblocking, see
+-- .I send()
+-- and
+-- .IR produce() .
+module(...,package.seeall)
+
+require("dnsjit.output.dnscli_h")
+local ffi = require("ffi")
+local C = ffi.C
+
+local t_name = "output_dnscli_t"
+local output_dnscli_t = ffi.typeof(t_name)
+local Dnscli = {
+    NONBLOCKING = 0x1,
+    UDP = 0x10,
+    TCP = 0x20,
+    TLS = 0x30,
+}
+
+-- Create a new Dnscli output.
+function Dnscli.new(mode)
+    local self = {
+        obj = output_dnscli_t(),
+    }
+    C.output_dnscli_init(self.obj, mode)
+    ffi.gc(self.obj, C.output_dnscli_destroy)
+    return setmetatable(self, { __index = Dnscli })
+end
+
+-- Set or return the timeout used for sending and reciving, must be used before
+-- .IR connect() .
+function Dnscli:timeout(seconds, nanoseconds)
+    if seconds == nil and nanoseconds == nil then
+        return self.obj.timeout
+    end
+    if nanoseconds == nil then
+        nanoseconds = 0
+    end
+    self.obj.timeout.sec = seconds
+    self.obj.timeout.nsec = nanoseconds
+end
+
+-- Connect to the
+-- .I host
+-- and
+-- .I port
+-- and return 0 if successful.
+function Dnscli:connect(host, port)
+    return C.output_dnscli_connect(self.obj, host, port)
+end
+
+-- Return if nonblocking mode is on (true) or off (false).
+function Dnscli:nonblocking()
+    if self.obj.nonblocking == 1 then
+        return true
+    end
+    return false
+end
+
+-- Send an object and optionally continue sending after
+-- .I sent
+-- bytes.
+-- Unlike the receive interface this function lets you know if the sending was
+-- successful or not which might be needed on nonblocking connections.
+-- Returns -2 on error, -1 if interrupted, timed out or unable to send due to
+-- nonblocking, or the number of bytes sent.
+-- .B Note
+-- the counters for sent, received, errors and timeouts are not affected by
+-- this function.
+function Dnscli:send(object, sent)
+    if sent == nil then
+        sent = 0
+    end
+    return C.output_dnscli_send(self.obj, object, sent)
+end
+
+-- Return the C functions and context for receiving objects, these objects
+-- will be sent.
+function Dnscli:receive()
+    return C.output_dnscli_receiver(self.obj), self.obj
+end
+
+-- Return the C functions and context for producing objects, these objects
+-- are received.
+-- If nonblocking mode is enabled the producer will return a payload object
+-- with length zero if there was nothing to receive.
+-- If nonblocking mode is disabled the producer will wait for data and if
+-- timed out (see
+-- .IR timeout )
+-- it will return a payload object with length zero.
+-- The producer returns nil on error.
+function Dnscli:produce()
+    return C.output_dnscli_producer(self.obj), self.obj
+end
+
+-- Return the number of "packets" sent, actually the number of completely sent
+-- payloads.
+function Dnscli:packets()
+    return tonumber(self.obj.pkts)
+end
+
+-- Return the number of "packets" received, actually the number of successful
+-- calls to
+-- .IR recvfrom (2)
+-- that returned data.
+function Dnscli:received()
+    return tonumber(self.obj.pkts_recv)
+end
+
+-- Return the number of errors when sending or receiving.
+function Dnscli:errors()
+    return tonumber(self.obj.errs)
+end
+
+-- Return the number of timeouts when sending or receiving.
+function Dnscli:timeouts()
+    return tonumber(self.obj.timeouts)
+end
+
+-- core.object.dns (3),
+-- core.object.payload (3),
+-- core.timespec (3)
+return Dnscli


### PR DESCRIPTION
- Add `output.dnscli`, a DNS aware UDP/TCP/TLS client
- `examples/replay.lua`: Use `output.dnscli`
- Add `examples/replay_multicli.lua`, example of replay using multiple non-blocking sockets
- `core.object.dns`: Add marker if DNS length is included in the payload (as with TCP)
- `core.compat`: Add `struct pollfd`
- `gen-makefile.sh`: Sort find to minimize changes after each run