### PR TITLE
PCAP link type

### DIFF
--- a/src/input/fpcap.hh
+++ b/src/input/fpcap.hh
@@ -46,6 +46,8 @@ typedef struct input_fpcap {
     uint32_t sigfigs;
     uint32_t snaplen;
     uint32_t network;
+
+    uint32_t linktype;
 } input_fpcap_t;
 
 core_log_t* input_fpcap_log();

--- a/src/input/fpcap.lua
+++ b/src/input/fpcap.lua
@@ -55,7 +55,11 @@
 -- Max length of captured packets, in octets.
 -- .TP
 -- network
--- Data link type.
+-- The link type found in the PCAP header, see https://www.tcpdump.org/linktypes.html .
+-- .TP
+-- linktype
+-- The data link type, mapped from
+-- .IR network .
 module(...,package.seeall)
 
 require("dnsjit.input.fpcap_h")

--- a/src/input/mmpcap.hh
+++ b/src/input/mmpcap.hh
@@ -46,6 +46,8 @@ typedef struct input_mmpcap {
     uint32_t sigfigs;
     uint32_t snaplen;
     uint32_t network;
+
+    uint32_t linktype;
 } input_mmpcap_t;
 
 core_log_t* input_mmpcap_log();

--- a/src/input/mmpcap.lua
+++ b/src/input/mmpcap.lua
@@ -55,7 +55,11 @@
 -- Max length of captured packets, in octets.
 -- .TP
 -- network
--- Data link type.
+-- The link type found in the PCAP header, see https://www.tcpdump.org/linktypes.html .
+-- .TP
+-- linktype
+-- The data link type, mapped from
+-- .IR network .
 module(...,package.seeall)
 
 require("dnsjit.input.mmpcap_h")


### PR DESCRIPTION
- `input.fpcap`: Fix #109: Add `linktype` and translate `network` to the correct `DLT_`
- `input.mmpcap`: Fix #109: Add `linktype` and translate `network` to the correct `DLT_`