### PR TITLE
filter/timing: add realtime mode

### DIFF
--- a/src/filter/timing.hh
+++ b/src/filter/timing.hh
@@ -32,10 +32,12 @@ typedef struct filter_timing {
         TIMING_MODE_INCREASE = 1,
         TIMING_MODE_REDUCE   = 2,
         TIMING_MODE_MULTIPLY = 3,
-        TIMING_MODE_FIXED    = 4
+        TIMING_MODE_FIXED    = 4,
+        TIMING_MODE_REALTIME = 5
     } mode;
-    size_t inc, red, fixed;
+    size_t inc, red, fixed, rt_batch;
     float  mul;
+    uint64_t rt_drift;
 
     core_producer_t prod;
     void*           prod_ctx;

--- a/src/filter/timing.hh
+++ b/src/filter/timing.hh
@@ -35,8 +35,8 @@ typedef struct filter_timing {
         TIMING_MODE_FIXED    = 4,
         TIMING_MODE_REALTIME = 5
     } mode;
-    size_t inc, red, fixed, rt_batch;
-    float  mul;
+    size_t   inc, red, fixed, rt_batch;
+    float    mul;
     uint64_t rt_drift;
 
     core_producer_t prod;

--- a/src/filter/timing.lua
+++ b/src/filter/timing.lua
@@ -82,6 +82,22 @@ function Timing:fixed(ns)
     self.obj.fixed = ns
 end
 
+-- Set the timing mode to simulate the timing of packets in realtime.
+-- Packets are processed in batches of given size (default 128) before
+-- adjusting time. Aborts if real time drifts ahead more than given
+-- number of seconds (default 1.0s).
+function Timing:realtime(drift, batch_size)
+    self.obj.mode = "TIMING_MODE_REALTIME"
+    if drift == nil then
+        drift = 1
+    end
+    if batch_size == nil then
+        batch_size = 128
+    end
+    self.obj.rt_batch = batch_size
+    self.obj.rt_drift = math.floor(drift * 1000000000)
+end
+
 -- Return the C functions and context for receiving objects.
 function Timing:receive()
     return C.filter_timing_receiver(), self.obj


### PR DESCRIPTION
The realtime mode is a high-throughput variant of the keep mode. It
is less precise, but is more efficient and able to handle higher
throughput.

If there are significant time gaps in the input packets, the realtime
mode may send them earlier if both packets end up in the same batch.
However, packets are guaranteed to never be sent later than the
specified drift. In cases where the timer isn't able to keep up for any
reason, it aborts the execution.

The default batch size of 128 is an empirical value that has been tested
to perform well with input data of up to ~500k pps.