### PR TITLE
filter/copy: add producer interface

### DIFF
--- a/src/filter/copy.c
+++ b/src/filter/copy.c
@@ -148,10 +148,13 @@ uint64_t filter_copy_get(filter_copy_t* self, int32_t obj_type)
     return 0;
 }
 
-static void _receive(filter_copy_t* self, const core_object_t* obj)
+
+static core_object_t* _copy(filter_copy_t* self, const core_object_t* obj)
 {
     mlassert_self();
-    lassert(obj, "obj is nil");
+
+    if (obj == NULL)
+        return NULL;
 
     core_object_t*       outobj  = NULL;
     core_object_t*       next    = NULL;
@@ -172,12 +175,22 @@ static void _receive(filter_copy_t* self, const core_object_t* obj)
         srcobj = srcobj->obj_prev;
     } while (srcobj != NULL);
 
-    if (outobj == NULL) {
+    return outobj;
+}
+
+static void _receive(filter_copy_t* self, const core_object_t* obj)
+{
+    mlassert_self();
+    lassert(obj, "obj is nil");
+
+    core_object_t* copied = _copy(self, obj);
+
+    if (copied == NULL) {
         lnotice("object discarded (no types to copy)");
         return;
     }
 
-    self->recv(self->recv_ctx, outobj);
+    self->recv(self->recv_ctx, copied);
 }
 
 core_receiver_t filter_copy_receiver(filter_copy_t* self)

--- a/src/filter/copy.c
+++ b/src/filter/copy.c
@@ -203,3 +203,25 @@ core_receiver_t filter_copy_receiver(filter_copy_t* self)
 
     return (core_receiver_t)_receive;
 }
+
+static const core_object_t* _produce(filter_copy_t* self)
+{
+    mlassert_self();
+
+    const core_object_t* obj = self->prod(self->prod_ctx);
+    if (obj == NULL)
+        return NULL;
+
+    return _copy(self, obj);
+}
+
+core_producer_t filter_copy_producer(filter_copy_t* self)
+{
+    mlassert_self();
+
+    if (!self->prod) {
+        lfatal("no producer set");
+    }
+
+    return (core_producer_t)_produce;
+}

--- a/src/filter/copy.h
+++ b/src/filter/copy.h
@@ -21,6 +21,7 @@
 #include "core/log.h"
 #include "core/object.h"
 #include "core/receiver.h"
+#include "core/producer.h"
 
 #ifndef __dnsjit_filter_copy_h
 #define __dnsjit_filter_copy_h

--- a/src/filter/copy.hh
+++ b/src/filter/copy.hh
@@ -20,12 +20,16 @@
 
 //lua:require("dnsjit.core.log")
 //lua:require("dnsjit.core.receiver_h")
+//lua:require("dnsjit.core.producer_h")
 
 typedef struct filter_copy {
     core_log_t _log;
 
     core_receiver_t recv;
     void*           recv_ctx;
+
+    core_producer_t prod;
+    void*           prod_ctx;
 
     uint64_t copy;
 } filter_copy_t;
@@ -38,3 +42,4 @@ void filter_copy_set(filter_copy_t* self, int32_t obj_type);
 uint64_t filter_copy_get(filter_copy_t* self, int32_t obj_type);
 
 core_receiver_t filter_copy_receiver(filter_copy_t* self);
+core_producer_t filter_copy_producer(filter_copy_t* self);

--- a/src/filter/copy.lua
+++ b/src/filter/copy.lua
@@ -71,4 +71,18 @@ function Copy:receiver(o)
     self.obj.recv, self.obj.recv_ctx = o:receive()
 end
 
+-- Return the C functions and context for producing objects. Note that produce()
+-- returns nil either when the producer has no more data OR when an object is
+-- discarded by the filter (e.g. due to having no layers to copy). For most
+-- use-cases, the receiver interface should be more suitable as it doesn't suffer
+-- from this issue.
+function Copy:produce()
+    return C.filter_copy_producer(self.obj), self.obj
+end
+
+-- Set the producer to get objects from.
+function Copy:producer(o)
+    self.obj.prod, self.obj.prod_ctx = o:produce()
+end
+
 return Copy


### PR DESCRIPTION
The producer interface for copy filter doesn't seem too useful to me, but I added it to be more consistent with other filter components.