### PR TITLE
man: update documentation for payload

### DIFF
--- a/src/core/object/payload.lua
+++ b/src/core/object/payload.lua
@@ -17,29 +17,21 @@
 -- along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
 
 -- dnsjit.core.object.payload
--- An UDP packet
+-- Application data payload
 --
--- An UDP packet which is usually at the top of the object chain
--- after parsing with, for example, Layer filter.
+-- Payload object contains the data carried by the underlying transport
+-- protocol. Payload is usually at the top of the object chain after parsing
+-- with, for example, Layer filter.
 -- .SS Attributes
--- .TP
--- sport
--- Source port.
--- .TP
--- dport
--- Destination port.
--- .TP
--- ulen
--- UDP length (as described in the UDP header).
--- .TP
--- sum
--- Checksum.
 -- .TP
 -- payload
 -- A pointer to the payload.
 -- .TP
 -- len
 -- The length of the payload.
+-- .TP
+-- padding
+-- The length of padding in the underlying packet.
 module(...,package.seeall)
 
 require("dnsjit.core.object.payload_h")
@@ -83,5 +75,7 @@ end
 core_object_payload_t = ffi.metatype(t_name, { __index = Payload })
 
 -- dnsjit.core.object (3),
+-- dnsjit.core.object.udp (3),
+-- dnsjit.core.object.tcp (3),
 -- dnsjit.filter.layer (3)
 return Payload

--- a/src/core/object/payload.lua
+++ b/src/core/object/payload.lua
@@ -20,8 +20,10 @@
 -- Application data payload
 --
 -- Payload object contains the data carried by the underlying transport
--- protocol. Payload is usually at the top of the object chain after parsing
--- with, for example, Layer filter.
+-- protocol.
+-- Payload is usually at the top of the object chain after parsing with,
+-- for example,
+-- .IR dnsjit.filter.layer .
 -- .SS Attributes
 -- .TP
 -- payload

--- a/src/core/object/tcp.lua
+++ b/src/core/object/tcp.lua
@@ -19,8 +19,12 @@
 -- dnsjit.core.object.tcp
 -- A TCP segment header
 --
--- A TCP segment header. The data itself is in the payload object, which is the
--- next object in the chain after parsing with, for example, Layer filter.
+-- A TCP segment header.
+-- The data itself is in the
+-- .I dnsjit.core.object.payload
+-- object, which is the next object in the chain after parsing with,
+-- for example,
+-- .IR dnsjit.filter.layer .
 -- .SS Attributes
 -- .TP
 -- sport

--- a/src/core/object/tcp.lua
+++ b/src/core/object/tcp.lua
@@ -17,10 +17,10 @@
 -- along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
 
 -- dnsjit.core.object.tcp
--- A TCP packet
+-- A TCP segment header
 --
--- A TCP packet which is usually at the top of the object chain
--- after parsing with, for example, Layer filter.
+-- A TCP segment header. The data itself is in the payload object, which is the
+-- next object in the chain after parsing with, for example, Layer filter.
 -- .SS Attributes
 -- .TP
 -- sport
@@ -58,12 +58,6 @@
 -- .TP
 -- opts_len
 -- Length of the TCP options.
--- .TP
--- payload
--- A pointer to the payload.
--- .TP
--- len
--- The length of the payload.
 module(...,package.seeall)
 
 require("dnsjit.core.object.tcp_h")
@@ -107,5 +101,6 @@ end
 core_object_tcp_t = ffi.metatype(t_name, { __index = Tcp })
 
 -- dnsjit.core.object (3),
+-- dnsjit.core.object.payload (3),
 -- dnsjit.filter.layer (3)
 return Tcp

--- a/src/core/object/udp.lua
+++ b/src/core/object/udp.lua
@@ -17,12 +17,11 @@
 -- along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
 
 -- dnsjit.core.object.udp
--- An UDP packet
+-- A UDP datagram header
 --
--- An UDP packet which is usually at the top of the object chain
--- after parsing with, for example, Layer filter.
--- .SS Attributes
--- .TP
+-- A UDP datagram header. The data itself is in the payload object, which is
+-- the next object in the chain after parsing with, for example, Layer filter.
+-- .SS Attributes .TP
 -- sport
 -- Source port.
 -- .TP
@@ -34,12 +33,6 @@
 -- .TP
 -- sum
 -- Checksum.
--- .TP
--- payload
--- A pointer to the payload.
--- .TP
--- len
--- The length of the payload.
 module(...,package.seeall)
 
 require("dnsjit.core.object.udp_h")
@@ -83,5 +76,6 @@ end
 core_object_udp_t = ffi.metatype(t_name, { __index = Udp })
 
 -- dnsjit.core.object (3),
+-- dnsjit.core.object.payload (3),
 -- dnsjit.filter.layer (3)
 return Udp

--- a/src/core/object/udp.lua
+++ b/src/core/object/udp.lua
@@ -19,9 +19,14 @@
 -- dnsjit.core.object.udp
 -- A UDP datagram header
 --
--- A UDP datagram header. The data itself is in the payload object, which is
--- the next object in the chain after parsing with, for example, Layer filter.
--- .SS Attributes .TP
+-- A UDP datagram header.
+-- The data itself is in the
+-- .I dnsjit.core.object.payload
+-- object, which is the next object in the chain after parsing with,
+-- for example,
+-- .IR dnsjit.filter.layer .
+-- .SS Attributes
+-- .TP
 -- sport
 -- Source port.
 -- .TP

--- a/src/filter/layer.lua
+++ b/src/filter/layer.lua
@@ -88,5 +88,6 @@ end
 -- dnsjit.core.object.icmp (3),
 -- dnsjit.core.object.icmp6 (3),
 -- dnsjit.core.object.udp (3),
--- dnsjit.core.object.tcp (3)
+-- dnsjit.core.object.tcp (3),
+-- dnsjit.core.object.payload (3)
 return Layer


### PR DESCRIPTION
Sync the documentation to reflect the actual code. Non-existent
attributes were removed from tcp and udp objects. Reference to
payload object carrying the application data was added.