### PR TITLE
output/dnssim: add TLS support

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -13,6 +13,7 @@ extraction:
         - liblmdb-dev
         - libck-dev
         - libgnutls28-dev
+        - libuv1-dev
     configure:
       command:
         - ./autogen.sh

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -42,16 +42,16 @@ lua_objects = core.luao lib.luao input.luao filter.luao output.luao
 dnsjit_LDADD = $(PTHREAD_LIBS) $(luajit_LIBS) $(libuv_LIBS)
 
 # C source and headers
-dnsjit_SOURCES += core/producer.c core/compat.c core/channel.c core/object/pcap.c core/object/loop.c core/object/ether.c core/object/dns.c core/object/payload.c core/object/null.c core/object/ip6.c core/object/gre.c core/object/icmp.c core/object/icmp6.c core/object/ieee802.c core/object/linuxsll.c core/object/udp.c core/object/ip.c core/object/tcp.c core/log.c core/receiver.c core/object.c core/thread.c lib/clock.c input/pcap.c input/mmpcap.c input/fpcap.c input/zero.c filter/ipsplit.c filter/layer.c filter/split.c filter/copy.c filter/timing.c output/pcap.c output/tlscli.c output/tcpcli.c output/udpcli.c output/null.c output/respdiff.c output/dnscli.c output/dnssim/common.c output/dnssim/udp.c output/dnssim/tcp.c output/dnssim.c
-dist_dnsjit_SOURCES += core/object.h core/producer.h core/channel.h core/object/icmp.h core/object/icmp6.h core/object/pcap.h core/object/gre.h core/object/ip.h core/object/linuxsll.h core/object/payload.h core/object/udp.h core/object/ether.h core/object/tcp.h core/object/null.h core/object/ip6.h core/object/dns.h core/object/loop.h core/object/ieee802.h core/thread.h core/receiver.h core/assert.h core/timespec.h core/log.h core/compat.h lib/clock.h input/pcap.h input/zero.h input/mmpcap.h input/fpcap.h filter/copy.h filter/ipsplit.h filter/layer.h filter/timing.h filter/split.h output/dnssim.h output/pcap.h output/dnscli.h output/null.h output/dnssim/ll.h output/dnssim/internal.h output/tlscli.h output/tcpcli.h output/respdiff.h output/udpcli.h
+dnsjit_SOURCES += core/thread.c core/compat.c core/channel.c core/object/null.c core/object/icmp.c core/object/ip.c core/object/udp.c core/object/ieee802.c core/object/gre.c core/object/pcap.c core/object/dns.c core/object/linuxsll.c core/object/ether.c core/object/payload.c core/object/loop.c core/object/icmp6.c core/object/tcp.c core/object/ip6.c core/receiver.c core/producer.c core/object.c core/log.c lib/clock.c input/mmpcap.c input/zero.c input/pcap.c input/fpcap.c filter/timing.c filter/split.c filter/ipsplit.c filter/copy.c filter/layer.c output/null.c output/tlscli.c output/dnssim/tls.c output/dnssim/udp.c output/dnssim/connection.c output/dnssim/common.c output/dnssim/tcp.c output/respdiff.c output/pcap.c output/dnssim.c output/tcpcli.c output/dnscli.c output/udpcli.c
+dist_dnsjit_SOURCES += core/log.h core/producer.h core/assert.h core/compat.h core/object/udp.h core/object/payload.h core/object/gre.h core/object/icmp.h core/object/ip.h core/object/pcap.h core/object/dns.h core/object/loop.h core/object/ieee802.h core/object/ether.h core/object/linuxsll.h core/object/ip6.h core/object/icmp6.h core/object/tcp.h core/object/null.h core/object.h core/receiver.h core/channel.h core/timespec.h core/thread.h lib/clock.h input/zero.h input/fpcap.h input/pcap.h input/mmpcap.h filter/copy.h filter/layer.h filter/ipsplit.h filter/split.h filter/timing.h output/dnssim.h output/dnscli.h output/dnssim/ll.h output/dnssim/internal.h output/pcap.h output/respdiff.h output/udpcli.h output/tlscli.h output/tcpcli.h output/null.h
 
 # Lua headers
-dist_dnsjit_SOURCES += core/log.hh core/receiver.hh core/producer.hh core/object/linuxsll.hh core/object/udp.hh core/object/icmp.hh core/object/ip6.hh core/object/loop.hh core/object/null.hh core/object/ieee802.hh core/object/ip.hh core/object/ether.hh core/object/tcp.hh core/object/icmp6.hh core/object/gre.hh core/object/pcap.hh core/object/dns.hh core/object/payload.hh core/thread.hh core/timespec.hh core/channel.hh core/object.hh lib/clock.hh input/mmpcap.hh input/fpcap.hh input/pcap.hh input/zero.hh filter/layer.hh filter/ipsplit.hh filter/split.hh filter/copy.hh filter/timing.hh output/dnscli.hh output/udpcli.hh output/dnssim.hh output/respdiff.hh output/null.hh output/tcpcli.hh output/pcap.hh output/tlscli.hh
-lua_hobjects += core/log.luaho core/receiver.luaho core/producer.luaho core/object/linuxsll.luaho core/object/udp.luaho core/object/icmp.luaho core/object/ip6.luaho core/object/loop.luaho core/object/null.luaho core/object/ieee802.luaho core/object/ip.luaho core/object/ether.luaho core/object/tcp.luaho core/object/icmp6.luaho core/object/gre.luaho core/object/pcap.luaho core/object/dns.luaho core/object/payload.luaho core/thread.luaho core/timespec.luaho core/channel.luaho core/object.luaho lib/clock.luaho input/mmpcap.luaho input/fpcap.luaho input/pcap.luaho input/zero.luaho filter/layer.luaho filter/ipsplit.luaho filter/split.luaho filter/copy.luaho filter/timing.luaho output/dnscli.luaho output/udpcli.luaho output/dnssim.luaho output/respdiff.luaho output/null.luaho output/tcpcli.luaho output/pcap.luaho output/tlscli.luaho
+dist_dnsjit_SOURCES += core/timespec.hh core/object.hh core/channel.hh core/receiver.hh core/producer.hh core/object/icmp.hh core/object/ether.hh core/object/pcap.hh core/object/loop.hh core/object/dns.hh core/object/ip.hh core/object/null.hh core/object/icmp6.hh core/object/udp.hh core/object/ieee802.hh core/object/ip6.hh core/object/gre.hh core/object/linuxsll.hh core/object/tcp.hh core/object/payload.hh core/log.hh core/thread.hh lib/clock.hh input/mmpcap.hh input/zero.hh input/pcap.hh input/fpcap.hh filter/split.hh filter/copy.hh filter/ipsplit.hh filter/timing.hh filter/layer.hh output/udpcli.hh output/dnscli.hh output/pcap.hh output/null.hh output/respdiff.hh output/tlscli.hh output/dnssim.hh output/tcpcli.hh
+lua_hobjects += core/timespec.luaho core/object.luaho core/channel.luaho core/receiver.luaho core/producer.luaho core/object/icmp.luaho core/object/ether.luaho core/object/pcap.luaho core/object/loop.luaho core/object/dns.luaho core/object/ip.luaho core/object/null.luaho core/object/icmp6.luaho core/object/udp.luaho core/object/ieee802.luaho core/object/ip6.luaho core/object/gre.luaho core/object/linuxsll.luaho core/object/tcp.luaho core/object/payload.luaho core/log.luaho core/thread.luaho lib/clock.luaho input/mmpcap.luaho input/zero.luaho input/pcap.luaho input/fpcap.luaho filter/split.luaho filter/copy.luaho filter/ipsplit.luaho filter/timing.luaho filter/layer.luaho output/udpcli.luaho output/dnscli.luaho output/pcap.luaho output/null.luaho output/respdiff.luaho output/tlscli.luaho output/dnssim.luaho output/tcpcli.luaho
 
 # Lua sources
-dist_dnsjit_SOURCES += core/objects.lua core/object/null.lua core/object/icmp.lua core/object/payload.lua core/object/icmp6.lua core/object/ieee802.lua core/object/ip6.lua core/object/tcp.lua core/object/ip.lua core/object/loop.lua core/object/linuxsll.lua core/object/udp.lua core/object/dns/label.lua core/object/dns/q.lua core/object/dns/rr.lua core/object/pcap.lua core/object/ether.lua core/object/dns.lua core/object/gre.lua core/thread.lua core/channel.lua core/log.lua core/compat.lua core/object.lua core/timespec.lua core/producer.lua core/receiver.lua lib/parseconf.lua lib/getopt.lua lib/clock.lua input/zero.lua input/fpcap.lua input/pcap.lua input/mmpcap.lua filter/copy.lua filter/timing.lua filter/layer.lua filter/ipsplit.lua filter/split.lua output/null.lua output/udpcli.lua output/dnssim.lua output/tcpcli.lua output/tlscli.lua output/pcap.lua output/dnscli.lua output/respdiff.lua
-lua_objects += core/objects.luao core/object/null.luao core/object/icmp.luao core/object/payload.luao core/object/icmp6.luao core/object/ieee802.luao core/object/ip6.luao core/object/tcp.luao core/object/ip.luao core/object/loop.luao core/object/linuxsll.luao core/object/udp.luao core/object/dns/label.luao core/object/dns/q.luao core/object/dns/rr.luao core/object/pcap.luao core/object/ether.luao core/object/dns.luao core/object/gre.luao core/thread.luao core/channel.luao core/log.luao core/compat.luao core/object.luao core/timespec.luao core/producer.luao core/receiver.luao lib/parseconf.luao lib/getopt.luao lib/clock.luao input/zero.luao input/fpcap.luao input/pcap.luao input/mmpcap.luao filter/copy.luao filter/timing.luao filter/layer.luao filter/ipsplit.luao filter/split.luao output/null.luao output/udpcli.luao output/dnssim.luao output/tcpcli.luao output/tlscli.luao output/pcap.luao output/dnscli.luao output/respdiff.luao
+dist_dnsjit_SOURCES += core/producer.lua core/timespec.lua core/log.lua core/thread.lua core/compat.lua core/object/pcap.lua core/object/udp.lua core/object/ip.lua core/object/ip6.lua core/object/loop.lua core/object/ieee802.lua core/object/dns/label.lua core/object/dns/q.lua core/object/dns/rr.lua core/object/icmp.lua core/object/ether.lua core/object/null.lua core/object/payload.lua core/object/gre.lua core/object/icmp6.lua core/object/linuxsll.lua core/object/dns.lua core/object/tcp.lua core/objects.lua core/object.lua core/receiver.lua core/channel.lua lib/getopt.lua lib/clock.lua lib/parseconf.lua input/pcap.lua input/fpcap.lua input/mmpcap.lua input/zero.lua filter/split.lua filter/layer.lua filter/ipsplit.lua filter/copy.lua filter/timing.lua output/dnssim.lua output/pcap.lua output/dnscli.lua output/tlscli.lua output/udpcli.lua output/tcpcli.lua output/null.lua output/respdiff.lua
+lua_objects += core/producer.luao core/timespec.luao core/log.luao core/thread.luao core/compat.luao core/object/pcap.luao core/object/udp.luao core/object/ip.luao core/object/ip6.luao core/object/loop.luao core/object/ieee802.luao core/object/dns/label.luao core/object/dns/q.luao core/object/dns/rr.luao core/object/icmp.luao core/object/ether.luao core/object/null.luao core/object/payload.luao core/object/gre.luao core/object/icmp6.luao core/object/linuxsll.luao core/object/dns.luao core/object/tcp.luao core/objects.luao core/object.luao core/receiver.luao core/channel.luao lib/getopt.luao lib/clock.luao lib/parseconf.luao input/pcap.luao input/fpcap.luao input/mmpcap.luao input/zero.luao filter/split.luao filter/layer.luao filter/ipsplit.luao filter/copy.luao filter/timing.luao output/dnssim.luao output/pcap.luao output/dnscli.luao output/tlscli.luao output/udpcli.luao output/tcpcli.luao output/null.luao output/respdiff.luao
 
 dnsjit_LDFLAGS = -Wl,-E
 dnsjit_LDADD += $(lua_hobjects) $(lua_objects)
@@ -61,7 +61,7 @@ man1_MANS = dnsjit.1
 CLEANFILES += $(man1_MANS)
 
 man3_MANS = dnsjit.core.3 dnsjit.lib.3 dnsjit.input.3 dnsjit.filter.3 dnsjit.output.3
-man3_MANS += dnsjit.core.objects.3 dnsjit.core.object.null.3 dnsjit.core.object.icmp.3 dnsjit.core.object.payload.3 dnsjit.core.object.icmp6.3 dnsjit.core.object.ieee802.3 dnsjit.core.object.ip6.3 dnsjit.core.object.tcp.3 dnsjit.core.object.ip.3 dnsjit.core.object.loop.3 dnsjit.core.object.linuxsll.3 dnsjit.core.object.udp.3 dnsjit.core.object.dns.label.3 dnsjit.core.object.dns.q.3 dnsjit.core.object.dns.rr.3 dnsjit.core.object.pcap.3 dnsjit.core.object.ether.3 dnsjit.core.object.dns.3 dnsjit.core.object.gre.3 dnsjit.core.thread.3 dnsjit.core.channel.3 dnsjit.core.log.3 dnsjit.core.compat.3 dnsjit.core.object.3 dnsjit.core.timespec.3 dnsjit.core.producer.3 dnsjit.core.receiver.3 dnsjit.lib.parseconf.3 dnsjit.lib.getopt.3 dnsjit.lib.clock.3 dnsjit.input.zero.3 dnsjit.input.fpcap.3 dnsjit.input.pcap.3 dnsjit.input.mmpcap.3 dnsjit.filter.copy.3 dnsjit.filter.timing.3 dnsjit.filter.layer.3 dnsjit.filter.ipsplit.3 dnsjit.filter.split.3 dnsjit.output.null.3 dnsjit.output.udpcli.3 dnsjit.output.dnssim.3 dnsjit.output.tcpcli.3 dnsjit.output.tlscli.3 dnsjit.output.pcap.3 dnsjit.output.dnscli.3 dnsjit.output.respdiff.3
+man3_MANS += dnsjit.core.producer.3 dnsjit.core.timespec.3 dnsjit.core.log.3 dnsjit.core.thread.3 dnsjit.core.compat.3 dnsjit.core.object.pcap.3 dnsjit.core.object.udp.3 dnsjit.core.object.ip.3 dnsjit.core.object.ip6.3 dnsjit.core.object.loop.3 dnsjit.core.object.ieee802.3 dnsjit.core.object.dns.label.3 dnsjit.core.object.dns.q.3 dnsjit.core.object.dns.rr.3 dnsjit.core.object.icmp.3 dnsjit.core.object.ether.3 dnsjit.core.object.null.3 dnsjit.core.object.payload.3 dnsjit.core.object.gre.3 dnsjit.core.object.icmp6.3 dnsjit.core.object.linuxsll.3 dnsjit.core.object.dns.3 dnsjit.core.object.tcp.3 dnsjit.core.objects.3 dnsjit.core.object.3 dnsjit.core.receiver.3 dnsjit.core.channel.3 dnsjit.lib.getopt.3 dnsjit.lib.clock.3 dnsjit.lib.parseconf.3 dnsjit.input.pcap.3 dnsjit.input.fpcap.3 dnsjit.input.mmpcap.3 dnsjit.input.zero.3 dnsjit.filter.split.3 dnsjit.filter.layer.3 dnsjit.filter.ipsplit.3 dnsjit.filter.copy.3 dnsjit.filter.timing.3 dnsjit.output.dnssim.3 dnsjit.output.pcap.3 dnsjit.output.dnscli.3 dnsjit.output.tlscli.3 dnsjit.output.udpcli.3 dnsjit.output.tcpcli.3 dnsjit.output.null.3 dnsjit.output.respdiff.3
 CLEANFILES += *.3in $(man3_MANS)
 
 .lua.luao:
@@ -114,41 +114,38 @@ dnsjit.filter.3in: filter.lua gen-manpage.lua
 dnsjit.output.3in: output.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output.lua" > "$@"
 
-dnsjit.core.objects.3in: core/objects.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/objects.lua" > "$@"
+dnsjit.core.producer.3in: core/producer.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/producer.lua" > "$@"
 
-dnsjit.core.object.null.3in: core/object/null.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/null.lua" > "$@"
+dnsjit.core.timespec.3in: core/timespec.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/timespec.lua" > "$@"
 
-dnsjit.core.object.icmp.3in: core/object/icmp.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/icmp.lua" > "$@"
+dnsjit.core.log.3in: core/log.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/log.lua" > "$@"
 
-dnsjit.core.object.payload.3in: core/object/payload.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/payload.lua" > "$@"
+dnsjit.core.thread.3in: core/thread.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/thread.lua" > "$@"
 
-dnsjit.core.object.icmp6.3in: core/object/icmp6.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/icmp6.lua" > "$@"
+dnsjit.core.compat.3in: core/compat.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/compat.lua" > "$@"
 
-dnsjit.core.object.ieee802.3in: core/object/ieee802.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/ieee802.lua" > "$@"
+dnsjit.core.object.pcap.3in: core/object/pcap.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/pcap.lua" > "$@"
 
-dnsjit.core.object.ip6.3in: core/object/ip6.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/ip6.lua" > "$@"
-
-dnsjit.core.object.tcp.3in: core/object/tcp.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/tcp.lua" > "$@"
+dnsjit.core.object.udp.3in: core/object/udp.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/udp.lua" > "$@"
 
 dnsjit.core.object.ip.3in: core/object/ip.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/ip.lua" > "$@"
 
+dnsjit.core.object.ip6.3in: core/object/ip6.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/ip6.lua" > "$@"
+
 dnsjit.core.object.loop.3in: core/object/loop.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/loop.lua" > "$@"
 
-dnsjit.core.object.linuxsll.3in: core/object/linuxsll.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/linuxsll.lua" > "$@"
-
-dnsjit.core.object.udp.3in: core/object/udp.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/udp.lua" > "$@"
+dnsjit.core.object.ieee802.3in: core/object/ieee802.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/ieee802.lua" > "$@"
 
 dnsjit.core.object.dns.label.3in: core/object/dns/label.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/dns/label.lua" > "$@"
@@ -159,44 +156,44 @@ dnsjit.core.object.dns.q.3in: core/object/dns/q.lua gen-manpage.lua
 dnsjit.core.object.dns.rr.3in: core/object/dns/rr.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/dns/rr.lua" > "$@"
 
-dnsjit.core.object.pcap.3in: core/object/pcap.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/pcap.lua" > "$@"
+dnsjit.core.object.icmp.3in: core/object/icmp.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/icmp.lua" > "$@"
 
 dnsjit.core.object.ether.3in: core/object/ether.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/ether.lua" > "$@"
 
-dnsjit.core.object.dns.3in: core/object/dns.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/dns.lua" > "$@"
+dnsjit.core.object.null.3in: core/object/null.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/null.lua" > "$@"
+
+dnsjit.core.object.payload.3in: core/object/payload.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/payload.lua" > "$@"
 
 dnsjit.core.object.gre.3in: core/object/gre.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/gre.lua" > "$@"
 
-dnsjit.core.thread.3in: core/thread.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/thread.lua" > "$@"
+dnsjit.core.object.icmp6.3in: core/object/icmp6.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/icmp6.lua" > "$@"
 
-dnsjit.core.channel.3in: core/channel.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/channel.lua" > "$@"
+dnsjit.core.object.linuxsll.3in: core/object/linuxsll.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/linuxsll.lua" > "$@"
 
-dnsjit.core.log.3in: core/log.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/log.lua" > "$@"
+dnsjit.core.object.dns.3in: core/object/dns.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/dns.lua" > "$@"
 
-dnsjit.core.compat.3in: core/compat.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/compat.lua" > "$@"
+dnsjit.core.object.tcp.3in: core/object/tcp.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/tcp.lua" > "$@"
+
+dnsjit.core.objects.3in: core/objects.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/objects.lua" > "$@"
 
 dnsjit.core.object.3in: core/object.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object.lua" > "$@"
 
-dnsjit.core.timespec.3in: core/timespec.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/timespec.lua" > "$@"
-
-dnsjit.core.producer.3in: core/producer.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/producer.lua" > "$@"
-
 dnsjit.core.receiver.3in: core/receiver.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/receiver.lua" > "$@"
 
-dnsjit.lib.parseconf.3in: lib/parseconf.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/lib/parseconf.lua" > "$@"
+dnsjit.core.channel.3in: core/channel.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/channel.lua" > "$@"
 
 dnsjit.lib.getopt.3in: lib/getopt.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/lib/getopt.lua" > "$@"
@@ -204,23 +201,23 @@ dnsjit.lib.getopt.3in: lib/getopt.lua gen-manpage.lua
 dnsjit.lib.clock.3in: lib/clock.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/lib/clock.lua" > "$@"
 
-dnsjit.input.zero.3in: input/zero.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/input/zero.lua" > "$@"
-
-dnsjit.input.fpcap.3in: input/fpcap.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/input/fpcap.lua" > "$@"
+dnsjit.lib.parseconf.3in: lib/parseconf.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/lib/parseconf.lua" > "$@"
 
 dnsjit.input.pcap.3in: input/pcap.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/input/pcap.lua" > "$@"
 
+dnsjit.input.fpcap.3in: input/fpcap.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/input/fpcap.lua" > "$@"
+
 dnsjit.input.mmpcap.3in: input/mmpcap.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/input/mmpcap.lua" > "$@"
 
-dnsjit.filter.copy.3in: filter/copy.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/filter/copy.lua" > "$@"
+dnsjit.input.zero.3in: input/zero.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/input/zero.lua" > "$@"
 
-dnsjit.filter.timing.3in: filter/timing.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/filter/timing.lua" > "$@"
+dnsjit.filter.split.3in: filter/split.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/filter/split.lua" > "$@"
 
 dnsjit.filter.layer.3in: filter/layer.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/filter/layer.lua" > "$@"
@@ -228,29 +225,32 @@ dnsjit.filter.layer.3in: filter/layer.lua gen-manpage.lua
 dnsjit.filter.ipsplit.3in: filter/ipsplit.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/filter/ipsplit.lua" > "$@"
 
-dnsjit.filter.split.3in: filter/split.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/filter/split.lua" > "$@"
+dnsjit.filter.copy.3in: filter/copy.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/filter/copy.lua" > "$@"
 
-dnsjit.output.null.3in: output/null.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output/null.lua" > "$@"
-
-dnsjit.output.udpcli.3in: output/udpcli.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output/udpcli.lua" > "$@"
+dnsjit.filter.timing.3in: filter/timing.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/filter/timing.lua" > "$@"
 
 dnsjit.output.dnssim.3in: output/dnssim.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output/dnssim.lua" > "$@"
-
-dnsjit.output.tcpcli.3in: output/tcpcli.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output/tcpcli.lua" > "$@"
-
-dnsjit.output.tlscli.3in: output/tlscli.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output/tlscli.lua" > "$@"
 
 dnsjit.output.pcap.3in: output/pcap.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output/pcap.lua" > "$@"
 
 dnsjit.output.dnscli.3in: output/dnscli.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output/dnscli.lua" > "$@"
+
+dnsjit.output.tlscli.3in: output/tlscli.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output/tlscli.lua" > "$@"
+
+dnsjit.output.udpcli.3in: output/udpcli.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output/udpcli.lua" > "$@"
+
+dnsjit.output.tcpcli.3in: output/tcpcli.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output/tcpcli.lua" > "$@"
+
+dnsjit.output.null.3in: output/null.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output/null.lua" > "$@"
 
 dnsjit.output.respdiff.3in: output/respdiff.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output/respdiff.lua" > "$@"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -42,16 +42,16 @@ lua_objects = core.luao lib.luao input.luao filter.luao output.luao
 dnsjit_LDADD = $(PTHREAD_LIBS) $(luajit_LIBS) $(libuv_LIBS)
 
 # C source and headers
-dnsjit_SOURCES += core/thread.c core/compat.c core/channel.c core/object/null.c core/object/icmp.c core/object/ip.c core/object/udp.c core/object/ieee802.c core/object/gre.c core/object/pcap.c core/object/dns.c core/object/linuxsll.c core/object/ether.c core/object/payload.c core/object/loop.c core/object/icmp6.c core/object/tcp.c core/object/ip6.c core/receiver.c core/producer.c core/object.c core/log.c lib/clock.c input/mmpcap.c input/zero.c input/pcap.c input/fpcap.c filter/timing.c filter/split.c filter/ipsplit.c filter/copy.c filter/layer.c output/null.c output/tlscli.c output/dnssim/tls.c output/dnssim/udp.c output/dnssim/connection.c output/dnssim/common.c output/dnssim/tcp.c output/respdiff.c output/pcap.c output/dnssim.c output/tcpcli.c output/dnscli.c output/udpcli.c
-dist_dnsjit_SOURCES += core/log.h core/producer.h core/assert.h core/compat.h core/object/udp.h core/object/payload.h core/object/gre.h core/object/icmp.h core/object/ip.h core/object/pcap.h core/object/dns.h core/object/loop.h core/object/ieee802.h core/object/ether.h core/object/linuxsll.h core/object/ip6.h core/object/icmp6.h core/object/tcp.h core/object/null.h core/object.h core/receiver.h core/channel.h core/timespec.h core/thread.h lib/clock.h input/zero.h input/fpcap.h input/pcap.h input/mmpcap.h filter/copy.h filter/layer.h filter/ipsplit.h filter/split.h filter/timing.h output/dnssim.h output/dnscli.h output/dnssim/ll.h output/dnssim/internal.h output/pcap.h output/respdiff.h output/udpcli.h output/tlscli.h output/tcpcli.h output/null.h
+dnsjit_SOURCES += core/channel.c core/compat.c core/log.c core/object.c core/object/dns.c core/object/ether.c core/object/gre.c core/object/icmp6.c core/object/icmp.c core/object/ieee802.c core/object/ip6.c core/object/ip.c core/object/linuxsll.c core/object/loop.c core/object/null.c core/object/payload.c core/object/pcap.c core/object/tcp.c core/object/udp.c core/producer.c core/receiver.c core/thread.c filter/copy.c filter/ipsplit.c filter/layer.c filter/split.c filter/timing.c input/fpcap.c input/mmpcap.c input/pcap.c input/zero.c lib/clock.c output/dnscli.c output/dnssim.c output/dnssim/common.c output/dnssim/connection.c output/dnssim/tcp.c output/dnssim/tls.c output/dnssim/udp.c output/null.c output/pcap.c output/respdiff.c output/tcpcli.c output/tlscli.c output/udpcli.c
+dist_dnsjit_SOURCES += core/assert.h core/channel.h core/compat.h core/log.h core/object/dns.h core/object/ether.h core/object/gre.h core/object.h core/object/icmp6.h core/object/icmp.h core/object/ieee802.h core/object/ip6.h core/object/ip.h core/object/linuxsll.h core/object/loop.h core/object/null.h core/object/payload.h core/object/pcap.h core/object/tcp.h core/object/udp.h core/producer.h core/receiver.h core/thread.h core/timespec.h filter/copy.h filter/ipsplit.h filter/layer.h filter/split.h filter/timing.h input/fpcap.h input/mmpcap.h input/pcap.h input/zero.h lib/clock.h output/dnscli.h output/dnssim.h output/dnssim/internal.h output/dnssim/ll.h output/null.h output/pcap.h output/respdiff.h output/tcpcli.h output/tlscli.h output/udpcli.h
 
 # Lua headers
-dist_dnsjit_SOURCES += core/timespec.hh core/object.hh core/channel.hh core/receiver.hh core/producer.hh core/object/icmp.hh core/object/ether.hh core/object/pcap.hh core/object/loop.hh core/object/dns.hh core/object/ip.hh core/object/null.hh core/object/icmp6.hh core/object/udp.hh core/object/ieee802.hh core/object/ip6.hh core/object/gre.hh core/object/linuxsll.hh core/object/tcp.hh core/object/payload.hh core/log.hh core/thread.hh lib/clock.hh input/mmpcap.hh input/zero.hh input/pcap.hh input/fpcap.hh filter/split.hh filter/copy.hh filter/ipsplit.hh filter/timing.hh filter/layer.hh output/udpcli.hh output/dnscli.hh output/pcap.hh output/null.hh output/respdiff.hh output/tlscli.hh output/dnssim.hh output/tcpcli.hh
-lua_hobjects += core/timespec.luaho core/object.luaho core/channel.luaho core/receiver.luaho core/producer.luaho core/object/icmp.luaho core/object/ether.luaho core/object/pcap.luaho core/object/loop.luaho core/object/dns.luaho core/object/ip.luaho core/object/null.luaho core/object/icmp6.luaho core/object/udp.luaho core/object/ieee802.luaho core/object/ip6.luaho core/object/gre.luaho core/object/linuxsll.luaho core/object/tcp.luaho core/object/payload.luaho core/log.luaho core/thread.luaho lib/clock.luaho input/mmpcap.luaho input/zero.luaho input/pcap.luaho input/fpcap.luaho filter/split.luaho filter/copy.luaho filter/ipsplit.luaho filter/timing.luaho filter/layer.luaho output/udpcli.luaho output/dnscli.luaho output/pcap.luaho output/null.luaho output/respdiff.luaho output/tlscli.luaho output/dnssim.luaho output/tcpcli.luaho
+dist_dnsjit_SOURCES += core/channel.hh core/log.hh core/object/dns.hh core/object/ether.hh core/object/gre.hh core/object.hh core/object/icmp6.hh core/object/icmp.hh core/object/ieee802.hh core/object/ip6.hh core/object/ip.hh core/object/linuxsll.hh core/object/loop.hh core/object/null.hh core/object/payload.hh core/object/pcap.hh core/object/tcp.hh core/object/udp.hh core/producer.hh core/receiver.hh core/thread.hh core/timespec.hh filter/copy.hh filter/ipsplit.hh filter/layer.hh filter/split.hh filter/timing.hh input/fpcap.hh input/mmpcap.hh input/pcap.hh input/zero.hh lib/clock.hh output/dnscli.hh output/dnssim.hh output/null.hh output/pcap.hh output/respdiff.hh output/tcpcli.hh output/tlscli.hh output/udpcli.hh
+lua_hobjects += core/channel.luaho core/log.luaho core/object/dns.luaho core/object/ether.luaho core/object/gre.luaho core/object/icmp6.luaho core/object/icmp.luaho core/object/ieee802.luaho core/object/ip6.luaho core/object/ip.luaho core/object/linuxsll.luaho core/object/loop.luaho core/object.luaho core/object/null.luaho core/object/payload.luaho core/object/pcap.luaho core/object/tcp.luaho core/object/udp.luaho core/producer.luaho core/receiver.luaho core/thread.luaho core/timespec.luaho filter/copy.luaho filter/ipsplit.luaho filter/layer.luaho filter/split.luaho filter/timing.luaho input/fpcap.luaho input/mmpcap.luaho input/pcap.luaho input/zero.luaho lib/clock.luaho output/dnscli.luaho output/dnssim.luaho output/null.luaho output/pcap.luaho output/respdiff.luaho output/tcpcli.luaho output/tlscli.luaho output/udpcli.luaho
 
 # Lua sources
-dist_dnsjit_SOURCES += core/producer.lua core/timespec.lua core/log.lua core/thread.lua core/compat.lua core/object/pcap.lua core/object/udp.lua core/object/ip.lua core/object/ip6.lua core/object/loop.lua core/object/ieee802.lua core/object/dns/label.lua core/object/dns/q.lua core/object/dns/rr.lua core/object/icmp.lua core/object/ether.lua core/object/null.lua core/object/payload.lua core/object/gre.lua core/object/icmp6.lua core/object/linuxsll.lua core/object/dns.lua core/object/tcp.lua core/objects.lua core/object.lua core/receiver.lua core/channel.lua lib/getopt.lua lib/clock.lua lib/parseconf.lua input/pcap.lua input/fpcap.lua input/mmpcap.lua input/zero.lua filter/split.lua filter/layer.lua filter/ipsplit.lua filter/copy.lua filter/timing.lua output/dnssim.lua output/pcap.lua output/dnscli.lua output/tlscli.lua output/udpcli.lua output/tcpcli.lua output/null.lua output/respdiff.lua
-lua_objects += core/producer.luao core/timespec.luao core/log.luao core/thread.luao core/compat.luao core/object/pcap.luao core/object/udp.luao core/object/ip.luao core/object/ip6.luao core/object/loop.luao core/object/ieee802.luao core/object/dns/label.luao core/object/dns/q.luao core/object/dns/rr.luao core/object/icmp.luao core/object/ether.luao core/object/null.luao core/object/payload.luao core/object/gre.luao core/object/icmp6.luao core/object/linuxsll.luao core/object/dns.luao core/object/tcp.luao core/objects.luao core/object.luao core/receiver.luao core/channel.luao lib/getopt.luao lib/clock.luao lib/parseconf.luao input/pcap.luao input/fpcap.luao input/mmpcap.luao input/zero.luao filter/split.luao filter/layer.luao filter/ipsplit.luao filter/copy.luao filter/timing.luao output/dnssim.luao output/pcap.luao output/dnscli.luao output/tlscli.luao output/udpcli.luao output/tcpcli.luao output/null.luao output/respdiff.luao
+dist_dnsjit_SOURCES += core/channel.lua core/compat.lua core/log.lua core/object/dns/label.lua core/object/dns.lua core/object/dns/q.lua core/object/dns/rr.lua core/object/ether.lua core/object/gre.lua core/object/icmp6.lua core/object/icmp.lua core/object/ieee802.lua core/object/ip6.lua core/object/ip.lua core/object/linuxsll.lua core/object/loop.lua core/object.lua core/object/null.lua core/object/payload.lua core/object/pcap.lua core/objects.lua core/object/tcp.lua core/object/udp.lua core/producer.lua core/receiver.lua core/thread.lua core/timespec.lua filter/copy.lua filter/ipsplit.lua filter/layer.lua filter/split.lua filter/timing.lua input/fpcap.lua input/mmpcap.lua input/pcap.lua input/zero.lua lib/clock.lua lib/getopt.lua lib/parseconf.lua output/dnscli.lua output/dnssim.lua output/null.lua output/pcap.lua output/respdiff.lua output/tcpcli.lua output/tlscli.lua output/udpcli.lua
+lua_objects += core/channel.luao core/compat.luao core/log.luao core/object/dns/label.luao core/object/dns.luao core/object/dns/q.luao core/object/dns/rr.luao core/object/ether.luao core/object/gre.luao core/object/icmp6.luao core/object/icmp.luao core/object/ieee802.luao core/object/ip6.luao core/object/ip.luao core/object/linuxsll.luao core/object/loop.luao core/object.luao core/object/null.luao core/object/payload.luao core/object/pcap.luao core/objects.luao core/object/tcp.luao core/object/udp.luao core/producer.luao core/receiver.luao core/thread.luao core/timespec.luao filter/copy.luao filter/ipsplit.luao filter/layer.luao filter/split.luao filter/timing.luao input/fpcap.luao input/mmpcap.luao input/pcap.luao input/zero.luao lib/clock.luao lib/getopt.luao lib/parseconf.luao output/dnscli.luao output/dnssim.luao output/null.luao output/pcap.luao output/respdiff.luao output/tcpcli.luao output/tlscli.luao output/udpcli.luao
 
 dnsjit_LDFLAGS = -Wl,-E
 dnsjit_LDADD += $(lua_hobjects) $(lua_objects)
@@ -61,7 +61,7 @@ man1_MANS = dnsjit.1
 CLEANFILES += $(man1_MANS)
 
 man3_MANS = dnsjit.core.3 dnsjit.lib.3 dnsjit.input.3 dnsjit.filter.3 dnsjit.output.3
-man3_MANS += dnsjit.core.producer.3 dnsjit.core.timespec.3 dnsjit.core.log.3 dnsjit.core.thread.3 dnsjit.core.compat.3 dnsjit.core.object.pcap.3 dnsjit.core.object.udp.3 dnsjit.core.object.ip.3 dnsjit.core.object.ip6.3 dnsjit.core.object.loop.3 dnsjit.core.object.ieee802.3 dnsjit.core.object.dns.label.3 dnsjit.core.object.dns.q.3 dnsjit.core.object.dns.rr.3 dnsjit.core.object.icmp.3 dnsjit.core.object.ether.3 dnsjit.core.object.null.3 dnsjit.core.object.payload.3 dnsjit.core.object.gre.3 dnsjit.core.object.icmp6.3 dnsjit.core.object.linuxsll.3 dnsjit.core.object.dns.3 dnsjit.core.object.tcp.3 dnsjit.core.objects.3 dnsjit.core.object.3 dnsjit.core.receiver.3 dnsjit.core.channel.3 dnsjit.lib.getopt.3 dnsjit.lib.clock.3 dnsjit.lib.parseconf.3 dnsjit.input.pcap.3 dnsjit.input.fpcap.3 dnsjit.input.mmpcap.3 dnsjit.input.zero.3 dnsjit.filter.split.3 dnsjit.filter.layer.3 dnsjit.filter.ipsplit.3 dnsjit.filter.copy.3 dnsjit.filter.timing.3 dnsjit.output.dnssim.3 dnsjit.output.pcap.3 dnsjit.output.dnscli.3 dnsjit.output.tlscli.3 dnsjit.output.udpcli.3 dnsjit.output.tcpcli.3 dnsjit.output.null.3 dnsjit.output.respdiff.3
+man3_MANS += dnsjit.core.channel.3 dnsjit.core.compat.3 dnsjit.core.log.3 dnsjit.core.object.3 dnsjit.core.object.dns.3 dnsjit.core.object.dns.label.3 dnsjit.core.object.dns.q.3 dnsjit.core.object.dns.rr.3 dnsjit.core.object.ether.3 dnsjit.core.object.gre.3 dnsjit.core.object.icmp.3 dnsjit.core.object.icmp6.3 dnsjit.core.object.ieee802.3 dnsjit.core.object.ip.3 dnsjit.core.object.ip6.3 dnsjit.core.object.linuxsll.3 dnsjit.core.object.loop.3 dnsjit.core.object.null.3 dnsjit.core.object.payload.3 dnsjit.core.object.pcap.3 dnsjit.core.objects.3 dnsjit.core.object.tcp.3 dnsjit.core.object.udp.3 dnsjit.core.producer.3 dnsjit.core.receiver.3 dnsjit.core.thread.3 dnsjit.core.timespec.3 dnsjit.filter.copy.3 dnsjit.filter.ipsplit.3 dnsjit.filter.layer.3 dnsjit.filter.split.3 dnsjit.filter.timing.3 dnsjit.input.fpcap.3 dnsjit.input.mmpcap.3 dnsjit.input.pcap.3 dnsjit.input.zero.3 dnsjit.lib.clock.3 dnsjit.lib.getopt.3 dnsjit.lib.parseconf.3 dnsjit.output.dnscli.3 dnsjit.output.dnssim.3 dnsjit.output.null.3 dnsjit.output.pcap.3 dnsjit.output.respdiff.3 dnsjit.output.tcpcli.3 dnsjit.output.tlscli.3 dnsjit.output.udpcli.3
 CLEANFILES += *.3in $(man3_MANS)
 
 .lua.luao:
@@ -114,41 +114,20 @@ dnsjit.filter.3in: filter.lua gen-manpage.lua
 dnsjit.output.3in: output.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output.lua" > "$@"
 
-dnsjit.core.producer.3in: core/producer.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/producer.lua" > "$@"
-
-dnsjit.core.timespec.3in: core/timespec.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/timespec.lua" > "$@"
-
-dnsjit.core.log.3in: core/log.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/log.lua" > "$@"
-
-dnsjit.core.thread.3in: core/thread.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/thread.lua" > "$@"
+dnsjit.core.channel.3in: core/channel.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/channel.lua" > "$@"
 
 dnsjit.core.compat.3in: core/compat.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/compat.lua" > "$@"
 
-dnsjit.core.object.pcap.3in: core/object/pcap.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/pcap.lua" > "$@"
-
-dnsjit.core.object.udp.3in: core/object/udp.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/udp.lua" > "$@"
-
-dnsjit.core.object.ip.3in: core/object/ip.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/ip.lua" > "$@"
-
-dnsjit.core.object.ip6.3in: core/object/ip6.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/ip6.lua" > "$@"
-
-dnsjit.core.object.loop.3in: core/object/loop.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/loop.lua" > "$@"
-
-dnsjit.core.object.ieee802.3in: core/object/ieee802.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/ieee802.lua" > "$@"
+dnsjit.core.log.3in: core/log.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/log.lua" > "$@"
 
 dnsjit.core.object.dns.label.3in: core/object/dns/label.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/dns/label.lua" > "$@"
+
+dnsjit.core.object.dns.3in: core/object/dns.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/dns.lua" > "$@"
 
 dnsjit.core.object.dns.q.3in: core/object/dns/q.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/dns/q.lua" > "$@"
@@ -156,17 +135,8 @@ dnsjit.core.object.dns.q.3in: core/object/dns/q.lua gen-manpage.lua
 dnsjit.core.object.dns.rr.3in: core/object/dns/rr.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/dns/rr.lua" > "$@"
 
-dnsjit.core.object.icmp.3in: core/object/icmp.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/icmp.lua" > "$@"
-
 dnsjit.core.object.ether.3in: core/object/ether.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/ether.lua" > "$@"
-
-dnsjit.core.object.null.3in: core/object/null.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/null.lua" > "$@"
-
-dnsjit.core.object.payload.3in: core/object/payload.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/payload.lua" > "$@"
 
 dnsjit.core.object.gre.3in: core/object/gre.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/gre.lua" > "$@"
@@ -174,38 +144,71 @@ dnsjit.core.object.gre.3in: core/object/gre.lua gen-manpage.lua
 dnsjit.core.object.icmp6.3in: core/object/icmp6.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/icmp6.lua" > "$@"
 
+dnsjit.core.object.icmp.3in: core/object/icmp.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/icmp.lua" > "$@"
+
+dnsjit.core.object.ieee802.3in: core/object/ieee802.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/ieee802.lua" > "$@"
+
+dnsjit.core.object.ip6.3in: core/object/ip6.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/ip6.lua" > "$@"
+
+dnsjit.core.object.ip.3in: core/object/ip.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/ip.lua" > "$@"
+
 dnsjit.core.object.linuxsll.3in: core/object/linuxsll.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/linuxsll.lua" > "$@"
 
-dnsjit.core.object.dns.3in: core/object/dns.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/dns.lua" > "$@"
-
-dnsjit.core.object.tcp.3in: core/object/tcp.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/tcp.lua" > "$@"
-
-dnsjit.core.objects.3in: core/objects.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/objects.lua" > "$@"
+dnsjit.core.object.loop.3in: core/object/loop.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/loop.lua" > "$@"
 
 dnsjit.core.object.3in: core/object.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object.lua" > "$@"
 
+dnsjit.core.object.null.3in: core/object/null.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/null.lua" > "$@"
+
+dnsjit.core.object.payload.3in: core/object/payload.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/payload.lua" > "$@"
+
+dnsjit.core.object.pcap.3in: core/object/pcap.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/pcap.lua" > "$@"
+
+dnsjit.core.objects.3in: core/objects.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/objects.lua" > "$@"
+
+dnsjit.core.object.tcp.3in: core/object/tcp.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/tcp.lua" > "$@"
+
+dnsjit.core.object.udp.3in: core/object/udp.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/object/udp.lua" > "$@"
+
+dnsjit.core.producer.3in: core/producer.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/producer.lua" > "$@"
+
 dnsjit.core.receiver.3in: core/receiver.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/receiver.lua" > "$@"
 
-dnsjit.core.channel.3in: core/channel.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/channel.lua" > "$@"
+dnsjit.core.thread.3in: core/thread.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/thread.lua" > "$@"
 
-dnsjit.lib.getopt.3in: lib/getopt.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/lib/getopt.lua" > "$@"
+dnsjit.core.timespec.3in: core/timespec.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/core/timespec.lua" > "$@"
 
-dnsjit.lib.clock.3in: lib/clock.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/lib/clock.lua" > "$@"
+dnsjit.filter.copy.3in: filter/copy.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/filter/copy.lua" > "$@"
 
-dnsjit.lib.parseconf.3in: lib/parseconf.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/lib/parseconf.lua" > "$@"
+dnsjit.filter.ipsplit.3in: filter/ipsplit.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/filter/ipsplit.lua" > "$@"
 
-dnsjit.input.pcap.3in: input/pcap.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/input/pcap.lua" > "$@"
+dnsjit.filter.layer.3in: filter/layer.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/filter/layer.lua" > "$@"
+
+dnsjit.filter.split.3in: filter/split.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/filter/split.lua" > "$@"
+
+dnsjit.filter.timing.3in: filter/timing.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/filter/timing.lua" > "$@"
 
 dnsjit.input.fpcap.3in: input/fpcap.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/input/fpcap.lua" > "$@"
@@ -213,44 +216,41 @@ dnsjit.input.fpcap.3in: input/fpcap.lua gen-manpage.lua
 dnsjit.input.mmpcap.3in: input/mmpcap.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/input/mmpcap.lua" > "$@"
 
+dnsjit.input.pcap.3in: input/pcap.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/input/pcap.lua" > "$@"
+
 dnsjit.input.zero.3in: input/zero.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/input/zero.lua" > "$@"
 
-dnsjit.filter.split.3in: filter/split.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/filter/split.lua" > "$@"
+dnsjit.lib.clock.3in: lib/clock.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/lib/clock.lua" > "$@"
 
-dnsjit.filter.layer.3in: filter/layer.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/filter/layer.lua" > "$@"
+dnsjit.lib.getopt.3in: lib/getopt.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/lib/getopt.lua" > "$@"
 
-dnsjit.filter.ipsplit.3in: filter/ipsplit.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/filter/ipsplit.lua" > "$@"
+dnsjit.lib.parseconf.3in: lib/parseconf.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/lib/parseconf.lua" > "$@"
 
-dnsjit.filter.copy.3in: filter/copy.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/filter/copy.lua" > "$@"
-
-dnsjit.filter.timing.3in: filter/timing.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/filter/timing.lua" > "$@"
+dnsjit.output.dnscli.3in: output/dnscli.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output/dnscli.lua" > "$@"
 
 dnsjit.output.dnssim.3in: output/dnssim.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output/dnssim.lua" > "$@"
 
+dnsjit.output.null.3in: output/null.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output/null.lua" > "$@"
+
 dnsjit.output.pcap.3in: output/pcap.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output/pcap.lua" > "$@"
 
-dnsjit.output.dnscli.3in: output/dnscli.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output/dnscli.lua" > "$@"
+dnsjit.output.respdiff.3in: output/respdiff.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output/respdiff.lua" > "$@"
+
+dnsjit.output.tcpcli.3in: output/tcpcli.lua gen-manpage.lua
+	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output/tcpcli.lua" > "$@"
 
 dnsjit.output.tlscli.3in: output/tlscli.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output/tlscli.lua" > "$@"
 
 dnsjit.output.udpcli.3in: output/udpcli.lua gen-manpage.lua
 	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output/udpcli.lua" > "$@"
-
-dnsjit.output.tcpcli.3in: output/tcpcli.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output/tcpcli.lua" > "$@"
-
-dnsjit.output.null.3in: output/null.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output/null.lua" > "$@"
-
-dnsjit.output.respdiff.3in: output/respdiff.lua gen-manpage.lua
-	$(LUAJIT) "$(srcdir)/gen-manpage.lua" "$(srcdir)/output/respdiff.lua" > "$@"

--- a/src/gen-makefile.sh
+++ b/src/gen-makefile.sh
@@ -45,18 +45,18 @@ dnsjit_LDADD = $(PTHREAD_LIBS) $(luajit_LIBS) $(libuv_LIBS)
 
 # C source and headers';
 
-echo "dnsjit_SOURCES +=`find core lib input filter output -type f -name '*.c' -printf ' %p'|sort`"
-echo "dist_dnsjit_SOURCES +=`find core lib input filter output -type f -name '*.h' -printf ' %p'|sort`"
+echo "dnsjit_SOURCES +=`find core lib input filter output -type f -name '*.c' | sort | while read line; do echo -n " $line"; done`"
+echo "dist_dnsjit_SOURCES +=`find core lib input filter output -type f -name '*.h' | sort | while read line; do echo -n " $line"; done`"
 
 echo '
 # Lua headers'
-echo "dist_dnsjit_SOURCES +=`find core lib input filter output -type f -name '*.hh' -printf ' %p'|sort`"
-echo "lua_hobjects +=`find core lib input filter output -type f -name '*.hh' -printf ' %p'|sed -e 's%.hh%.luaho%g'|sort`"
+echo "dist_dnsjit_SOURCES +=`find core lib input filter output -type f -name '*.hh' | sort | while read line; do echo -n " $line"; done`"
+echo "lua_hobjects +=`find core lib input filter output -type f -name '*.hh' | sed -e 's%.hh%.luaho%g' | sort | while read line; do echo -n " $line"; done`"
 
 echo '
 # Lua sources'
-echo "dist_dnsjit_SOURCES +=`find core lib input filter output -type f -name '*.lua' -printf ' %p'|sort`"
-echo "lua_objects +=`find core lib input filter output -type f -name '*.lua' -printf ' %p '|sed -e 's%.lua %.luao%g'|sort`"
+echo "dist_dnsjit_SOURCES +=`find core lib input filter output -type f -name '*.lua' | sort | while read line; do echo -n " $line"; done`"
+echo "lua_objects +=`find core lib input filter output -type f -name '*.lua' | sed -e 's%.lua%.luao%g' | sort | while read line; do echo -n " $line"; done`"
 
 echo '
 dnsjit_LDFLAGS = -Wl,-E
@@ -67,7 +67,7 @@ man1_MANS = dnsjit.1
 CLEANFILES += $(man1_MANS)
 
 man3_MANS = dnsjit.core.3 dnsjit.lib.3 dnsjit.input.3 dnsjit.filter.3 dnsjit.output.3';
-echo "man3_MANS +=`find core lib input filter output -type f -name '*.lua' -printf ' dnsjit.%p'|sed -e 's%.lua%.3%g'|sed -e 's%/%.%g'|sort`"
+echo "man3_MANS +=`find core lib input filter output -type f -name '*.lua' | sed -e 's%.lua%.3%g' | sed -e 's%/%.%g' | sort | while read line; do echo -n " dnsjit.$line"; done`"
 
 echo 'CLEANFILES += *.3in $(man3_MANS)
 
@@ -113,7 +113,7 @@ dnsjit.${man}in: $file gen-manpage.lua
 	\$(LUAJIT) \"\$(srcdir)/gen-manpage.lua\" \"\$(srcdir)/$file\" > \"\$@\"";
 done
 
-find core lib input filter output -type f -name '*.lua' | while read file; do
+find core lib input filter output -type f -name '*.lua' | sort | while read file; do
     man=`echo "$file"|sed -e 's%.lua%.3%g'|sed -e 's%/%.%g'`
 echo "
 dnsjit.${man}in: $file gen-manpage.lua

--- a/src/output/dnssim.c
+++ b/src/output/dnssim.c
@@ -115,6 +115,11 @@ void output_dnssim_free(output_dnssim_t* self)
         } while (_self->source != first);
     }
 
+    for (int i = 0; i < self->max_clients; ++i) {
+        if (_self->client_arr[i].tls_ticket.size != 0) {
+            gnutls_free(_self->client_arr[i].tls_ticket.data);
+        }
+    }
     free(_self->client_arr);
 
     ret = uv_loop_close(&_self->loop);

--- a/src/output/dnssim.c
+++ b/src/output/dnssim.c
@@ -74,7 +74,6 @@ output_dnssim_t* output_dnssim_new(size_t max_clients)
         _self->client_arr[i].dnssim = self;
     }
 
-    gnutls_global_init();
     ret = gnutls_priority_init(&_self->tls_priority, "PERFORMANCE", NULL);
     if (ret < 0)
         lfatal("failed to initialize TLS priority cache (%s)", gnutls_strerror(ret));
@@ -127,7 +126,6 @@ void output_dnssim_free(output_dnssim_t* self)
 
     gnutls_certificate_free_credentials(_self->tls_cred);
     gnutls_priority_deinit(_self->tls_priority);
-    gnutls_global_deinit();
 
     free(self);
 }

--- a/src/output/dnssim.c
+++ b/src/output/dnssim.c
@@ -364,7 +364,7 @@ static void _on_stats_timer_tick(uv_timer_t* handle)
     lassert(self->stats_current, "stats_current is nil");
 
     lnotice("total processed:%10ld; answers:%10ld; discarded:%10ld; ongoing:%10ld",
-        self->processed, self->stats_sum->answers, self->discarded, self->ongoing);
+            self->processed, self->stats_sum->answers, self->discarded, self->ongoing);
 
     output_dnssim_stats_t* stats_next;
     lfatal_oom(stats_next = calloc(1, sizeof(output_dnssim_stats_t)));

--- a/src/output/dnssim.c
+++ b/src/output/dnssim.c
@@ -232,9 +232,10 @@ void output_dnssim_set_transport(output_dnssim_t* self, output_dnssim_transport_
         lnotice("transport set to TCP");
         break;
     case OUTPUT_DNSSIM_TRANSPORT_TLS:
+#if GNUTLS_VERSION_NUMBER >= DNSSIM_MIN_GNUTLS_VERSION
         lnotice("transport set to TLS");
-#if GNUTLS_VERSION_NUMBER < 0x030603
-        lwarning("TLS session resumption requires GnuTLS 3.6.3+");
+#else
+        lfatal(DNSSIM_MIN_GNUTLS_ERRORMSG);
 #endif
         break;
     case OUTPUT_DNSSIM_TRANSPORT_UDP:

--- a/src/output/dnssim.c
+++ b/src/output/dnssim.c
@@ -233,6 +233,9 @@ void output_dnssim_set_transport(output_dnssim_t* self, output_dnssim_transport_
         break;
     case OUTPUT_DNSSIM_TRANSPORT_TLS:
         lnotice("transport set to TLS");
+#if GNUTLS_VERSION_NUMBER < 0x030603
+        lwarning("TLS session resumption requires GnuTLS 3.6.3+");
+#endif
         break;
     case OUTPUT_DNSSIM_TRANSPORT_UDP:
     default:

--- a/src/output/dnssim.c
+++ b/src/output/dnssim.c
@@ -89,7 +89,7 @@ output_dnssim_t* output_dnssim_new(size_t max_clients)
 void output_dnssim_free(output_dnssim_t* self)
 {
     mlassert_self();
-    int                      ret;
+    int                      ret, i;
     _output_dnssim_source_t* source;
     _output_dnssim_source_t* first = _self->source;
     output_dnssim_stats_t*   stats_prev;
@@ -112,7 +112,7 @@ void output_dnssim_free(output_dnssim_t* self)
         } while (_self->source != first);
     }
 
-    for (int i = 0; i < self->max_clients; ++i) {
+    for (i = 0; i < self->max_clients; ++i) {
         if (_self->client_arr[i].tls_ticket.size != 0) {
             gnutls_free(_self->client_arr[i].tls_ticket.data);
         }

--- a/src/output/dnssim.hh
+++ b/src/output/dnssim.hh
@@ -104,6 +104,7 @@ void output_dnssim_free(output_dnssim_t* self);
 void output_dnssim_set_transport(output_dnssim_t* self, output_dnssim_transport_t tr);
 int output_dnssim_target(output_dnssim_t* self, const char* ip, uint16_t port);
 int output_dnssim_bind(output_dnssim_t* self, const char* ip);
+int output_dnssim_tls_priority(output_dnssim_t* self, const char* priority);
 int output_dnssim_run_nowait(output_dnssim_t* self);
 void output_dnssim_timeout_ms(output_dnssim_t* self, uint64_t timeout_ms);
 void output_dnssim_stats_collect(output_dnssim_t* self, uint64_t interval_ms);

--- a/src/output/dnssim.hh
+++ b/src/output/dnssim.hh
@@ -48,6 +48,9 @@ struct output_dnssim_stats {
     /* Number of connection handshake attempts during the stats interval. */
     uint64_t conn_handshakes;
 
+    /* Number of connection that have been resumed with TLS session resumption. */
+    uint64_t conn_resumed;
+
     /* Number of timed out connection handshakes during the stats interval. */
     uint64_t conn_handshakes_failed;
 

--- a/src/output/dnssim.lua
+++ b/src/output/dnssim.lua
@@ -112,7 +112,14 @@ function DnsSim:tcp()
 end
 
 -- Set the transport to TLS.
-function DnsSim:tls()
+--
+-- Optional argument priority is a GnuTLS priority string. It can be used to
+-- select TLS versions, cipher suites etc. Refer to
+-- https://gnutls.org/manual/html_node/Priority-Strings.html
+function DnsSim:tls(priority)
+    if priority ~= nil then
+        C.output_dnssim_tls_priority(self.obj, priority)
+    end
     C.output_dnssim_set_transport(self.obj, C.OUTPUT_DNSSIM_TRANSPORT_TLS)
 end
 

--- a/src/output/dnssim.lua
+++ b/src/output/dnssim.lua
@@ -113,9 +113,17 @@ end
 
 -- Set the transport to TLS.
 --
--- Optional argument priority is a GnuTLS priority string. It can be used to
--- select TLS versions, cipher suites etc. Refer to
--- https://gnutls.org/manual/html_node/Priority-Strings.html
+-- The optional arguments is a GnuTLS priority string, whih can be used to
+-- select TLS versions, cipher suites etc. For example:
+--
+-- .BR NORMAL:%NO_TICKETS
+-- Use defaults without TLS session resumption.
+--
+-- .BR SECURE128:-VERS-ALL:+VERS-TLS1.3
+-- Use only TLS 1.3 with 128-bit secure ciphers.
+--
+-- Refer to:
+-- .I https://gnutls.org/manual/html_node/Priority-Strings.html
 function DnsSim:tls(priority)
     if priority ~= nil then
         C.output_dnssim_tls_priority(self.obj, priority)

--- a/src/output/dnssim.lua
+++ b/src/output/dnssim.lua
@@ -51,7 +51,7 @@ local C = ffi.C
 
 local DnsSim = {}
 
-local _DNSSIM_JSON_VERSION = 20200406
+local _DNSSIM_JSON_VERSION = 20200527
 
 -- Create a new DnsSim output for up to max_clients.
 function DnsSim.new(max_clients)
@@ -220,6 +220,7 @@ function DnsSim:export(filename)
                 '"answers":', tonumber(stats.answers), ',',
                 '"conn_active":', tonumber(stats.conn_active), ',',
                 '"conn_handshakes":', tonumber(stats.conn_handshakes), ',',
+                '"conn_resumed":', tonumber(stats.conn_resumed), ',',
                 '"conn_handshakes_failed":', tonumber(stats.conn_handshakes_failed), ',',
                 '"rcode_noerror":', tonumber(stats.rcode_noerror), ',',
                 '"rcode_formerr":', tonumber(stats.rcode_formerr), ',',

--- a/src/output/dnssim.lua
+++ b/src/output/dnssim.lua
@@ -114,13 +114,14 @@ end
 -- Set the transport to TLS.
 --
 -- The optional arguments is a GnuTLS priority string, whih can be used to
--- select TLS versions, cipher suites etc. For example:
+-- select TLS versions, cipher suites etc.
+-- For example:
 --
--- .BR NORMAL:%NO_TICKETS
--- Use defaults without TLS session resumption.
+-- .RB "- """ NORMAL:%NO_TICKETS """"
+-- will use defaults without TLS session resumption.
 --
--- .BR SECURE128:-VERS-ALL:+VERS-TLS1.3
--- Use only TLS 1.3 with 128-bit secure ciphers.
+-- .RB "- """ SECURE128:-VERS-ALL:+VERS-TLS1.3 """"
+-- will use only TLS 1.3 with 128-bit secure ciphers.
 --
 -- Refer to:
 -- .I https://gnutls.org/manual/html_node/Priority-Strings.html

--- a/src/output/dnssim/common.c
+++ b/src/output/dnssim/common.c
@@ -72,7 +72,11 @@ void _output_dnssim_create_request(output_dnssim_t* self, _output_dnssim_client_
         ret = _output_dnssim_create_query_tcp(self, req);
         break;
     case OUTPUT_DNSSIM_TRANSPORT_TLS:
+#if GNUTLS_VERSION_NUMBER >= DNSSIM_MIN_GNUTLS_VERSION
         ret = _output_dnssim_create_query_tls(self, req);
+#else
+        lfatal(DNSSIM_MIN_GNUTLS_ERRORMSG);
+#endif
         break;
     default:
         lfatal("unsupported dnssim transport");
@@ -150,7 +154,11 @@ static void _close_query(_output_dnssim_query_t* qry)
         _output_dnssim_close_query_tcp((_output_dnssim_query_tcp_t*)qry);
         break;
     case OUTPUT_DNSSIM_TRANSPORT_TLS:
+#if GNUTLS_VERSION_NUMBER >= DNSSIM_MIN_GNUTLS_VERSION
         _output_dnssim_close_query_tls((_output_dnssim_query_tcp_t*)qry);
+#else
+        mlfatal(DNSSIM_MIN_GNUTLS_ERRORMSG);
+#endif
         break;
     default:
         mlfatal("invalid query transport");

--- a/src/output/dnssim/common.c
+++ b/src/output/dnssim/common.c
@@ -71,6 +71,9 @@ void _output_dnssim_create_request(output_dnssim_t* self, _output_dnssim_client_
     case OUTPUT_DNSSIM_TRANSPORT_TCP:
         ret = _output_dnssim_create_query_tcp(self, req);
         break;
+    case OUTPUT_DNSSIM_TRANSPORT_TLS:
+        ret = _output_dnssim_create_query_tls(self, req);
+        break;
     default:
         lfatal("unsupported dnssim transport");
         break;
@@ -145,6 +148,9 @@ static void _close_query(_output_dnssim_query_t* qry)
         break;
     case OUTPUT_DNSSIM_TRANSPORT_TCP:
         _output_dnssim_close_query_tcp((_output_dnssim_query_tcp_t*)qry);
+        break;
+    case OUTPUT_DNSSIM_TRANSPORT_TLS:
+        _output_dnssim_close_query_tls((_output_dnssim_query_tcp_t*)qry);
         break;
     default:
         mlfatal("invalid query transport");

--- a/src/output/dnssim/connection.c
+++ b/src/output/dnssim/connection.c
@@ -263,7 +263,11 @@ static int _parse_dnsbuf_data(_output_dnssim_connection_t* conn)
         conn->dnsbuf_len     = ntohs(*p_dnslen);
         if (conn->dnsbuf_len == 0) {
             mlwarning("invalid dnslen received: 0");
-            conn->read_state = _OUTPUT_DNSSIM_READ_STATE_DNSMSG;
+            conn->dnsbuf_len = 2;
+            conn->read_state = _OUTPUT_DNSSIM_READ_STATE_DNSLEN;
+        } else if (conn->dnsbuf_len < 12) {
+            mldebug("invalid dnslen received: %d", conn->dnsbuf_len);
+            ret = -1;
         }
         else {
             mldebug("dnslen: %d", conn->dnsbuf_len);

--- a/src/output/dnssim/connection.c
+++ b/src/output/dnssim/connection.c
@@ -141,7 +141,7 @@ static void _send_pending_queries(_output_dnssim_connection_t* conn)
     mlassert(conn->client, "conn->client is nil");
     qry = (_output_dnssim_query_tcp_t*)conn->client->pending;
 
-    while (qry != NULL) {
+    while (qry != NULL && conn->state == _OUTPUT_DNSSIM_CONN_ACTIVE) {
         _output_dnssim_query_tcp_t* next = (_output_dnssim_query_tcp_t*)qry->qry.next;
         if (qry->qry.state == _OUTPUT_DNSSIM_QUERY_PENDING_WRITE) {
             switch(qry->qry.transport) {

--- a/src/output/dnssim/connection.c
+++ b/src/output/dnssim/connection.c
@@ -271,8 +271,7 @@ static int _parse_dnsbuf_data(_output_dnssim_connection_t* conn)
         } else if (conn->dnsbuf_len < 12) {
             mldebug("invalid dnslen received: %d", conn->dnsbuf_len);
             ret = -1;
-        }
-        else {
+        } else {
             mldebug("dnslen: %d", conn->dnsbuf_len);
             conn->read_state = _OUTPUT_DNSSIM_READ_STATE_DNSMSG;
         }

--- a/src/output/dnssim/connection.c
+++ b/src/output/dnssim/connection.c
@@ -22,9 +22,186 @@
 
 #include "output/dnssim.h"
 #include "output/dnssim/internal.h"
+#include "output/dnssim/ll.h"
 #include "core/assert.h"
 
-bool _output_dnssim_connection_is_connecting(_output_dnssim_connection_t* conn)
+#include <string.h>
+
+static core_log_t _log = LOG_T_INIT("output.dnssim");
+
+static bool _conn_is_connecting(_output_dnssim_connection_t* conn)
 {
-    return (conn->state == _OUTPUT_DNSSIM_TCP_HANDSHAKE);
+    return (conn->state == _OUTPUT_DNSSIM_CONN_TCP_HANDSHAKE);
+}
+
+void _output_dnssim_conn_maybe_free(_output_dnssim_connection_t* conn)
+{
+    mlassert(conn, "conn can't be nil");
+    mlassert(conn->client, "conn must belong to a client");
+    if (conn->handle == NULL && conn->handshake_timer == NULL && conn->idle_timer == NULL) {
+        _ll_remove(conn->client->conn, conn);
+        if (conn->tls != NULL) {
+            free(conn->tls);
+            conn->tls = NULL;
+        }
+        free(conn);
+    }
+}
+
+static void _on_handshake_timer_closed(uv_handle_t* handle)
+{
+    _output_dnssim_connection_t* conn = (_output_dnssim_connection_t*)handle->data;
+    mlassert(conn, "conn is nil");
+    mlassert(conn->handshake_timer, "conn must have handshake timer when closing it");
+    free(conn->handshake_timer);
+    conn->handshake_timer = NULL;
+    _output_dnssim_conn_maybe_free(conn);
+}
+
+static void _on_idle_timer_closed(uv_handle_t* handle)
+{
+    _output_dnssim_connection_t* conn = (_output_dnssim_connection_t*)handle->data;
+    mlassert(conn, "conn is nil");
+    mlassert(conn->idle_timer, "conn must have idle timer when closing it");
+    free(conn->idle_timer);
+    conn->is_idle    = false;
+    conn->idle_timer = NULL;
+    _output_dnssim_conn_maybe_free(conn);
+}
+
+void _output_dnssim_conn_close(_output_dnssim_connection_t* conn)
+{
+    mlassert(conn, "conn can't be nil");
+    mlassert(conn->stats, "conn must have stats");
+    mlassert(conn->client, "conn must have client");
+    mlassert(conn->client->dnssim, "client must have dnssim");
+
+    output_dnssim_t* self = conn->client->dnssim;
+
+    switch (conn->state) {
+    case _OUTPUT_DNSSIM_CONN_CLOSING:
+    case _OUTPUT_DNSSIM_CONN_CLOSED:
+        return;
+    case _OUTPUT_DNSSIM_CONN_TCP_HANDSHAKE:
+        conn->stats->conn_handshakes_failed++;
+        self->stats_sum->conn_handshakes_failed++;
+        break;
+    case _OUTPUT_DNSSIM_CONN_ACTIVE:
+        self->stats_current->conn_active--;
+        break;
+    default:
+        break;
+    }
+    conn->state = _OUTPUT_DNSSIM_CONN_CLOSING;
+
+    if (conn->handshake_timer != NULL) {
+        uv_timer_stop(conn->handshake_timer);
+        uv_close((uv_handle_t*)conn->handshake_timer, _on_handshake_timer_closed);
+    }
+    if (conn->idle_timer != NULL) {
+        conn->is_idle = false;
+        uv_timer_stop(conn->idle_timer);
+        uv_close((uv_handle_t*)conn->idle_timer, _on_idle_timer_closed);
+    }
+
+    switch(_self->transport) {
+    case OUTPUT_DNSSIM_TRANSPORT_TCP:
+        _output_dnssim_tcp_close(conn);
+        break;
+    case OUTPUT_DNSSIM_TRANSPORT_TLS:
+        lfatal("TODO: implement tls conn close");
+        break;
+    default:
+        lfatal("unsupported transport");
+        break;
+    }
+
+}
+
+/* Close connection or run idle timer when there are no more outstanding queries. */
+void _output_dnssim_conn_idle(_output_dnssim_connection_t* conn)
+{
+    mlassert(conn, "conn can't be nil");
+
+    if (conn->queued == NULL && conn->sent == NULL) {
+        if (conn->idle_timer == NULL)
+            _output_dnssim_conn_close(conn);
+        else if (!conn->is_idle) {
+            conn->is_idle = true;
+            uv_timer_again(conn->idle_timer);
+        }
+    }
+}
+
+static void _send_pending_queries(_output_dnssim_connection_t* conn)
+{
+    _output_dnssim_query_tcp_t* qry;
+    mlassert(conn, "conn is nil");
+    mlassert(conn->client, "conn->client is nil");
+    qry = (_output_dnssim_query_tcp_t*)conn->client->pending;
+
+    // TODO support TLS
+    while (qry != NULL) {
+        _output_dnssim_query_tcp_t* next = (_output_dnssim_query_tcp_t*)qry->qry.next;
+        if (qry->qry.state == _OUTPUT_DNSSIM_QUERY_PENDING_WRITE)
+            _output_dnssim_tcp_write_query(conn, qry);
+        qry = next;
+    }
+}
+
+int _output_dnssim_handle_pending_queries(_output_dnssim_client_t* client)
+{
+    int ret = 0;
+    mlassert(client, "client is nil");
+
+    if (client->pending == NULL)
+        return ret;
+
+    output_dnssim_t* self = client->dnssim;
+    mlassert(self, "client must belong to dnssim");
+
+    /* Get active TCP connection or find out whether new connection has to be opened. */
+    bool                         is_connecting = false;
+    _output_dnssim_connection_t* conn          = client->conn;
+    while (conn != NULL) {
+        if (conn->state == _OUTPUT_DNSSIM_CONN_ACTIVE)
+            break;
+        else if (_conn_is_connecting(conn))
+            is_connecting = true;
+        conn              = conn->next;
+    }
+
+    if (conn != NULL) { /* Send data right away over active connection. */
+        _send_pending_queries(conn);
+    } else if (!is_connecting) { /* No active or connecting connection -> open a new one. */
+        lfatal_oom(conn = calloc(1, sizeof(_output_dnssim_connection_t)));
+        conn->state  = _OUTPUT_DNSSIM_CONN_INITIALIZED;
+        conn->client = client;
+        conn->stats  = self->stats_current;
+        ret          = _output_dnssim_tcp_connect(self, conn);  // TODO tls
+        if (ret < 0)
+            return ret;
+        _ll_append(client->conn, conn);
+    } /* Otherwise, pending queries wil be sent after connected callback. */
+
+    return ret;
+}
+
+void _output_dnssim_conn_activate(_output_dnssim_connection_t* conn)
+{
+    mlassert(conn, "conn is nil");
+    mlassert(conn->client, "conn must be associated with a client");
+    mlassert(conn->client->dnssim, "client must be associated with dnssim");
+
+    uv_timer_stop(conn->handshake_timer);
+
+    conn->state = _OUTPUT_DNSSIM_CONN_ACTIVE;
+    conn->client->dnssim->stats_current->conn_active++;
+    conn->read_state          = _OUTPUT_DNSSIM_READ_STATE_DNSLEN;
+    conn->dnsbuf_len            = 2;
+    conn->dnsbuf_pos            = 0;
+    conn->dnsbuf_free_after_use = false;
+
+    _send_pending_queries(conn);
+    _output_dnssim_conn_idle(conn);
 }

--- a/src/output/dnssim/connection.c
+++ b/src/output/dnssim/connection.c
@@ -110,7 +110,11 @@ void _output_dnssim_conn_close(_output_dnssim_connection_t* conn)
         _output_dnssim_tcp_close(conn);
         break;
     case OUTPUT_DNSSIM_TRANSPORT_TLS:
+#if GNUTLS_VERSION_NUMBER >= DNSSIM_MIN_GNUTLS_VERSION
         _output_dnssim_tls_close(conn);
+#else
+        lfatal(DNSSIM_MIN_GNUTLS_ERRORMSG);
+#endif
         break;
     default:
         lfatal("unsupported transport");
@@ -149,7 +153,11 @@ static void _send_pending_queries(_output_dnssim_connection_t* conn)
                 _output_dnssim_tcp_write_query(conn, qry);
                 break;
             case OUTPUT_DNSSIM_TRANSPORT_TLS:
+#if GNUTLS_VERSION_NUMBER >= DNSSIM_MIN_GNUTLS_VERSION
                 _output_dnssim_tls_write_query(conn, qry);
+#else
+                mlfatal(DNSSIM_MIN_GNUTLS_ERRORMSG);
+#endif
                 break;
             default:
                 mlfatal("unsupported protocol");
@@ -190,9 +198,13 @@ int _output_dnssim_handle_pending_queries(_output_dnssim_client_t* client)
         conn->client = client;
         conn->stats  = self->stats_current;
         if (_self->transport == OUTPUT_DNSSIM_TRANSPORT_TLS) {
+#if GNUTLS_VERSION_NUMBER >= DNSSIM_MIN_GNUTLS_VERSION
             ret = _output_dnssim_tls_init(conn);
             if (ret < 0)
                 return ret;
+#else
+            lfatal(DNSSIM_MIN_GNUTLS_ERRORMSG);
+#endif
         }
         ret = _output_dnssim_tcp_connect(self, conn);
         if (ret < 0)

--- a/src/output/dnssim/connection.c
+++ b/src/output/dnssim/connection.c
@@ -189,8 +189,11 @@ int _output_dnssim_handle_pending_queries(_output_dnssim_client_t* client)
         conn->state  = _OUTPUT_DNSSIM_CONN_INITIALIZED;
         conn->client = client;
         conn->stats  = self->stats_current;
-        if (_self->transport == OUTPUT_DNSSIM_TRANSPORT_TLS)
-            _output_dnssim_tls_init(conn);
+        if (_self->transport == OUTPUT_DNSSIM_TRANSPORT_TLS) {
+            ret = _output_dnssim_tls_init(conn);
+            if (ret < 0)
+                return ret;
+        }
         ret = _output_dnssim_tcp_connect(self, conn);
         if (ret < 0)
             return ret;

--- a/src/output/dnssim/connection.c
+++ b/src/output/dnssim/connection.c
@@ -251,7 +251,7 @@ int _process_dnsmsg(_output_dnssim_connection_t* conn)
     return 0;
 }
 
-int _parse_dnsbuf_data(_output_dnssim_connection_t* conn)
+static int _parse_dnsbuf_data(_output_dnssim_connection_t* conn)
 {
     mlassert(conn, "conn can't be nil");
     mlassert(conn->dnsbuf_pos == conn->dnsbuf_len, "attempt to parse incomplete dnsbuf_data");
@@ -261,6 +261,10 @@ int _parse_dnsbuf_data(_output_dnssim_connection_t* conn)
     case _OUTPUT_DNSSIM_READ_STATE_DNSLEN: {
         uint16_t* p_dnslen = (uint16_t*)conn->dnsbuf_data;
         conn->dnsbuf_len     = ntohs(*p_dnslen);
+        if (conn->dnsbuf_len == 0) {
+            mlwarning("invalid dnslen received: 0");
+            return -1;
+        }
         mldebug("tcp dnslen: %d", conn->dnsbuf_len);
         conn->read_state = _OUTPUT_DNSSIM_READ_STATE_DNSMSG;
         break;
@@ -289,7 +293,7 @@ int _parse_dnsbuf_data(_output_dnssim_connection_t* conn)
     return ret;
 }
 
-unsigned int _read_dns_stream_chunk(_output_dnssim_connection_t* conn, size_t len, const char* data)
+static unsigned int _read_dns_stream_chunk(_output_dnssim_connection_t* conn, size_t len, const char* data)
 {
     mlassert(conn, "conn can't be nil");
     mlassert(data, "data can't be nil");

--- a/src/output/dnssim/connection.c
+++ b/src/output/dnssim/connection.c
@@ -305,7 +305,7 @@ static unsigned int _read_dns_stream_chunk(_output_dnssim_connection_t* conn, si
     mlassert(data, "data can't be nil");
     mlassert(len > 0, "no data to read");
     mlassert((conn->read_state == _OUTPUT_DNSSIM_READ_STATE_DNSLEN || conn->read_state == _OUTPUT_DNSSIM_READ_STATE_DNSMSG),
-        "connection has invalid read_state");
+            "connection has invalid read_state");
 
     int          ret = 0;
     unsigned int nread;

--- a/src/output/dnssim/connection.c
+++ b/src/output/dnssim/connection.c
@@ -263,10 +263,12 @@ static int _parse_dnsbuf_data(_output_dnssim_connection_t* conn)
         conn->dnsbuf_len     = ntohs(*p_dnslen);
         if (conn->dnsbuf_len == 0) {
             mlwarning("invalid dnslen received: 0");
-            return -1;
+            conn->read_state = _OUTPUT_DNSSIM_READ_STATE_DNSMSG;
         }
-        mldebug("tcp dnslen: %d", conn->dnsbuf_len);
-        conn->read_state = _OUTPUT_DNSSIM_READ_STATE_DNSMSG;
+        else {
+            mldebug("dnslen: %d", conn->dnsbuf_len);
+            conn->read_state = _OUTPUT_DNSSIM_READ_STATE_DNSMSG;
+        }
         break;
     }
     case _OUTPUT_DNSSIM_READ_STATE_DNSMSG:

--- a/src/output/dnssim/connection.c
+++ b/src/output/dnssim/connection.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2020, CZ.NIC, z.s.p.o.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "output/dnssim.h"
+#include "output/dnssim/internal.h"
+#include "core/assert.h"
+
+bool _output_dnssim_connection_is_connecting(_output_dnssim_connection_t* conn)
+{
+    return (conn->state == _OUTPUT_DNSSIM_TCP_HANDSHAKE);
+}

--- a/src/output/dnssim/connection.c
+++ b/src/output/dnssim/connection.c
@@ -31,7 +31,7 @@ static core_log_t _log = LOG_T_INIT("output.dnssim");
 
 static bool _conn_is_connecting(_output_dnssim_connection_t* conn)
 {
-    return (conn->state == _OUTPUT_DNSSIM_CONN_TCP_HANDSHAKE);
+    return (conn->state >= _OUTPUT_DNSSIM_CONN_TCP_HANDSHAKE && conn->state <= _OUTPUT_DNSSIM_CONN_ACTIVE);
 }
 
 void _output_dnssim_conn_maybe_free(_output_dnssim_connection_t* conn)

--- a/src/output/dnssim/internal.h
+++ b/src/output/dnssim/internal.h
@@ -152,7 +152,7 @@ struct _output_dnssim_connection {
     /* State of the connection. */
     enum {
         _OUTPUT_DNSSIM_CONN_INITIALIZED,
-        _OUTPUT_DNSSIM_CONN_CONNECTING,
+        _OUTPUT_DNSSIM_CONN_TCP_HANDSHAKE,
         _OUTPUT_DNSSIM_CONN_ACTIVE,
         _OUTPUT_DNSSIM_CONN_CLOSING,
         _OUTPUT_DNSSIM_CONN_CLOSED
@@ -230,5 +230,6 @@ void _output_dnssim_request_answered(_output_dnssim_request_t* req, core_object_
 void _output_dnssim_maybe_free_request(_output_dnssim_request_t* req);
 void _output_dnssim_on_uv_alloc(uv_handle_t* handle, size_t suggested_size, uv_buf_t* buf);
 void _output_dnssim_create_request(output_dnssim_t* self, _output_dnssim_client_t* client, core_object_payload_t* payload);
+bool _output_dnssim_connection_is_connecting(_output_dnssim_connection_t* conn);
 
 #endif

--- a/src/output/dnssim/internal.h
+++ b/src/output/dnssim/internal.h
@@ -31,7 +31,7 @@
 #define _ERR_MSGID -3
 #define _ERR_TC -4
 
-#define TLS_BUF_SIZE 2048
+#define WIRE_BUF_SIZE 65535 + 2 + 16384  /** max tcplen + 2b tcplen + 16kb tls record */
 
 typedef struct _output_dnssim_request    _output_dnssim_request_t;
 typedef struct _output_dnssim_connection _output_dnssim_connection_t;
@@ -135,7 +135,6 @@ typedef enum _output_dnssim_read_state {
 typedef struct _output_dnssim_tls_ctx {
     gnutls_session_t session;
     uint8_t* buf;
-    //uint8_t recv_buf[TLS_BUF_SIZE];
     ssize_t buf_len;
     ssize_t buf_pos;
     size_t write_queue_size;
@@ -235,6 +234,7 @@ struct _output_dnssim {
 
     gnutls_priority_t tls_priority;
     gnutls_certificate_credentials_t tls_cred;
+    char wire_buf[WIRE_BUF_SIZE];  /* thread-local buffer for processing tls input */
 };
 
 /*

--- a/src/output/dnssim/internal.h
+++ b/src/output/dnssim/internal.h
@@ -26,6 +26,9 @@
 #include "core/object/dns.h"
 #include "core/object/payload.h"
 
+#define DNSSIM_MIN_GNUTLS_VERSION 0x030603
+#define DNSSIM_MIN_GNUTLS_ERRORMSG "dnssim tls transport requires GnuTLS >= 3.6.3"
+
 #define _self ((_output_dnssim_t*)self)
 #define _ERR_MALFORMED -2
 #define _ERR_MSGID -3
@@ -247,10 +250,8 @@ struct _output_dnssim {
 int _output_dnssim_bind_before_connect(output_dnssim_t* self, uv_handle_t* handle);
 int _output_dnssim_create_query_udp(output_dnssim_t* self, _output_dnssim_request_t* req);
 int _output_dnssim_create_query_tcp(output_dnssim_t* self, _output_dnssim_request_t* req);
-int _output_dnssim_create_query_tls(output_dnssim_t* self, _output_dnssim_request_t* req);
 void _output_dnssim_close_query_udp(_output_dnssim_query_udp_t* qry);
 void _output_dnssim_close_query_tcp(_output_dnssim_query_tcp_t* qry);
-void _output_dnssim_close_query_tls(_output_dnssim_query_tcp_t* qry);
 void _output_dnssim_request_answered(_output_dnssim_request_t* req, core_object_dns_t* msg);
 void _output_dnssim_maybe_free_request(_output_dnssim_request_t* req);
 void _output_dnssim_on_uv_alloc(uv_handle_t* handle, size_t suggested_size, uv_buf_t* buf);
@@ -259,15 +260,20 @@ int _output_dnssim_handle_pending_queries(_output_dnssim_client_t* client);
 int _output_dnssim_tcp_connect(output_dnssim_t* self, _output_dnssim_connection_t* conn);
 void _output_dnssim_tcp_close(_output_dnssim_connection_t* conn);
 void _output_dnssim_tcp_write_query(_output_dnssim_connection_t* conn, _output_dnssim_query_tcp_t* qry);
-int _output_dnssim_tls_init(_output_dnssim_connection_t* conn);
 void _output_dnssim_conn_close(_output_dnssim_connection_t* conn);
 void _output_dnssim_conn_idle(_output_dnssim_connection_t* conn);
 int _output_dnssim_handle_pending_queries(_output_dnssim_client_t* client);
 void _output_dnssim_conn_activate(_output_dnssim_connection_t* conn);
 void _output_dnssim_conn_maybe_free(_output_dnssim_connection_t* conn);
 void _output_dnssim_read_dns_stream(_output_dnssim_connection_t* conn, size_t len, const char* data);
+
+#if GNUTLS_VERSION_NUMBER >= DNSSIM_MIN_GNUTLS_VERSION
+int _output_dnssim_create_query_tls(output_dnssim_t* self, _output_dnssim_request_t* req);
+void _output_dnssim_close_query_tls(_output_dnssim_query_tcp_t* qry);
+int _output_dnssim_tls_init(_output_dnssim_connection_t* conn);
 void _output_dnssim_tls_process_input_data(_output_dnssim_connection_t* conn);
 void _output_dnssim_tls_close(_output_dnssim_connection_t* conn);
 void _output_dnssim_tls_write_query(_output_dnssim_connection_t* conn, _output_dnssim_query_tcp_t* qry);
+#endif
 
 #endif

--- a/src/output/dnssim/internal.h
+++ b/src/output/dnssim/internal.h
@@ -161,15 +161,15 @@ struct _output_dnssim_connection {
     /* State of the data stream read. */
     _output_dnssim_read_state_t read_state;
 
-    /* Total length of the expected stream data (either 2 for dnslen, or dnslen itself). */
-    size_t recv_len;
+    /* Total length of the expected dns data (either 2 for dnslen, or dnslen itself). */
+    size_t dnsbuf_len;
 
-    /* Current position in the receive buffer. */
-    size_t recv_pos;
+    /* Current position in the receive dns buffer. */
+    size_t dnsbuf_pos;
 
     /* Receive buffer used for incomplete messages or dnslen. */
-    char* recv_data;
-    bool  recv_free_after_use;
+    char* dnsbuf_data;
+    bool  dnsbuf_free_after_use;
 
     /* Statistics interval in which the handshake is tracked. */
     output_dnssim_stats_t* stats;

--- a/src/output/dnssim/internal.h
+++ b/src/output/dnssim/internal.h
@@ -235,7 +235,7 @@ struct _output_dnssim {
     /* Array of clients, mapped by client ID (ranges from 0 to max_clients). */
     _output_dnssim_client_t* client_arr;
 
-    gnutls_priority_t tls_priority;
+    gnutls_priority_t* tls_priority;
     gnutls_certificate_credentials_t tls_cred;
     char wire_buf[WIRE_BUF_SIZE];  /* thread-local buffer for processing tls input */
 };

--- a/src/output/dnssim/internal.h
+++ b/src/output/dnssim/internal.h
@@ -206,6 +206,9 @@ struct _output_dnssim_client {
 
     /* List of queries that are pending to be sent over any available connection. */
     _output_dnssim_query_t* pending;
+
+    /* TLS-ticket for session resumption. */
+    gnutls_datum_t tls_ticket;
 };
 
 /*

--- a/src/output/dnssim/tcp.c
+++ b/src/output/dnssim/tcp.c
@@ -154,6 +154,7 @@ static void _on_tcp_read(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf
     output_dnssim_t* self = conn->client->dnssim;
 
     if (nread > 0) {
+        mldebug("tcp nread: %d", nread);
         switch(_self->transport) {
         case OUTPUT_DNSSIM_TRANSPORT_TCP:
             _output_dnssim_read_dns_stream(conn, nread, buf->base);
@@ -200,6 +201,7 @@ static void _on_tcp_connected(uv_connect_t* conn_req, int status)
         return;
     }
 
+    mldebug("tcp connected");
     mlassert(conn->client, "conn must be associated with a client");
     mlassert(conn->client->dnssim, "client must be associated with dnssim");
     output_dnssim_t* self = conn->client->dnssim;
@@ -208,6 +210,7 @@ static void _on_tcp_connected(uv_connect_t* conn_req, int status)
         _output_dnssim_conn_activate(conn);
         break;
     case OUTPUT_DNSSIM_TRANSPORT_TLS:
+        mldebug("init tls handshake");
         _output_dnssim_tls_process_input_data(conn);  /* Initiate TLS handshake. */
         break;
     default:
@@ -265,6 +268,7 @@ int _output_dnssim_tcp_connect(output_dnssim_t* self, _output_dnssim_connection_
         uv_timer_stop(conn->idle_timer);
     }
 
+    mldebug("tcp connecting");
     uv_connect_t* conn_req;
     lfatal_oom(conn_req = malloc(sizeof(uv_connect_t)));
     ret = uv_tcp_connect(conn_req, conn->handle, (struct sockaddr*)&_self->target, _on_tcp_connected);

--- a/src/output/dnssim/tcp.c
+++ b/src/output/dnssim/tcp.c
@@ -161,7 +161,7 @@ static void _on_tcp_read(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf
             break;
         case OUTPUT_DNSSIM_TRANSPORT_TLS:
             mlassert(conn->tls, "con must have tls ctx");
-            conn->tls->buf = buf->base;
+            conn->tls->buf = (uint8_t*)buf->base;
             conn->tls->buf_pos = 0;
             conn->tls->buf_len = nread;
             _output_dnssim_tls_process_input_data(conn);

--- a/src/output/dnssim/tcp.c
+++ b/src/output/dnssim/tcp.c
@@ -267,7 +267,7 @@ int _parse_dnsbuf_data(_output_dnssim_connection_t* conn)
     return ret;
 }
 
-unsigned int _read_tcp_stream(_output_dnssim_connection_t* conn, size_t len, const char* data)
+unsigned int _read_dns_stream(_output_dnssim_connection_t* conn, size_t len, const char* data)
 {
     mlassert(conn, "conn can't be nil");
     mlassert(data, "data can't be nil");
@@ -320,7 +320,7 @@ static void _on_tcp_read(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf
         int   chunk = 0;
         char* data  = buf->base;
         while (pos < nread) {
-            chunk = _read_tcp_stream(conn, nread - pos, data + pos);
+            chunk = _read_dns_stream(conn, nread - pos, data + pos);
             if (chunk < 0) {
                 mlwarning("lost orientation in TCP stream, closing");
                 _close_connection(conn);

--- a/src/output/dnssim/tcp.c
+++ b/src/output/dnssim/tcp.c
@@ -160,11 +160,15 @@ static void _on_tcp_read(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf
             _output_dnssim_read_dns_stream(conn, nread, buf->base);
             break;
         case OUTPUT_DNSSIM_TRANSPORT_TLS:
+#if GNUTLS_VERSION_NUMBER >= DNSSIM_MIN_GNUTLS_VERSION
             mlassert(conn->tls, "con must have tls ctx");
             conn->tls->buf = (uint8_t*)buf->base;
             conn->tls->buf_pos = 0;
             conn->tls->buf_len = nread;
             _output_dnssim_tls_process_input_data(conn);
+#else
+            mlfatal(DNSSIM_MIN_GNUTLS_ERRORMSG);
+#endif
             break;
         default:
             mlfatal("unsupported transport");
@@ -210,8 +214,12 @@ static void _on_tcp_connected(uv_connect_t* conn_req, int status)
         _output_dnssim_conn_activate(conn);
         break;
     case OUTPUT_DNSSIM_TRANSPORT_TLS:
+#if GNUTLS_VERSION_NUMBER >= DNSSIM_MIN_GNUTLS_VERSION
         mldebug("init tls handshake");
         _output_dnssim_tls_process_input_data(conn);  /* Initiate TLS handshake. */
+#else
+        mlfatal(DNSSIM_MIN_GNUTLS_ERRORMSG);
+#endif
         break;
     default:
         lfatal("unsupported transport protocol");

--- a/src/output/dnssim/tls.c
+++ b/src/output/dnssim/tls.c
@@ -261,6 +261,7 @@ int _output_dnssim_tls_init(_output_dnssim_connection_t* conn)
     conn->tls->buf = NULL;
     conn->tls->buf_len = 0;
     conn->tls->buf_pos = 0;
+    conn->tls->write_queue_size = 0;
 
 	ret = gnutls_init(&conn->tls->session, GNUTLS_CLIENT | GNUTLS_NONBLOCK);
     if (ret < 0) {

--- a/src/output/dnssim/tls.c
+++ b/src/output/dnssim/tls.c
@@ -370,7 +370,7 @@ void _output_dnssim_tls_write_query(_output_dnssim_connection_t* conn, _output_d
 
 	int ret = gnutls_record_uncork(conn->tls->session, GNUTLS_RECORD_WAIT);
 	if (gnutls_error_is_fatal(ret)) {
-        mlwarning("gnutls_record_uncorck failed: %s", gnutls_strerror_name(ret));
+        mlinfo("gnutls_record_uncorck failed: %s", gnutls_strerror_name(ret));
         _output_dnssim_conn_close(conn);
         return;
 	}

--- a/src/output/dnssim/tls.c
+++ b/src/output/dnssim/tls.c
@@ -71,6 +71,7 @@ void _output_dnssim_tls_process_input_data(_output_dnssim_connection_t* conn)
      * See https://www.gnutls.org/manual/html_node/TLS-handshake.html */
     while (conn->state <= _OUTPUT_DNSSIM_CONN_TLS_HANDSHAKE) {
         int err = _tls_handshake(conn);
+        mldebug("tls handshake returned: %s", gnutls_strerror(err));
         if (err == GNUTLS_E_SUCCESS) {
             _output_dnssim_conn_activate(conn);
             if (gnutls_session_is_resumed(conn->tls->session))
@@ -128,6 +129,7 @@ static ssize_t _tls_pull(gnutls_transport_ptr_t ptr, void *buf, size_t len)
 
     ssize_t	avail = conn->tls->buf_len - conn->tls->buf_pos;
     if (conn->tls->buf_pos >= conn->tls->buf_len) {
+        mldebug("tls pull: no more data");
         errno = EAGAIN;
         return -1;
     }

--- a/src/output/dnssim/tls.c
+++ b/src/output/dnssim/tls.c
@@ -315,6 +315,7 @@ void _output_dnssim_close_query_tls(_output_dnssim_query_tcp_t* qry)
     _output_dnssim_request_t* req = qry->qry.req;
     mlassert(req->client, "request must belong to a client");
 
+    _ll_try_remove(req->client->pending, &qry->qry);
     if (qry->conn) {
         _output_dnssim_connection_t* conn = qry->conn;
         _ll_try_remove(conn->sent, &qry->qry);

--- a/src/output/dnssim/tls.c
+++ b/src/output/dnssim/tls.c
@@ -28,6 +28,8 @@
 #include <gnutls/gnutls.h>
 #include <string.h>
 
+#if GNUTLS_VERSION_NUMBER >= DNSSIM_MIN_GNUTLS_VERSION
+
 #define MIN(a,b) (((a)<(b))?(a):(b))			/** Minimum of two numbers **/
 
 static core_log_t _log = LOG_T_INIT("output.dnssim");
@@ -372,7 +374,6 @@ void _output_dnssim_tls_close(_output_dnssim_connection_t* conn)
     mlassert(conn->tls, "conn must have tls ctx");
     mlassert(conn->client, "conn must belong to a client");
 
-#if GNUTLS_VERSION_NUMBER >= 0x030603
     /* Try and get a TLS session ticket for potential resumption. */
     int ret;
     if (gnutls_session_get_flags(conn->tls->session) & GNUTLS_SFLAGS_SESSION_TICKET) {
@@ -385,7 +386,6 @@ void _output_dnssim_tls_close(_output_dnssim_connection_t* conn)
             conn->client->tls_ticket.size = 0;
         }
     }
-#endif
 
     gnutls_deinit(conn->tls->session);
     _output_dnssim_tcp_close(conn);
@@ -443,3 +443,5 @@ void _output_dnssim_tls_write_query(_output_dnssim_connection_t* conn, _output_d
 
     qry->qry.state = _OUTPUT_DNSSIM_QUERY_SENT;
 }
+
+#endif

--- a/src/output/dnssim/tls.c
+++ b/src/output/dnssim/tls.c
@@ -92,6 +92,9 @@ void _output_dnssim_tls_process_input_data(_output_dnssim_connection_t* conn)
 
 	/* See https://gnutls.org/manual/html_node/Data-transfer-and-termination.html#Data-transfer-and-termination */
 	while (true) {
+        if (conn->state != _OUTPUT_DNSSIM_CONN_ACTIVE)
+            return;
+
 		ssize_t count = gnutls_record_recv(conn->tls->session, _self->wire_buf, WIRE_BUF_SIZE);
         if (count > 0) {
             _output_dnssim_read_dns_stream(conn, count, _self->wire_buf);

--- a/src/output/dnssim/tls.c
+++ b/src/output/dnssim/tls.c
@@ -368,8 +368,7 @@ void _output_dnssim_tls_close(_output_dnssim_connection_t* conn)
     mlassert(conn->tls, "conn must have tls ctx");
     mlassert(conn->client, "conn must belong to a client");
 
-    // TODO gnutls detect support
-    // TODO make optional
+#if GNUTLS_VERSION_NUMBER >= 0x030603
     /* Try and get a TLS session ticket for potential resumption. */
     int ret;
     if (gnutls_session_get_flags(conn->tls->session) & GNUTLS_SFLAGS_SESSION_TICKET) {
@@ -382,6 +381,7 @@ void _output_dnssim_tls_close(_output_dnssim_connection_t* conn)
             conn->client->tls_ticket.size = 0;
         }
     }
+#endif
 
     gnutls_deinit(conn->tls->session);
     _output_dnssim_tcp_close(conn);

--- a/src/output/dnssim/tls.c
+++ b/src/output/dnssim/tls.c
@@ -132,7 +132,7 @@ static void _tls_on_write_complete(uv_write_t *req, int status)
 	_output_dnssim_connection_t* conn = async_ctx->conn;
     mlassert(conn, "conn is nil");
     mlassert(conn->tls, "conn must have tls ctx");
-    mlassert(conn->tls->write_queue_size > 0, "invalid write_queue_size");
+    mlassert(conn->tls->write_queue_size > 0, "invalid write_queue_size: %d", conn->tls->write_queue_size);
 	conn->tls->write_queue_size -= 1;
 	free(req->data);
 

--- a/src/output/dnssim/tls.c
+++ b/src/output/dnssim/tls.c
@@ -73,6 +73,11 @@ void _output_dnssim_tls_process_input_data(_output_dnssim_connection_t* conn)
 		int err = _tls_handshake(conn);
 		if (err == GNUTLS_E_AGAIN) {
 			return; /* Wait for more data */
+        } else if (err == GNUTLS_E_FATAL_ALERT_RECEIVED) {
+            gnutls_alert_description_t alert = gnutls_alert_get(conn->tls->session);
+            mlwarning("gnutls_handshake failed: %s", gnutls_alert_get_name(alert));
+            _output_dnssim_conn_close(conn);
+            return;
 		} else if (err < 0) {
             mlwarning("gnutls_handshake failed: %s", gnutls_strerror_name(err));
             _output_dnssim_conn_close(conn);

--- a/src/output/dnssim/tls.c
+++ b/src/output/dnssim/tls.c
@@ -175,7 +175,8 @@ static ssize_t _tls_vec_push(gnutls_transport_ptr_t ptr, const giovec_t * iov, i
 
     size_t total_len = 0;
     uv_buf_t uv_buf[iovcnt];
-    for (int i = 0; i < iovcnt; ++i) {
+    int i;
+    for (i = 0; i < iovcnt; ++i) {
         uv_buf[i].base = iov[i].iov_base;
         uv_buf[i].len = iov[i].iov_len;
         total_len += iov[i].iov_len;
@@ -225,7 +226,8 @@ static ssize_t _tls_vec_push(gnutls_transport_ptr_t ptr, const giovec_t * iov, i
         size_t to_skip = ret;
         /* Copy the buffer into owned memory */
         size_t off = 0;
-        for (int i = 0; i < iovcnt; ++i) {
+        int i;
+        for (i = 0; i < iovcnt; ++i) {
             if (to_skip > 0) {
                 /* Ignore current buffer if it's all skipped */
                 if (to_skip >= uv_buf[i].len) {

--- a/src/output/dnssim/tls.c
+++ b/src/output/dnssim/tls.c
@@ -33,9 +33,9 @@
 static core_log_t _log = LOG_T_INIT("output.dnssim");
 
 struct async_write_ctx {
-	uv_write_t write_req;
-	_output_dnssim_connection_t* conn;
-	char buf[];
+    uv_write_t write_req;
+    _output_dnssim_connection_t* conn;
+    char buf[];
 };
 
 static int _tls_handshake(_output_dnssim_connection_t* conn)
@@ -52,7 +52,7 @@ static int _tls_handshake(_output_dnssim_connection_t* conn)
     }
     conn->state = _OUTPUT_DNSSIM_CONN_TLS_HANDSHAKE;
 
-	return gnutls_handshake(conn->tls->session);
+    return gnutls_handshake(conn->tls->session);
 }
 
 void _output_dnssim_tls_process_input_data(_output_dnssim_connection_t* conn)
@@ -67,56 +67,56 @@ void _output_dnssim_tls_process_input_data(_output_dnssim_connection_t* conn)
 
     output_dnssim_t* self = conn->client->dnssim;
 
-	/* Ensure TLS handshake is performed before receiving data.
-	 * See https://www.gnutls.org/manual/html_node/TLS-handshake.html */
-	while (conn->state <= _OUTPUT_DNSSIM_CONN_TLS_HANDSHAKE) {
-		int err = _tls_handshake(conn);
+    /* Ensure TLS handshake is performed before receiving data.
+     * See https://www.gnutls.org/manual/html_node/TLS-handshake.html */
+    while (conn->state <= _OUTPUT_DNSSIM_CONN_TLS_HANDSHAKE) {
+        int err = _tls_handshake(conn);
         if (err == GNUTLS_E_SUCCESS) {
             _output_dnssim_conn_activate(conn);
             if (gnutls_session_is_resumed(conn->tls->session))
                 conn->stats->conn_resumed++;
             break;
         } else if (err == GNUTLS_E_AGAIN) {
-			return; /* Wait for more data */
+            return; /* Wait for more data */
         } else if (err == GNUTLS_E_FATAL_ALERT_RECEIVED) {
             gnutls_alert_description_t alert = gnutls_alert_get(conn->tls->session);
             mlwarning("gnutls_handshake failed: %s", gnutls_alert_get_name(alert));
             _output_dnssim_conn_close(conn);
             return;
-		} else if (gnutls_error_is_fatal(err)) {
+        } else if (gnutls_error_is_fatal(err)) {
             mlwarning("gnutls_handshake failed: %s", gnutls_strerror_name(err));
             _output_dnssim_conn_close(conn);
             return;
-		}
-	}
+        }
+    }
 
-	/* See https://gnutls.org/manual/html_node/Data-transfer-and-termination.html#Data-transfer-and-termination */
-	while (true) {
+    /* See https://gnutls.org/manual/html_node/Data-transfer-and-termination.html#Data-transfer-and-termination */
+    while (true) {
         if (conn->state != _OUTPUT_DNSSIM_CONN_ACTIVE)
             return;
 
-		ssize_t count = gnutls_record_recv(conn->tls->session, _self->wire_buf, WIRE_BUF_SIZE);
+        ssize_t count = gnutls_record_recv(conn->tls->session, _self->wire_buf, WIRE_BUF_SIZE);
         if (count > 0) {
             _output_dnssim_read_dns_stream(conn, count, _self->wire_buf);
         } else if (count == GNUTLS_E_AGAIN) {
-			if (conn->tls->buf_pos == conn->tls->buf_len) {
-				/* See https://www.gnutls.org/manual/html_node/Asynchronous-operation.html */
-				break; /* No more data available in this libuv buffer */
-			}
-			continue;
-		} else if (count == GNUTLS_E_INTERRUPTED) {
-			continue;
-		} else if (count == GNUTLS_E_REHANDSHAKE) {
+            if (conn->tls->buf_pos == conn->tls->buf_len) {
+                /* See https://www.gnutls.org/manual/html_node/Asynchronous-operation.html */
+                break; /* No more data available in this libuv buffer */
+            }
+            continue;
+        } else if (count == GNUTLS_E_INTERRUPTED) {
+            continue;
+        } else if (count == GNUTLS_E_REHANDSHAKE) {
             // TODO implement rehandshake?
-			continue;
-		} else if (count < 0) {
+            continue;
+        } else if (count < 0) {
             mlwarning("gnutls_record_recv failed: %s", gnutls_strerror_name(count));
             _output_dnssim_conn_close(conn);
             return;
-		} else if (count == 0) {
-			break;
-		}
-	}
+        } else if (count == 0) {
+            break;
+        }
+    }
     mlassert(conn->tls->buf_len == conn->tls->buf_pos, "tls didn't read the entire buffer");
 
 }
@@ -127,28 +127,28 @@ static ssize_t _tls_pull(gnutls_transport_ptr_t ptr, void *buf, size_t len)
     mlassert(conn != NULL, "conn is null");
     mlassert(conn->tls != NULL, "conn must have tls ctx");
 
-	ssize_t	avail = conn->tls->buf_len - conn->tls->buf_pos;
-	if (conn->tls->buf_pos >= conn->tls->buf_len) {
-		errno = EAGAIN;
-		return -1;
-	}
+    ssize_t	avail = conn->tls->buf_len - conn->tls->buf_pos;
+    if (conn->tls->buf_pos >= conn->tls->buf_len) {
+        errno = EAGAIN;
+        return -1;
+    }
 
-	ssize_t	transfer = MIN(avail, len);
-	memcpy(buf, conn->tls->buf + conn->tls->buf_pos, transfer);
-	conn->tls->buf_pos += transfer;
-	return transfer;
+    ssize_t	transfer = MIN(avail, len);
+    memcpy(buf, conn->tls->buf + conn->tls->buf_pos, transfer);
+    conn->tls->buf_pos += transfer;
+    return transfer;
 }
 
 static void _tls_on_write_complete(uv_write_t *req, int status)
 {
-	mlassert(req->data != NULL, "uv_write req has no data pointer");
-	struct async_write_ctx *async_ctx = (struct async_write_ctx *)req->data;
-	_output_dnssim_connection_t* conn = async_ctx->conn;
+    mlassert(req->data != NULL, "uv_write req has no data pointer");
+    struct async_write_ctx *async_ctx = (struct async_write_ctx *)req->data;
+    _output_dnssim_connection_t* conn = async_ctx->conn;
     mlassert(conn, "conn is nil");
     mlassert(conn->tls, "conn must have tls ctx");
     mlassert(conn->tls->write_queue_size > 0, "invalid write_queue_size: %d", conn->tls->write_queue_size);
-	conn->tls->write_queue_size -= 1;
-	free(req->data);
+    conn->tls->write_queue_size -= 1;
+    free(req->data);
 
     if (status < 0)
         _output_dnssim_conn_close(conn);
@@ -160,123 +160,122 @@ static ssize_t _tls_vec_push(gnutls_transport_ptr_t ptr, const giovec_t * iov, i
     mlassert(conn != NULL, "conn is null");
     mlassert(conn->tls != NULL, "conn must have tls ctx");
 
-	if (iovcnt == 0)
-		return 0;
+    if (iovcnt == 0)
+        return 0;
 
-	/*
-	 * This is a little bit complicated. There are two different writes:
-	 * 1. Immediate, these don't need to own the buffered data and return immediately
-	 * 2. Asynchronous, these need to own the buffers until the write completes
-	 * In order to avoid copying the buffer, an immediate write is tried first if possible.
-	 * If it isn't possible to write the data without queueing, an asynchronous write
-	 * is created (with copied buffered data).
-	 */
+    /*
+     * This is a little bit complicated. There are two different writes:
+     * 1. Immediate, these don't need to own the buffered data and return immediately
+     * 2. Asynchronous, these need to own the buffers until the write completes
+     * In order to avoid copying the buffer, an immediate write is tried first if possible.
+     * If it isn't possible to write the data without queueing, an asynchronous write
+     * is created (with copied buffered data).
+     */
 
-	size_t total_len = 0;
-	uv_buf_t uv_buf[iovcnt];
-	for (int i = 0; i < iovcnt; ++i) {
-		uv_buf[i].base = iov[i].iov_base;
-		uv_buf[i].len = iov[i].iov_len;
-		total_len += iov[i].iov_len;
-	}
+    size_t total_len = 0;
+    uv_buf_t uv_buf[iovcnt];
+    for (int i = 0; i < iovcnt; ++i) {
+        uv_buf[i].base = iov[i].iov_base;
+        uv_buf[i].len = iov[i].iov_len;
+        total_len += iov[i].iov_len;
+    }
 
-	/* Try to perform the immediate write first to avoid copy */
-	int ret = 0;
-	if (conn->tls->write_queue_size == 0) {
-		ret = uv_try_write((uv_stream_t*)conn->handle, uv_buf, iovcnt);
-		/* from libuv documentation -
-		   uv_try_write will return either:
-		     > 0: number of bytes written (can be less than the supplied buffer size).
-		     < 0: negative error code (UV_EAGAIN is returned if no data can be sent immediately).
-		*/
-		if (ret == total_len) {
-			/* All the data were buffered by libuv.
-			 * Return. */
-			return ret;
-		}
+    /* Try to perform the immediate write first to avoid copy */
+    int ret = 0;
+    if (conn->tls->write_queue_size == 0) {
+        ret = uv_try_write((uv_stream_t*)conn->handle, uv_buf, iovcnt);
+        /* from libuv documentation -
+           uv_try_write will return either:
+           > 0: number of bytes written (can be less than the supplied buffer size).
+           < 0: negative error code (UV_EAGAIN is returned if no data can be sent immediately).
+           */
+        if (ret == total_len) {
+            /* All the data were buffered by libuv.
+             * Return. */
+            return ret;
+        }
 
-		if (ret < 0 && ret != UV_EAGAIN) {
-			/* uv_try_write() has returned error code other then UV_EAGAIN.
-			 * Return. */
-			errno = EIO;
-			return -1;
-		}
-		/* Since we are here expression below is true
-		 * (ret != total_len) && (ret >= 0 || ret == UV_EAGAIN)
-		 * or the same
-		 * (ret != total_len && ret >= 0) || (ret != total_len && ret == UV_EAGAIN)
-		 * i.e. either occurs partial write or UV_EAGAIN.
-		 * Proceed and copy data amount to owned memory and perform async write.
-		 */
-		if (ret == UV_EAGAIN) {
-			/* No data were buffered, so we must buffer all the data. */
-			ret = 0;
-		}
-	}
+        if (ret < 0 && ret != UV_EAGAIN) {
+            /* uv_try_write() has returned error code other then UV_EAGAIN.
+             * Return. */
+            errno = EIO;
+            return -1;
+        }
+        /* Since we are here expression below is true
+         * (ret != total_len) && (ret >= 0 || ret == UV_EAGAIN)
+         * or the same
+         * (ret != total_len && ret >= 0) || (ret != total_len && ret == UV_EAGAIN)
+         * i.e. either occurs partial write or UV_EAGAIN.
+         * Proceed and copy data amount to owned memory and perform async write.
+         */
+        if (ret == UV_EAGAIN) {
+            /* No data were buffered, so we must buffer all the data. */
+            ret = 0;
+        }
+    }
 
-	/* Fallback when the queue is full, and it's not possible to do an immediate write */
-	char *p = malloc(sizeof(struct async_write_ctx) + total_len - ret);
-	if (p != NULL) {
-		struct async_write_ctx *async_ctx = (struct async_write_ctx *)p;
-		async_ctx->conn = conn;
-		char *buf = async_ctx->buf;
-		/* Skip data written in the partial write */
-		size_t to_skip = ret;
-		/* Copy the buffer into owned memory */
-		size_t off = 0;
-		for (int i = 0; i < iovcnt; ++i) {
-			if (to_skip > 0) {
-				/* Ignore current buffer if it's all skipped */
-				if (to_skip >= uv_buf[i].len) {
-					to_skip -= uv_buf[i].len;
-					continue;
-				}
-				/* Skip only part of the buffer */
-				uv_buf[i].base += to_skip;
-				uv_buf[i].len -= to_skip;
-				to_skip = 0;
-			}
-			memcpy(buf + off, uv_buf[i].base, uv_buf[i].len);
-			off += uv_buf[i].len;
-		}
-		uv_buf[0].base = buf;
-		uv_buf[0].len = off;
+    /* Fallback when the queue is full, and it's not possible to do an immediate write */
+    char *p = malloc(sizeof(struct async_write_ctx) + total_len - ret);
+    if (p != NULL) {
+        struct async_write_ctx *async_ctx = (struct async_write_ctx *)p;
+        async_ctx->conn = conn;
+        char *buf = async_ctx->buf;
+        /* Skip data written in the partial write */
+        size_t to_skip = ret;
+        /* Copy the buffer into owned memory */
+        size_t off = 0;
+        for (int i = 0; i < iovcnt; ++i) {
+            if (to_skip > 0) {
+                /* Ignore current buffer if it's all skipped */
+                if (to_skip >= uv_buf[i].len) {
+                    to_skip -= uv_buf[i].len;
+                    continue;
+                }
+                /* Skip only part of the buffer */
+                uv_buf[i].base += to_skip;
+                uv_buf[i].len -= to_skip;
+                to_skip = 0;
+            }
+            memcpy(buf + off, uv_buf[i].base, uv_buf[i].len);
+            off += uv_buf[i].len;
+        }
+        uv_buf[0].base = buf;
+        uv_buf[0].len = off;
 
-		/* Create an asynchronous write request */
-		uv_write_t *write_req = &async_ctx->write_req;
-		memset(write_req, 0, sizeof(uv_write_t));
-		write_req->data = p;
+        /* Create an asynchronous write request */
+        uv_write_t *write_req = &async_ctx->write_req;
+        memset(write_req, 0, sizeof(uv_write_t));
+        write_req->data = p;
 
-		/* Perform an asynchronous write with a callback */
-		if (uv_write(write_req, (uv_stream_t*)conn->handle, uv_buf, 1, _tls_on_write_complete) == 0) {
-			ret = total_len;
-			conn->tls->write_queue_size += 1;
-		} else {
-			free(p);
-			errno = EIO;
-			ret = -1;
-		}
-	} else {
-		errno = ENOMEM;
-		ret = -1;
-	}
+        /* Perform an asynchronous write with a callback */
+        if (uv_write(write_req, (uv_stream_t*)conn->handle, uv_buf, 1, _tls_on_write_complete) == 0) {
+            ret = total_len;
+            conn->tls->write_queue_size += 1;
+        } else {
+            free(p);
+            errno = EIO;
+            ret = -1;
+        }
+    } else {
+        errno = ENOMEM;
+        ret = -1;
+    }
 
-	return ret;
+    return ret;
 }
 
-// TODO reident everything
 int _tls_pull_timeout(gnutls_transport_ptr_t ptr, unsigned int ms)
 {
     _output_dnssim_connection_t* conn = (_output_dnssim_connection_t*)ptr;
     mlassert(conn != NULL, "conn is null");
     mlassert(conn->tls != NULL, "conn must have tls ctx");
 
-	ssize_t	avail = conn->tls->buf_len - conn->tls->buf_pos;
-	if (avail <= 0) {
-		errno = EAGAIN;
-		return -1;
-	}
-	return avail;
+    ssize_t	avail = conn->tls->buf_len - conn->tls->buf_pos;
+    if (avail <= 0) {
+        errno = EAGAIN;
+        return -1;
+    }
+    return avail;
 }
 
 int _output_dnssim_tls_init(_output_dnssim_connection_t* conn)
@@ -291,7 +290,7 @@ int _output_dnssim_tls_init(_output_dnssim_connection_t* conn)
     conn->tls->buf_pos = 0;
     conn->tls->write_queue_size = 0;
 
-	ret = gnutls_init(&conn->tls->session, GNUTLS_CLIENT | GNUTLS_NONBLOCK);
+    ret = gnutls_init(&conn->tls->session, GNUTLS_CLIENT | GNUTLS_NONBLOCK);
     if (ret < 0) {
         mldebug("failed gnutls_init() (%s)", gnutls_strerror(ret));
         return ret;
@@ -318,12 +317,12 @@ int _output_dnssim_tls_init(_output_dnssim_connection_t* conn)
         return ret;
     }
 
-	gnutls_transport_set_pull_function(conn->tls->session, _tls_pull);
-	gnutls_transport_set_pull_timeout_function(conn->tls->session, _tls_pull_timeout);
-	gnutls_transport_set_vec_push_function(conn->tls->session, _tls_vec_push);
-	gnutls_transport_set_ptr(conn->tls->session, conn);
+    gnutls_transport_set_pull_function(conn->tls->session, _tls_pull);
+    gnutls_transport_set_pull_timeout_function(conn->tls->session, _tls_pull_timeout);
+    gnutls_transport_set_vec_push_function(conn->tls->session, _tls_vec_push);
+    gnutls_transport_set_ptr(conn->tls->session, conn);
 
-	return 0;
+    return 0;
 }
 
 // TODO so far this is the same as the tcp function (except qry.transport)
@@ -406,29 +405,29 @@ void _output_dnssim_tls_write_query(_output_dnssim_connection_t* conn, _output_d
     core_object_payload_t* payload = (core_object_payload_t*)qry->qry.req->dns_q->obj_prev;
     uint16_t len = htons(payload->len);
 
-	gnutls_record_cork(conn->tls->session);
-	ssize_t count = 0;
-	if ((count = gnutls_record_send(conn->tls->session, &len, sizeof(len)) < 0) ||
-	    (count = gnutls_record_send(conn->tls->session, payload->payload, payload->len) < 0)) {
+    gnutls_record_cork(conn->tls->session);
+    ssize_t count = 0;
+    if ((count = gnutls_record_send(conn->tls->session, &len, sizeof(len)) < 0) ||
+            (count = gnutls_record_send(conn->tls->session, payload->payload, payload->len) < 0)) {
         mlwarning("gnutls_record_send failed: %s", gnutls_strerror_name(count));
         _output_dnssim_conn_close(conn);
         return;
-	}
+    }
 
-	const ssize_t submitted = sizeof(len) + payload->len;
+    const ssize_t submitted = sizeof(len) + payload->len;
 
-	int ret = gnutls_record_uncork(conn->tls->session, GNUTLS_RECORD_WAIT);
-	if (gnutls_error_is_fatal(ret)) {
+    int ret = gnutls_record_uncork(conn->tls->session, GNUTLS_RECORD_WAIT);
+    if (gnutls_error_is_fatal(ret)) {
         mlinfo("gnutls_record_uncorck failed: %s", gnutls_strerror_name(ret));
         _output_dnssim_conn_close(conn);
         return;
-	}
+    }
 
-	if (ret != submitted) {
+    if (ret != submitted) {
         mlwarning("gnutls_record_uncork didn't send all data");
         _output_dnssim_conn_close(conn);
         return;
-	}
+    }
 
     qry->conn = conn;
     _ll_remove(conn->client->pending, &qry->qry);

--- a/src/output/dnssim/tls.c
+++ b/src/output/dnssim/tls.c
@@ -28,33 +28,229 @@
 #include <gnutls/gnutls.h>
 #include <string.h>
 
+#define MIN(a,b) (((a)<(b))?(a):(b))			/** Minimum of two numbers **/
+
+#define WIRE_BUF_SIZE 65535 + 2 + 16384  /** max tcplen + 2b tcplen + 16kb tls record */
+
 static core_log_t _log = LOG_T_INIT("output.dnssim");
 
+struct async_write_ctx {
+	uv_write_t write_req;
+	_output_dnssim_connection_t* conn;
+	char buf[];
+};
 
-void _tls_process_input_data()
+static int _tls_handshake(_output_dnssim_connection_t* conn)
 {
+    mlassert(conn, "conn is nil");
+    mlassert(conn->tls, "conn must have tls context");
+    mlassert(conn->state <= _OUTPUT_DNSSIM_CONN_TLS_HANDSHAKE, "conn in invalid state");
+
+    conn->state = _OUTPUT_DNSSIM_CONN_TLS_HANDSHAKE;
+
+	int err = gnutls_handshake(conn->tls->session);
+	if (err == GNUTLS_E_SUCCESS) {
+        _output_dnssim_conn_activate(conn);
+        return 0;
+	} else if (err == GNUTLS_E_AGAIN) {
+		return GNUTLS_E_AGAIN;
+	} else if (gnutls_error_is_fatal(err)) {
+        return err;
+	}
+	return 0;
+}
+
+void _output_dnssim_tls_process_input_data(_output_dnssim_connection_t* conn)
+{
+    static char wire_buf[WIRE_BUF_SIZE];
+    mlassert(conn, "conn is nil");
+    mlassert(conn->tls, "conn must have tls ctx");
+
+	/* Ensure TLS handshake is performed before receiving data.
+	 * See https://www.gnutls.org/manual/html_node/TLS-handshake.html */
+	while (conn->state <= _OUTPUT_DNSSIM_CONN_TLS_HANDSHAKE) {
+		int err = _tls_handshake(conn);
+		if (err == GNUTLS_E_AGAIN) {
+			return; /* Wait for more data */
+		} else if (err < 0) {
+            mlwarning("gnutls_handshake failed: %s", gnutls_strerror_name(err));
+            _output_dnssim_conn_close(conn);
+            return;
+		}
+	}
+
+	/* See https://gnutls.org/manual/html_node/Data-transfer-and-termination.html#Data-transfer-and-termination */
+	while (true) {
+		ssize_t count = gnutls_record_recv(conn->tls->session, wire_buf, WIRE_BUF_SIZE);
+        if (count > 0) {
+            _output_dnssim_read_dns_stream(conn, count, wire_buf);
+        } else if (count == GNUTLS_E_AGAIN) {
+			if (conn->tls->buf_pos == conn->tls->buf_len) {
+				/* See https://www.gnutls.org/manual/html_node/Asynchronous-operation.html */
+				break; /* No more data available in this libuv buffer */
+			}
+			continue;
+		} else if (count == GNUTLS_E_INTERRUPTED) {
+			continue;
+		} else if (count == GNUTLS_E_REHANDSHAKE) {
+            // TODO implement rehandshake?
+			continue;
+		} else if (count < 0) {
+            mlwarning("gnutls_record_recv failed: %s", gnutls_strerror_name(count));
+            _output_dnssim_conn_close(conn);
+            return;
+		} else if (count == 0) {
+			break;
+		}
+	}
+    mlassert(conn->tls->buf_len == conn->tls->buf_pos, "tls didn't read the entire buffer");
 
 }
 
-//static ssize_t _tls_pull(gnutls_transport_ptr_t h, void *buf, size_t len)
-//{
-//	struct tls_common_ctx *t = (struct tls_common_ctx *)h;
-//	assert(t != NULL);
-//
-//	ssize_t	avail = t->nread - t->consumed;
-//	DEBUG_MSG("[%s] pull wanted: %zu available: %zu\n",
-//		  t->client_side ? "tls_client" : "tls", len, avail);
-//	if (t->nread <= t->consumed) {
-//		errno = EAGAIN;
-//		return -1;
-//	}
-//
-//	ssize_t	transfer = MIN(avail, len);
-//	memcpy(buf, t->buf + t->consumed, transfer);
-//	t->consumed += transfer;
-//	return transfer;
-//}
-//
+static ssize_t _tls_pull(gnutls_transport_ptr_t ptr, void *buf, size_t len)
+{
+    _output_dnssim_connection_t* conn = (_output_dnssim_connection_t*)ptr;
+    mlassert(conn != NULL, "conn is null");
+    mlassert(conn->tls != NULL, "conn must have tls ctx");
+
+	ssize_t	avail = conn->tls->buf_len - conn->tls->buf_pos;
+	if (conn->tls->buf_pos >= conn->tls->buf_len) {
+		errno = EAGAIN;
+		return -1;
+	}
+
+	ssize_t	transfer = MIN(avail, len);
+	memcpy(buf, conn->tls->buf + conn->tls->buf_pos, transfer);
+	conn->tls->buf_pos += transfer;
+	return transfer;
+}
+
+static void _tls_on_write_complete(uv_write_t *req, int status)
+{
+	mlassert(req->data != NULL, "uv_write req has no data pointer");
+	struct async_write_ctx *async_ctx = (struct async_write_ctx *)req->data;
+	_output_dnssim_connection_t* conn = async_ctx->conn;
+    mlassert(conn, "conn is nil");
+    mlassert(conn->tls, "conn must have tls ctx");
+    mlassert(conn->tls->write_queue_size > 0, "invalid write_queue_size");
+	conn->tls->write_queue_size -= 1;
+	free(req->data);
+
+    if (status < 0)
+        _output_dnssim_conn_close(conn);
+}
+
+static ssize_t _tls_vec_push(gnutls_transport_ptr_t ptr, const giovec_t * iov, int iovcnt)
+{
+    _output_dnssim_connection_t* conn = (_output_dnssim_connection_t*)ptr;
+    mlassert(conn != NULL, "conn is null");
+    mlassert(conn->tls != NULL, "conn must have tls ctx");
+
+	if (iovcnt == 0)
+		return 0;
+
+	/*
+	 * This is a little bit complicated. There are two different writes:
+	 * 1. Immediate, these don't need to own the buffered data and return immediately
+	 * 2. Asynchronous, these need to own the buffers until the write completes
+	 * In order to avoid copying the buffer, an immediate write is tried first if possible.
+	 * If it isn't possible to write the data without queueing, an asynchronous write
+	 * is created (with copied buffered data).
+	 */
+
+	size_t total_len = 0;
+	uv_buf_t uv_buf[iovcnt];
+	for (int i = 0; i < iovcnt; ++i) {
+		uv_buf[i].base = iov[i].iov_base;
+		uv_buf[i].len = iov[i].iov_len;
+		total_len += iov[i].iov_len;
+	}
+
+	/* Try to perform the immediate write first to avoid copy */
+	int ret = 0;
+	if (conn->tls->write_queue_size == 0) {
+		ret = uv_try_write((uv_stream_t*)conn->handle, uv_buf, iovcnt);
+		/* from libuv documentation -
+		   uv_try_write will return either:
+		     > 0: number of bytes written (can be less than the supplied buffer size).
+		     < 0: negative error code (UV_EAGAIN is returned if no data can be sent immediately).
+		*/
+		if (ret == total_len) {
+			/* All the data were buffered by libuv.
+			 * Return. */
+			return ret;
+		}
+
+		if (ret < 0 && ret != UV_EAGAIN) {
+			/* uv_try_write() has returned error code other then UV_EAGAIN.
+			 * Return. */
+			errno = EIO;
+			return -1;
+		}
+		/* Since we are here expression below is true
+		 * (ret != total_len) && (ret >= 0 || ret == UV_EAGAIN)
+		 * or the same
+		 * (ret != total_len && ret >= 0) || (ret != total_len && ret == UV_EAGAIN)
+		 * i.e. either occurs partial write or UV_EAGAIN.
+		 * Proceed and copy data amount to owned memory and perform async write.
+		 */
+		if (ret == UV_EAGAIN) {
+			/* No data were buffered, so we must buffer all the data. */
+			ret = 0;
+		}
+	}
+
+	/* Fallback when the queue is full, and it's not possible to do an immediate write */
+	char *p = malloc(sizeof(struct async_write_ctx) + total_len - ret);
+	if (p != NULL) {
+		struct async_write_ctx *async_ctx = (struct async_write_ctx *)p;
+		async_ctx->conn = conn;
+		char *buf = async_ctx->buf;
+		/* Skip data written in the partial write */
+		size_t to_skip = ret;
+		/* Copy the buffer into owned memory */
+		size_t off = 0;
+		for (int i = 0; i < iovcnt; ++i) {
+			if (to_skip > 0) {
+				/* Ignore current buffer if it's all skipped */
+				if (to_skip >= uv_buf[i].len) {
+					to_skip -= uv_buf[i].len;
+					continue;
+				}
+				/* Skip only part of the buffer */
+				uv_buf[i].base += to_skip;
+				uv_buf[i].len -= to_skip;
+				to_skip = 0;
+			}
+			memcpy(buf + off, uv_buf[i].base, uv_buf[i].len);
+			off += uv_buf[i].len;
+		}
+		uv_buf[0].base = buf;
+		uv_buf[0].len = off;
+
+		/* Create an asynchronous write request */
+		uv_write_t *write_req = &async_ctx->write_req;
+		memset(write_req, 0, sizeof(uv_write_t));
+		write_req->data = p;
+
+		/* Perform an asynchronous write with a callback */
+		if (uv_write(write_req, (uv_stream_t*)conn->handle, uv_buf, 1, _tls_on_write_complete) == 0) {
+			ret = total_len;
+			conn->tls->write_queue_size += 1;
+		} else {
+			free(p);
+			errno = EIO;
+			ret = -1;
+		}
+	} else {
+		errno = ENOMEM;
+		ret = -1;
+	}
+
+	return ret;
+}
+
+
 int _output_dnssim_tls_init(_output_dnssim_connection_t* conn)
 {
     mlassert(conn, "conn is nil");
@@ -62,6 +258,9 @@ int _output_dnssim_tls_init(_output_dnssim_connection_t* conn)
 
     int ret;
     mlfatal_oom(conn->tls = malloc(sizeof(_output_dnssim_tls_ctx_t)));
+    conn->tls->buf = NULL;
+    conn->tls->buf_len = 0;
+    conn->tls->buf_pos = 0;
 
 	ret = gnutls_init(&conn->tls->session, GNUTLS_CLIENT | GNUTLS_NONBLOCK);
     if (ret < 0) {
@@ -76,145 +275,20 @@ int _output_dnssim_tls_init(_output_dnssim_connection_t* conn)
         return ret;
     }
 
-    ret = gnutls_credentials_set(conn->tls->session, GNUTLS_CRD_CERTIFICATE, &_self->tls_cred);
+    ret = gnutls_credentials_set(conn->tls->session, GNUTLS_CRD_CERTIFICATE, _self->tls_cred);
     if (ret < 0) {
         mldebug("failed gnutls_credentials_set() (%s)", gnutls_strerror(ret));
         return ret;
     }
 
-    // TODO implement
-	// gnutls_transport_set_pull_function(tls->c.tls_session, kres_gnutls_pull);
-	// gnutls_transport_set_vec_push_function(tls->c.tls_session, kres_gnutls_vec_push);
-	// gnutls_transport_set_ptr(conn->tls->session, conn);
+	gnutls_transport_set_pull_function(conn->tls->session, _tls_pull);
+	gnutls_transport_set_vec_push_function(conn->tls->session, _tls_vec_push);
+	gnutls_transport_set_ptr(conn->tls->session, conn);
 
 	return 0;
 }
 
-//static ssize_t _tls_vec_push(gnutls_transport_ptr_t h, const giovec_t * iov, int iovcnt)
-//{
-//	struct tls_common_ctx *t = (struct tls_common_ctx *)h;
-//
-//	if (t == NULL) {
-//		errno = EFAULT;
-//		return -1;
-//	}
-//
-//	if (iovcnt == 0) {
-//		return 0;
-//	}
-//
-//	assert(t->session);
-//	uv_stream_t *handle = (uv_stream_t *)session_get_handle(t->session);
-//	assert(handle && handle->type == UV_TCP);
-//
-//	/*
-//	 * This is a little bit complicated. There are two different writes:
-//	 * 1. Immediate, these don't need to own the buffered data and return immediately
-//	 * 2. Asynchronous, these need to own the buffers until the write completes
-//	 * In order to avoid copying the buffer, an immediate write is tried first if possible.
-//	 * If it isn't possible to write the data without queueing, an asynchronous write
-//	 * is created (with copied buffered data).
-//	 */
-//
-//	size_t total_len = 0;
-//	uv_buf_t uv_buf[iovcnt];
-//	for (int i = 0; i < iovcnt; ++i) {
-//		uv_buf[i].base = iov[i].iov_base;
-//		uv_buf[i].len = iov[i].iov_len;
-//		total_len += iov[i].iov_len;
-//	}
-//
-//	/* Try to perform the immediate write first to avoid copy */
-//	int ret = 0;
-//	if (stream_queue_is_empty(t)) {
-//		ret = uv_try_write(handle, uv_buf, iovcnt);
-//		DEBUG_MSG("[%s] push %zu <%p> = %d\n",
-//		    t->client_side ? "tls_client" : "tls", total_len, h, ret);
-//		/* from libuv documentation -
-//		   uv_try_write will return either:
-//		     > 0: number of bytes written (can be less than the supplied buffer size).
-//		     < 0: negative error code (UV_EAGAIN is returned if no data can be sent immediately).
-//		*/
-//		if (ret == total_len) {
-//			/* All the data were buffered by libuv.
-//			 * Return. */
-//			return ret;
-//		}
-//
-//		if (ret < 0 && ret != UV_EAGAIN) {
-//			/* uv_try_write() has returned error code other then UV_EAGAIN.
-//			 * Return. */
-//			ret = -1;
-//			errno = EIO;
-//			return ret;
-//		}
-//		/* Since we are here expression below is true
-//		 * (ret != total_len) && (ret >= 0 || ret == UV_EAGAIN)
-//		 * or the same
-//		 * (ret != total_len && ret >= 0) || (ret != total_len && ret == UV_EAGAIN)
-//		 * i.e. either occurs partial write or UV_EAGAIN.
-//		 * Proceed and copy data amount to owned memory and perform async write.
-//		 */
-//		if (ret == UV_EAGAIN) {
-//			/* No data were buffered, so we must buffer all the data. */
-//			ret = 0;
-//		}
-//	}
-//
-//	/* Fallback when the queue is full, and it's not possible to do an immediate write */
-//	char *p = malloc(sizeof(struct async_write_ctx) + total_len - ret);
-//	if (p != NULL) {
-//		struct async_write_ctx *async_ctx = (struct async_write_ctx *)p;
-//		/* Save pointer to session tls context */
-//		async_ctx->t = t;
-//		char *buf = async_ctx->buf;
-//		/* Skip data written in the partial write */
-//		size_t to_skip = ret;
-//		/* Copy the buffer into owned memory */
-//		size_t off = 0;
-//		for (int i = 0; i < iovcnt; ++i) {
-//			if (to_skip > 0) {
-//				/* Ignore current buffer if it's all skipped */
-//				if (to_skip >= uv_buf[i].len) {
-//					to_skip -= uv_buf[i].len;
-//					continue;
-//				}
-//				/* Skip only part of the buffer */
-//				uv_buf[i].base += to_skip;
-//				uv_buf[i].len -= to_skip;
-//				to_skip = 0;
-//			}
-//			memcpy(buf + off, uv_buf[i].base, uv_buf[i].len);
-//			off += uv_buf[i].len;
-//		}
-//		uv_buf[0].base = buf;
-//		uv_buf[0].len = off;
-//
-//		/* Create an asynchronous write request */
-//		uv_write_t *write_req = &async_ctx->write_req;
-//		memset(write_req, 0, sizeof(uv_write_t));
-//		write_req->data = p;
-//
-//		/* Perform an asynchronous write with a callback */
-//		if (uv_write(write_req, handle, uv_buf, 1, on_write_complete) == 0) {
-//			ret = total_len;
-//			t->write_queue_size += 1;
-//		} else {
-//			free(p);
-//			errno = EIO;
-//			ret = -1;
-//		}
-//	} else {
-//		errno = ENOMEM;
-//		ret = -1;
-//	}
-//
-//	DEBUG_MSG("[%s] queued %zu <%p> = %d\n",
-//	    t->client_side ? "tls_client" : "tls", total_len, h, ret);
-//
-//	return ret;
-//}
-
+// TODO so far this is the same as the tcp function (except qry.transport)
 int _output_dnssim_create_query_tls(output_dnssim_t* self, _output_dnssim_request_t* req)
 {
     mlassert_self();
@@ -231,9 +305,7 @@ int _output_dnssim_create_query_tls(output_dnssim_t* self, _output_dnssim_reques
     req->qry           = &qry->qry; // TODO change when adding support for multiple Qs for req
     _ll_append(req->client->pending, &qry->qry);
 
-    // TODO call _handle_pending_queries or tls equivalent
-    //return _handle_pending_queries(req->client);
-    return 0;
+    return _output_dnssim_handle_pending_queries(req->client);
 }
 
 void _output_dnssim_close_query_tls(_output_dnssim_query_tcp_t* qry)
@@ -243,5 +315,79 @@ void _output_dnssim_close_query_tls(_output_dnssim_query_tcp_t* qry)
     _output_dnssim_request_t* req = qry->qry.req;
     mlassert(req->client, "request must belong to a client");
 
-    mlfatal("TODO: handle closing tls queries");
+    if (qry->conn) {
+        _output_dnssim_connection_t* conn = qry->conn;
+        _ll_try_remove(conn->sent, &qry->qry);
+        qry->conn = NULL;
+        _output_dnssim_conn_idle(conn);
+    }
+
+    _ll_remove(req->qry, &qry->qry);
+    free(qry);
+}
+
+void _output_dnssim_tls_close(_output_dnssim_connection_t* conn)
+{
+    mlassert(conn, "conn can't be nil");
+    mlassert(conn->tls, "conn must have tls ctx");
+
+    /*
+     * TODO: proper gnutls_bye() might be needed to allow session resumption
+     * https://gnutls.org/manual/html_node/Data-transfer-and-termination.html#Data-transfer-and-termination
+     */
+    gnutls_deinit(conn->tls->session);
+    _output_dnssim_tcp_close(conn);
+}
+
+void _output_dnssim_tls_write_query(_output_dnssim_connection_t* conn, _output_dnssim_query_tcp_t* qry)
+{
+    mlassert(qry, "qry can't be null");
+    mlassert(qry->qry.state == _OUTPUT_DNSSIM_QUERY_PENDING_WRITE, "qry must be pending write");
+    mlassert(qry->qry.req, "req can't be null");
+    mlassert(qry->qry.req->dns_q, "dns_q can't be null");
+    mlassert(qry->qry.req->dns_q->obj_prev, "payload can't be null");
+    mlassert(conn, "conn can't be null");
+    mlassert(conn->state == _OUTPUT_DNSSIM_CONN_ACTIVE, "connection state != ACTIVE");
+    mlassert(conn->tls, "conn must have tls ctx");
+    mlassert(conn->client, "conn must be associated with client");
+    mlassert(conn->client->pending, "conn has no pending queries");
+
+    core_object_payload_t* payload = (core_object_payload_t*)qry->qry.req->dns_q->obj_prev;
+    uint16_t len = htons(payload->len);
+
+	gnutls_record_cork(conn->tls->session);
+	ssize_t count = 0;
+	if ((count = gnutls_record_send(conn->tls->session, &len, sizeof(len)) < 0) ||
+	    (count = gnutls_record_send(conn->tls->session, payload->payload, payload->len) < 0)) {
+        mlwarning("gnutls_record_send failed: %s", gnutls_strerror_name(count));
+        _output_dnssim_conn_close(conn);
+        return;
+	}
+
+	const ssize_t submitted = sizeof(len) + payload->len;
+
+	int ret = gnutls_record_uncork(conn->tls->session, GNUTLS_RECORD_WAIT);
+	if (gnutls_error_is_fatal(ret)) {
+        mlwarning("gnutls_record_uncorck failed: %s", gnutls_strerror_name(ret));
+        _output_dnssim_conn_close(conn);
+        return;
+	}
+
+	if (ret != submitted) {
+        mlwarning("gnutls_record_uncork didn't send all data");
+        _output_dnssim_conn_close(conn);
+        return;
+	}
+
+    qry->conn = conn;
+    _ll_remove(conn->client->pending, &qry->qry);
+    _ll_append(conn->sent, &qry->qry);
+
+    /* Stop idle timer, since there are queries to answer now. */
+    if (conn->idle_timer != NULL) {
+        conn->is_idle = false;
+        uv_timer_stop(conn->idle_timer);
+    }
+
+    qry->qry.state = _OUTPUT_DNSSIM_QUERY_SENT;
 }

--- a/src/output/dnssim/tls.c
+++ b/src/output/dnssim/tls.c
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2020, CZ.NIC, z.s.p.o.
+ * All rights reserved.
+ *
+ * This file is part of dnsjit.
+ *
+ * dnsjit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dnsjit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "output/dnssim.h"
+#include "output/dnssim/internal.h"
+#include "output/dnssim/ll.h"
+#include "core/assert.h"
+
+#include <gnutls/gnutls.h>
+#include <string.h>
+
+static core_log_t _log = LOG_T_INIT("output.dnssim");
+
+
+void _tls_process_input_data()
+{
+
+}
+
+//static ssize_t _tls_pull(gnutls_transport_ptr_t h, void *buf, size_t len)
+//{
+//	struct tls_common_ctx *t = (struct tls_common_ctx *)h;
+//	assert(t != NULL);
+//
+//	ssize_t	avail = t->nread - t->consumed;
+//	DEBUG_MSG("[%s] pull wanted: %zu available: %zu\n",
+//		  t->client_side ? "tls_client" : "tls", len, avail);
+//	if (t->nread <= t->consumed) {
+//		errno = EAGAIN;
+//		return -1;
+//	}
+//
+//	ssize_t	transfer = MIN(avail, len);
+//	memcpy(buf, t->buf + t->consumed, transfer);
+//	t->consumed += transfer;
+//	return transfer;
+//}
+//
+int _output_dnssim_tls_init(_output_dnssim_connection_t* conn)
+{
+    mlassert(conn, "conn is nil");
+    mlassert(conn->tls == NULL, "conn already has tls context");
+
+    int ret;
+    mlfatal_oom(conn->tls = malloc(sizeof(_output_dnssim_tls_ctx_t)));
+
+	ret = gnutls_init(&conn->tls->session, GNUTLS_CLIENT | GNUTLS_NONBLOCK);
+    if (ret < 0) {
+        mldebug("failed gnutls_init() (%s)", gnutls_strerror(ret));
+        return ret;
+    }
+
+    output_dnssim_t* self = conn->client->dnssim;
+    ret = gnutls_priority_set(conn->tls->session, _self->tls_priority);
+    if (ret < 0) {
+        mldebug("failed gnutls_priority_set() (%s)", gnutls_strerror(ret));
+        return ret;
+    }
+
+    ret = gnutls_credentials_set(conn->tls->session, GNUTLS_CRD_CERTIFICATE, &_self->tls_cred);
+    if (ret < 0) {
+        mldebug("failed gnutls_credentials_set() (%s)", gnutls_strerror(ret));
+        return ret;
+    }
+
+    // TODO implement
+	// gnutls_transport_set_pull_function(tls->c.tls_session, kres_gnutls_pull);
+	// gnutls_transport_set_vec_push_function(tls->c.tls_session, kres_gnutls_vec_push);
+	// gnutls_transport_set_ptr(conn->tls->session, conn);
+
+	return 0;
+}
+
+//static ssize_t _tls_vec_push(gnutls_transport_ptr_t h, const giovec_t * iov, int iovcnt)
+//{
+//	struct tls_common_ctx *t = (struct tls_common_ctx *)h;
+//
+//	if (t == NULL) {
+//		errno = EFAULT;
+//		return -1;
+//	}
+//
+//	if (iovcnt == 0) {
+//		return 0;
+//	}
+//
+//	assert(t->session);
+//	uv_stream_t *handle = (uv_stream_t *)session_get_handle(t->session);
+//	assert(handle && handle->type == UV_TCP);
+//
+//	/*
+//	 * This is a little bit complicated. There are two different writes:
+//	 * 1. Immediate, these don't need to own the buffered data and return immediately
+//	 * 2. Asynchronous, these need to own the buffers until the write completes
+//	 * In order to avoid copying the buffer, an immediate write is tried first if possible.
+//	 * If it isn't possible to write the data without queueing, an asynchronous write
+//	 * is created (with copied buffered data).
+//	 */
+//
+//	size_t total_len = 0;
+//	uv_buf_t uv_buf[iovcnt];
+//	for (int i = 0; i < iovcnt; ++i) {
+//		uv_buf[i].base = iov[i].iov_base;
+//		uv_buf[i].len = iov[i].iov_len;
+//		total_len += iov[i].iov_len;
+//	}
+//
+//	/* Try to perform the immediate write first to avoid copy */
+//	int ret = 0;
+//	if (stream_queue_is_empty(t)) {
+//		ret = uv_try_write(handle, uv_buf, iovcnt);
+//		DEBUG_MSG("[%s] push %zu <%p> = %d\n",
+//		    t->client_side ? "tls_client" : "tls", total_len, h, ret);
+//		/* from libuv documentation -
+//		   uv_try_write will return either:
+//		     > 0: number of bytes written (can be less than the supplied buffer size).
+//		     < 0: negative error code (UV_EAGAIN is returned if no data can be sent immediately).
+//		*/
+//		if (ret == total_len) {
+//			/* All the data were buffered by libuv.
+//			 * Return. */
+//			return ret;
+//		}
+//
+//		if (ret < 0 && ret != UV_EAGAIN) {
+//			/* uv_try_write() has returned error code other then UV_EAGAIN.
+//			 * Return. */
+//			ret = -1;
+//			errno = EIO;
+//			return ret;
+//		}
+//		/* Since we are here expression below is true
+//		 * (ret != total_len) && (ret >= 0 || ret == UV_EAGAIN)
+//		 * or the same
+//		 * (ret != total_len && ret >= 0) || (ret != total_len && ret == UV_EAGAIN)
+//		 * i.e. either occurs partial write or UV_EAGAIN.
+//		 * Proceed and copy data amount to owned memory and perform async write.
+//		 */
+//		if (ret == UV_EAGAIN) {
+//			/* No data were buffered, so we must buffer all the data. */
+//			ret = 0;
+//		}
+//	}
+//
+//	/* Fallback when the queue is full, and it's not possible to do an immediate write */
+//	char *p = malloc(sizeof(struct async_write_ctx) + total_len - ret);
+//	if (p != NULL) {
+//		struct async_write_ctx *async_ctx = (struct async_write_ctx *)p;
+//		/* Save pointer to session tls context */
+//		async_ctx->t = t;
+//		char *buf = async_ctx->buf;
+//		/* Skip data written in the partial write */
+//		size_t to_skip = ret;
+//		/* Copy the buffer into owned memory */
+//		size_t off = 0;
+//		for (int i = 0; i < iovcnt; ++i) {
+//			if (to_skip > 0) {
+//				/* Ignore current buffer if it's all skipped */
+//				if (to_skip >= uv_buf[i].len) {
+//					to_skip -= uv_buf[i].len;
+//					continue;
+//				}
+//				/* Skip only part of the buffer */
+//				uv_buf[i].base += to_skip;
+//				uv_buf[i].len -= to_skip;
+//				to_skip = 0;
+//			}
+//			memcpy(buf + off, uv_buf[i].base, uv_buf[i].len);
+//			off += uv_buf[i].len;
+//		}
+//		uv_buf[0].base = buf;
+//		uv_buf[0].len = off;
+//
+//		/* Create an asynchronous write request */
+//		uv_write_t *write_req = &async_ctx->write_req;
+//		memset(write_req, 0, sizeof(uv_write_t));
+//		write_req->data = p;
+//
+//		/* Perform an asynchronous write with a callback */
+//		if (uv_write(write_req, handle, uv_buf, 1, on_write_complete) == 0) {
+//			ret = total_len;
+//			t->write_queue_size += 1;
+//		} else {
+//			free(p);
+//			errno = EIO;
+//			ret = -1;
+//		}
+//	} else {
+//		errno = ENOMEM;
+//		ret = -1;
+//	}
+//
+//	DEBUG_MSG("[%s] queued %zu <%p> = %d\n",
+//	    t->client_side ? "tls_client" : "tls", total_len, h, ret);
+//
+//	return ret;
+//}
+
+int _output_dnssim_create_query_tls(output_dnssim_t* self, _output_dnssim_request_t* req)
+{
+    mlassert_self();
+    lassert(req, "req is nil");
+    lassert(req->client, "request must have a client associated with it");
+
+    _output_dnssim_query_tcp_t* qry;  // TODO do tls queries need other struct than tcp?
+
+    lfatal_oom(qry = calloc(1, sizeof(_output_dnssim_query_tcp_t)));
+
+    qry->qry.transport = OUTPUT_DNSSIM_TRANSPORT_TLS;
+    qry->qry.req       = req;
+    qry->qry.state     = _OUTPUT_DNSSIM_QUERY_PENDING_WRITE;
+    req->qry           = &qry->qry; // TODO change when adding support for multiple Qs for req
+    _ll_append(req->client->pending, &qry->qry);
+
+    // TODO call _handle_pending_queries or tls equivalent
+    //return _handle_pending_queries(req->client);
+    return 0;
+}
+
+void _output_dnssim_close_query_tls(_output_dnssim_query_tcp_t* qry)
+{
+    mlassert(qry, "qry can't be null");
+    mlassert(qry->qry.req, "query must be part of a request");
+    _output_dnssim_request_t* req = qry->qry.req;
+    mlassert(req->client, "request must belong to a client");
+
+    mlfatal("TODO: handle closing tls queries");
+}

--- a/src/output/dnssim/tls.c
+++ b/src/output/dnssim/tls.c
@@ -107,8 +107,7 @@ void _output_dnssim_tls_process_input_data(_output_dnssim_connection_t* conn)
         } else if (count == GNUTLS_E_INTERRUPTED) {
             continue;
         } else if (count == GNUTLS_E_REHANDSHAKE) {
-            // TODO implement rehandshake?
-            continue;
+            continue;  /* Ignore rehandshake request. */
         } else if (count < 0) {
             mlwarning("gnutls_record_recv failed: %s", gnutls_strerror_name(count));
             _output_dnssim_conn_close(conn);
@@ -325,14 +324,13 @@ int _output_dnssim_tls_init(_output_dnssim_connection_t* conn)
     return 0;
 }
 
-// TODO so far this is the same as the tcp function (except qry.transport)
 int _output_dnssim_create_query_tls(output_dnssim_t* self, _output_dnssim_request_t* req)
 {
     mlassert_self();
     lassert(req, "req is nil");
     lassert(req->client, "request must have a client associated with it");
 
-    _output_dnssim_query_tcp_t* qry;  // TODO do tls queries need other struct than tcp?
+    _output_dnssim_query_tcp_t* qry;
 
     lfatal_oom(qry = calloc(1, sizeof(_output_dnssim_query_tcp_t)));
 


### PR DESCRIPTION
Initial TLS support for dnssim. 

Features:
- can select TLS version and cipher suites with priority strings
- TLS session resumption is also supported and on by default (requires GnuTLS 3.6.3+). It can be explicitly turned off with priority string

Missing features include:
- TLS rehandshake (no plans to implements this)
- TLS false start / early data: this might be useful and might be implemented in the future. Skipped this for now, because it'd be quite complex and I have no use for it at this point

I've done some benchmarks with this and it seems to work (at least in my use-cases).