### PR TITLE
fmt, ccwarn

### DIFF
--- a/fmt.sh
+++ b/fmt.sh
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
 
-clang-format-4.0 \
+clang-format \
     -style=file \
     -i \
     src/*.c \

--- a/src/core/channel.hh
+++ b/src/core/channel.hh
@@ -35,15 +35,15 @@ typedef struct core_channel {
 
 core_log_t* core_channel_log();
 
-void core_channel_init(core_channel_t* self, size_t capacity);
-void core_channel_destroy(core_channel_t* self);
-void core_channel_put(core_channel_t* self, const void* obj);
-int core_channel_try_put(core_channel_t* self, const void* obj);
+void  core_channel_init(core_channel_t* self, size_t capacity);
+void  core_channel_destroy(core_channel_t* self);
+void  core_channel_put(core_channel_t* self, const void* obj);
+int   core_channel_try_put(core_channel_t* self, const void* obj);
 void* core_channel_get(core_channel_t* self);
 void* core_channel_try_get(core_channel_t* self);
-int core_channel_size(core_channel_t* self);
-bool core_channel_full(core_channel_t* self);
-void core_channel_close(core_channel_t* self);
+int   core_channel_size(core_channel_t* self);
+bool  core_channel_full(core_channel_t* self);
+void  core_channel_close(core_channel_t* self);
 
 core_receiver_t core_channel_receiver();
-void core_channel_run(core_channel_t* self);
+void            core_channel_run(core_channel_t* self);

--- a/src/core/object.hh
+++ b/src/core/object.hh
@@ -25,4 +25,4 @@ struct core_object {
 };
 
 core_object_t* core_object_copy(const core_object_t* self);
-void core_object_free(core_object_t* self);
+void           core_object_free(core_object_t* self);

--- a/src/core/object/dns.hh
+++ b/src/core/object/dns.hh
@@ -111,8 +111,8 @@ core_log_t* core_object_dns_log();
 
 core_object_dns_t* core_object_dns_new();
 core_object_dns_t* core_object_dns_copy(const core_object_dns_t* self);
-void core_object_dns_free(core_object_dns_t* self);
-void core_object_dns_reset(core_object_dns_t* self, const core_object_t* obj);
+void               core_object_dns_free(core_object_dns_t* self);
+void               core_object_dns_reset(core_object_dns_t* self, const core_object_t* obj);
 
 int core_object_dns_parse_header(core_object_dns_t* self);
 int core_object_dns_parse_q(core_object_dns_t* self, core_object_dns_q_t* q, core_object_dns_label_t* label, size_t labels);

--- a/src/core/object/ether.hh
+++ b/src/core/object/ether.hh
@@ -30,4 +30,4 @@ typedef struct core_object_ether {
 } core_object_ether_t;
 
 core_object_ether_t* core_object_ether_copy(const core_object_ether_t* self);
-void core_object_ether_free(core_object_ether_t* self);
+void                 core_object_ether_free(core_object_ether_t* self);

--- a/src/core/object/gre.hh
+++ b/src/core/object/gre.hh
@@ -34,4 +34,4 @@ typedef struct core_object_gre {
 } core_object_gre_t;
 
 core_object_gre_t* core_object_gre_copy(const core_object_gre_t* self);
-void core_object_gre_free(core_object_gre_t* self);
+void               core_object_gre_free(core_object_gre_t* self);

--- a/src/core/object/icmp.hh
+++ b/src/core/object/icmp.hh
@@ -30,4 +30,4 @@ typedef struct core_object_icmp {
 } core_object_icmp_t;
 
 core_object_icmp_t* core_object_icmp_copy(const core_object_icmp_t* self);
-void core_object_icmp_free(core_object_icmp_t* self);
+void                core_object_icmp_free(core_object_icmp_t* self);

--- a/src/core/object/icmp6.hh
+++ b/src/core/object/icmp6.hh
@@ -30,4 +30,4 @@ typedef struct core_object_icmp6 {
 } core_object_icmp6_t;
 
 core_object_icmp6_t* core_object_icmp6_copy(const core_object_icmp6_t* self);
-void core_object_icmp6_free(core_object_icmp6_t* self);
+void                 core_object_icmp6_free(core_object_icmp6_t* self);

--- a/src/core/object/ieee802.hh
+++ b/src/core/object/ieee802.hh
@@ -32,4 +32,4 @@ typedef struct core_object_ieee802 {
 } core_object_ieee802_t;
 
 core_object_ieee802_t* core_object_ieee802_copy(const core_object_ieee802_t* self);
-void core_object_ieee802_free(core_object_ieee802_t* self);
+void                   core_object_ieee802_free(core_object_ieee802_t* self);

--- a/src/core/object/ip.hh
+++ b/src/core/object/ip.hh
@@ -37,4 +37,4 @@ typedef struct core_object_ip {
 } core_object_ip_t;
 
 core_object_ip_t* core_object_ip_copy(const core_object_ip_t* self);
-void core_object_ip_free(core_object_ip_t* self);
+void              core_object_ip_free(core_object_ip_t* self);

--- a/src/core/object/ip6.hh
+++ b/src/core/object/ip6.hh
@@ -39,4 +39,4 @@ typedef struct core_object_ip6 {
 } core_object_ip6_t;
 
 core_object_ip6_t* core_object_ip6_copy(const core_object_ip6_t* self);
-void core_object_ip6_free(core_object_ip6_t* self);
+void               core_object_ip6_free(core_object_ip6_t* self);

--- a/src/core/object/linuxsll.hh
+++ b/src/core/object/linuxsll.hh
@@ -32,4 +32,4 @@ typedef struct core_object_linuxsll {
 } core_object_linuxsll_t;
 
 core_object_linuxsll_t* core_object_linuxsll_copy(const core_object_linuxsll_t* self);
-void core_object_linuxsll_free(core_object_linuxsll_t* self);
+void                    core_object_linuxsll_free(core_object_linuxsll_t* self);

--- a/src/core/object/loop.hh
+++ b/src/core/object/loop.hh
@@ -28,4 +28,4 @@ typedef struct core_object_loop {
 } core_object_loop_t;
 
 core_object_loop_t* core_object_loop_copy(const core_object_loop_t* self);
-void core_object_loop_free(core_object_loop_t* self);
+void                core_object_loop_free(core_object_loop_t* self);

--- a/src/core/object/null.hh
+++ b/src/core/object/null.hh
@@ -28,4 +28,4 @@ typedef struct core_object_null {
 } core_object_null_t;
 
 core_object_null_t* core_object_null_copy(const core_object_null_t* self);
-void core_object_null_free(core_object_null_t* self);
+void                core_object_null_free(core_object_null_t* self);

--- a/src/core/object/payload.hh
+++ b/src/core/object/payload.hh
@@ -29,4 +29,4 @@ typedef struct core_object_payload {
 } core_object_payload_t;
 
 core_object_payload_t* core_object_payload_copy(const core_object_payload_t* self);
-void core_object_payload_free(core_object_payload_t* self);
+void                   core_object_payload_free(core_object_payload_t* self);

--- a/src/core/object/pcap.hh
+++ b/src/core/object/pcap.hh
@@ -35,4 +35,4 @@ typedef struct core_object_pcap {
 } core_object_pcap_t;
 
 core_object_pcap_t* core_object_pcap_copy(const core_object_pcap_t* self);
-void core_object_pcap_free(core_object_pcap_t* self);
+void                core_object_pcap_free(core_object_pcap_t* self);

--- a/src/core/object/tcp.hh
+++ b/src/core/object/tcp.hh
@@ -40,4 +40,4 @@ typedef struct core_object_tcp {
 } core_object_tcp_t;
 
 core_object_tcp_t* core_object_tcp_copy(const core_object_tcp_t* self);
-void core_object_tcp_free(core_object_tcp_t* self);
+void               core_object_tcp_free(core_object_tcp_t* self);

--- a/src/core/object/udp.hh
+++ b/src/core/object/udp.hh
@@ -31,4 +31,4 @@ typedef struct core_object_udp {
 } core_object_udp_t;
 
 core_object_udp_t* core_object_udp_copy(const core_object_udp_t* self);
-void core_object_udp_free(core_object_udp_t* self);
+void               core_object_udp_free(core_object_udp_t* self);

--- a/src/core/thread.hh
+++ b/src/core/thread.hh
@@ -46,11 +46,11 @@ typedef struct core_thread {
 
 core_log_t* core_thread_log();
 
-void core_thread_init(core_thread_t* self);
-void core_thread_destroy(core_thread_t* self);
-int core_thread_start(core_thread_t* self, const char* bytecode, size_t len);
-int core_thread_stop(core_thread_t* self);
-void core_thread_push(core_thread_t* self, void* ptr, const char* type, size_t type_len, const char* module, size_t module_len);
-void core_thread_push_string(core_thread_t* self, const char* str, size_t len);
-void core_thread_push_int64(core_thread_t* self, int64_t i64);
+void                      core_thread_init(core_thread_t* self);
+void                      core_thread_destroy(core_thread_t* self);
+int                       core_thread_start(core_thread_t* self, const char* bytecode, size_t len);
+int                       core_thread_stop(core_thread_t* self);
+void                      core_thread_push(core_thread_t* self, void* ptr, const char* type, size_t type_len, const char* module, size_t module_len);
+void                      core_thread_push_string(core_thread_t* self, const char* str, size_t len);
+void                      core_thread_push_int64(core_thread_t* self, int64_t i64);
 const core_thread_item_t* core_thread_pop(core_thread_t* self);

--- a/src/filter/copy.hh
+++ b/src/filter/copy.hh
@@ -32,9 +32,9 @@ typedef struct filter_copy {
 
 core_log_t* filter_copy_log();
 
-void filter_copy_init(filter_copy_t* self);
-void filter_copy_destroy(filter_copy_t* self);
-void filter_copy_set(filter_copy_t* self, int32_t obj_type);
+void     filter_copy_init(filter_copy_t* self);
+void     filter_copy_destroy(filter_copy_t* self);
+void     filter_copy_set(filter_copy_t* self, int32_t obj_type);
 uint64_t filter_copy_get(filter_copy_t* self, int32_t obj_type);
 
 core_receiver_t filter_copy_receiver(filter_copy_t* self);

--- a/src/filter/ipsplit.hh
+++ b/src/filter/ipsplit.hh
@@ -54,8 +54,8 @@ typedef struct filter_ipsplit {
 core_log_t* filter_ipsplit_log();
 
 filter_ipsplit_t* filter_ipsplit_new();
-void filter_ipsplit_free(filter_ipsplit_t* self);
-void filter_ipsplit_add(filter_ipsplit_t* self, core_receiver_t recv, void* ctx, uint32_t weight);
-void filter_ipsplit_srand(unsigned int seed);
+void              filter_ipsplit_free(filter_ipsplit_t* self);
+void              filter_ipsplit_add(filter_ipsplit_t* self, core_receiver_t recv, void* ctx, uint32_t weight);
+void              filter_ipsplit_srand(unsigned int seed);
 
 core_receiver_t filter_ipsplit_receiver(filter_ipsplit_t* self);

--- a/src/filter/timing.hh
+++ b/src/filter/timing.hh
@@ -46,7 +46,7 @@ typedef struct filter_timing {
 core_log_t* filter_timing_log();
 
 filter_timing_t* filter_timing_new();
-void filter_timing_free(filter_timing_t* self);
+void             filter_timing_free(filter_timing_t* self);
 
 core_receiver_t filter_timing_receiver(filter_timing_t* self);
 core_producer_t filter_timing_producer(filter_timing_t* self);

--- a/src/input/fpcap.hh
+++ b/src/input/fpcap.hh
@@ -54,7 +54,7 @@ core_log_t* input_fpcap_log();
 
 void input_fpcap_init(input_fpcap_t* self);
 void input_fpcap_destroy(input_fpcap_t* self);
-int input_fpcap_open(input_fpcap_t* self, const char* file);
-int input_fpcap_run(input_fpcap_t* self);
+int  input_fpcap_open(input_fpcap_t* self, const char* file);
+int  input_fpcap_run(input_fpcap_t* self);
 
 core_producer_t input_fpcap_producer(input_fpcap_t* self);

--- a/src/input/mmpcap.hh
+++ b/src/input/mmpcap.hh
@@ -54,7 +54,7 @@ core_log_t* input_mmpcap_log();
 
 void input_mmpcap_init(input_mmpcap_t* self);
 void input_mmpcap_destroy(input_mmpcap_t* self);
-int input_mmpcap_open(input_mmpcap_t* self, const char* file);
-int input_mmpcap_run(input_mmpcap_t* self);
+int  input_mmpcap_open(input_mmpcap_t* self, const char* file);
+int  input_mmpcap_run(input_mmpcap_t* self);
 
 core_producer_t input_mmpcap_producer(input_mmpcap_t* self);

--- a/src/input/pcap.hh
+++ b/src/input/pcap.hh
@@ -47,10 +47,10 @@ core_log_t* input_pcap_log();
 
 void input_pcap_init(input_pcap_t* self);
 void input_pcap_destroy(input_pcap_t* self);
-int input_pcap_create(input_pcap_t* self, const char* source);
-int input_pcap_activate(input_pcap_t* self);
-int input_pcap_open_offline(input_pcap_t* self, const char* file);
-int input_pcap_loop(input_pcap_t* self, int cnt);
-int input_pcap_dispatch(input_pcap_t* self, int cnt);
+int  input_pcap_create(input_pcap_t* self, const char* source);
+int  input_pcap_activate(input_pcap_t* self);
+int  input_pcap_open_offline(input_pcap_t* self, const char* file);
+int  input_pcap_loop(input_pcap_t* self, int cnt);
+int  input_pcap_dispatch(input_pcap_t* self, int cnt);
 
 core_producer_t input_pcap_producer(input_pcap_t* self);

--- a/src/input/zero.c
+++ b/src/input/zero.c
@@ -29,7 +29,8 @@
 static core_log_t   _log      = LOG_T_INIT("input.zero");
 static input_zero_t _defaults = {
     LOG_T_INIT_OBJ("input.zero"),
-    0, 0,
+    0,
+    0,
 };
 
 static core_object_null_t _null = CORE_OBJECT_NULL_INIT(0);

--- a/src/output/dnscli.hh
+++ b/src/output/dnscli.hh
@@ -63,9 +63,9 @@ typedef struct output_dnscli {
 
 core_log_t* output_dnscli_log();
 
-void output_dnscli_init(output_dnscli_t* self, output_dnscli_mode_t mode);
-void output_dnscli_destroy(output_dnscli_t* self);
-int output_dnscli_connect(output_dnscli_t* self, const char* host, const char* port);
+void           output_dnscli_init(output_dnscli_t* self, output_dnscli_mode_t mode);
+void           output_dnscli_destroy(output_dnscli_t* self);
+int            output_dnscli_connect(output_dnscli_t* self, const char* host, const char* port);
 luajit_ssize_t output_dnscli_send(output_dnscli_t* self, const core_object_t* obj, size_t sent);
 
 core_receiver_t output_dnscli_receiver(output_dnscli_t* self);

--- a/src/output/dnssim.c
+++ b/src/output/dnssim.c
@@ -368,7 +368,7 @@ static void _on_stats_timer_tick(uv_timer_t* handle)
     lassert(self->stats_current, "stats_current is nil");
 
     lnotice("total processed:%10ld; answers:%10ld; discarded:%10ld; ongoing:%10ld",
-            self->processed, self->stats_sum->answers, self->discarded, self->ongoing);
+        self->processed, self->stats_sum->answers, self->discarded, self->ongoing);
 
     output_dnssim_stats_t* stats_next;
     lfatal_oom(stats_next = calloc(1, sizeof(output_dnssim_stats_t)));

--- a/src/output/dnssim.hh
+++ b/src/output/dnssim.hh
@@ -99,13 +99,13 @@ typedef struct output_dnssim {
 core_log_t* output_dnssim_log();
 
 output_dnssim_t* output_dnssim_new(size_t max_clients);
-void output_dnssim_free(output_dnssim_t* self);
+void             output_dnssim_free(output_dnssim_t* self);
 
 void output_dnssim_set_transport(output_dnssim_t* self, output_dnssim_transport_t tr);
-int output_dnssim_target(output_dnssim_t* self, const char* ip, uint16_t port);
-int output_dnssim_bind(output_dnssim_t* self, const char* ip);
-int output_dnssim_tls_priority(output_dnssim_t* self, const char* priority);
-int output_dnssim_run_nowait(output_dnssim_t* self);
+int  output_dnssim_target(output_dnssim_t* self, const char* ip, uint16_t port);
+int  output_dnssim_bind(output_dnssim_t* self, const char* ip);
+int  output_dnssim_tls_priority(output_dnssim_t* self, const char* priority);
+int  output_dnssim_run_nowait(output_dnssim_t* self);
 void output_dnssim_timeout_ms(output_dnssim_t* self, uint64_t timeout_ms);
 void output_dnssim_stats_collect(output_dnssim_t* self, uint64_t interval_ms);
 void output_dnssim_stats_finish(output_dnssim_t* self);

--- a/src/output/dnssim/connection.c
+++ b/src/output/dnssim/connection.c
@@ -105,7 +105,7 @@ void _output_dnssim_conn_close(_output_dnssim_connection_t* conn)
         uv_close((uv_handle_t*)conn->idle_timer, _on_idle_timer_closed);
     }
 
-    switch(_self->transport) {
+    switch (_self->transport) {
     case OUTPUT_DNSSIM_TRANSPORT_TCP:
         _output_dnssim_tcp_close(conn);
         break;
@@ -120,7 +120,6 @@ void _output_dnssim_conn_close(_output_dnssim_connection_t* conn)
         lfatal("unsupported transport");
         break;
     }
-
 }
 
 /* Close connection or run idle timer when there are no more outstanding queries. */
@@ -148,7 +147,7 @@ static void _send_pending_queries(_output_dnssim_connection_t* conn)
     while (qry != NULL && conn->state == _OUTPUT_DNSSIM_CONN_ACTIVE) {
         _output_dnssim_query_tcp_t* next = (_output_dnssim_query_tcp_t*)qry->qry.next;
         if (qry->qry.state == _OUTPUT_DNSSIM_QUERY_PENDING_WRITE) {
-            switch(qry->qry.transport) {
+            switch (qry->qry.transport) {
             case OUTPUT_DNSSIM_TRANSPORT_TCP:
                 _output_dnssim_tcp_write_query(conn, qry);
                 break;
@@ -187,7 +186,7 @@ int _output_dnssim_handle_pending_queries(_output_dnssim_client_t* client)
             break;
         else if (_conn_is_connecting(conn))
             is_connecting = true;
-        conn              = conn->next;
+        conn = conn->next;
     }
 
     if (conn != NULL) { /* Send data right away over active connection. */
@@ -225,7 +224,7 @@ void _output_dnssim_conn_activate(_output_dnssim_connection_t* conn)
 
     conn->state = _OUTPUT_DNSSIM_CONN_ACTIVE;
     conn->client->dnssim->stats_current->conn_active++;
-    conn->read_state          = _OUTPUT_DNSSIM_READ_STATE_DNSLEN;
+    conn->read_state            = _OUTPUT_DNSSIM_READ_STATE_DNSLEN;
     conn->dnsbuf_len            = 2;
     conn->dnsbuf_pos            = 0;
     conn->dnsbuf_free_after_use = false;
@@ -275,7 +274,7 @@ static int _parse_dnsbuf_data(_output_dnssim_connection_t* conn)
     switch (conn->read_state) {
     case _OUTPUT_DNSSIM_READ_STATE_DNSLEN: {
         uint16_t* p_dnslen = (uint16_t*)conn->dnsbuf_data;
-        conn->dnsbuf_len     = ntohs(*p_dnslen);
+        conn->dnsbuf_len   = ntohs(*p_dnslen);
         if (conn->dnsbuf_len == 0) {
             mlwarning("invalid dnslen received: 0");
             conn->dnsbuf_len = 2;
@@ -294,7 +293,7 @@ static int _parse_dnsbuf_data(_output_dnssim_connection_t* conn)
         if (ret) {
             conn->read_state = _OUTPUT_DNSSIM_READ_STATE_INVALID;
         } else {
-            conn->dnsbuf_len   = 2;
+            conn->dnsbuf_len = 2;
             conn->read_state = _OUTPUT_DNSSIM_READ_STATE_DNSLEN;
         }
         break;
@@ -319,7 +318,7 @@ static unsigned int _read_dns_stream_chunk(_output_dnssim_connection_t* conn, si
     mlassert(data, "data can't be nil");
     mlassert(len > 0, "no data to read");
     mlassert((conn->read_state == _OUTPUT_DNSSIM_READ_STATE_DNSLEN || conn->read_state == _OUTPUT_DNSSIM_READ_STATE_DNSMSG),
-            "connection has invalid read_state");
+        "connection has invalid read_state");
 
     int          ret = 0;
     unsigned int nread;
@@ -345,7 +344,7 @@ static unsigned int _read_dns_stream_chunk(_output_dnssim_connection_t* conn, si
         mlassert(expected <= len, "not enough data to perform complete read");
         conn->dnsbuf_data = (char*)data;
         conn->dnsbuf_pos  = conn->dnsbuf_len;
-        nread           = expected;
+        nread             = expected;
     }
 
     /* If entire dnslen/dnsmsg was read, attempt to parse it. */
@@ -360,8 +359,8 @@ static unsigned int _read_dns_stream_chunk(_output_dnssim_connection_t* conn, si
 
 void _output_dnssim_read_dns_stream(_output_dnssim_connection_t* conn, size_t len, const char* data)
 {
-    int   pos   = 0;
-    int   chunk = 0;
+    int pos   = 0;
+    int chunk = 0;
     while (pos < len) {
         chunk = _read_dns_stream_chunk(conn, len - pos, data + pos);
         if (chunk < 0) {

--- a/src/output/dnssim/internal.h
+++ b/src/output/dnssim/internal.h
@@ -34,7 +34,7 @@
 #define _ERR_MSGID -3
 #define _ERR_TC -4
 
-#define WIRE_BUF_SIZE 65535 + 2 + 16384  /** max tcplen + 2b tcplen + 16kb tls record */
+#define WIRE_BUF_SIZE 65535 + 2 + 16384 /** max tcplen + 2b tcplen + 16kb tls record */
 
 typedef struct _output_dnssim_request    _output_dnssim_request_t;
 typedef struct _output_dnssim_connection _output_dnssim_connection_t;
@@ -137,10 +137,10 @@ typedef enum _output_dnssim_read_state {
 /* TLS-related data for a single connection. */
 typedef struct _output_dnssim_tls_ctx {
     gnutls_session_t session;
-    uint8_t* buf;
-    ssize_t buf_len;
-    ssize_t buf_pos;
-    size_t write_queue_size;
+    uint8_t*         buf;
+    ssize_t          buf_len;
+    ssize_t          buf_pos;
+    size_t           write_queue_size;
 } _output_dnssim_tls_ctx_t;
 
 struct _output_dnssim_connection {
@@ -166,12 +166,12 @@ struct _output_dnssim_connection {
 
     /* State of the connection. */
     enum {
-        _OUTPUT_DNSSIM_CONN_INITIALIZED = 0,
+        _OUTPUT_DNSSIM_CONN_INITIALIZED   = 0,
         _OUTPUT_DNSSIM_CONN_TCP_HANDSHAKE = 10,
         _OUTPUT_DNSSIM_CONN_TLS_HANDSHAKE = 20,
-        _OUTPUT_DNSSIM_CONN_ACTIVE = 30,
-        _OUTPUT_DNSSIM_CONN_CLOSING = 40,
-        _OUTPUT_DNSSIM_CONN_CLOSED = 50
+        _OUTPUT_DNSSIM_CONN_ACTIVE        = 30,
+        _OUTPUT_DNSSIM_CONN_CLOSING       = 40,
+        _OUTPUT_DNSSIM_CONN_CLOSED        = 50
     } state;
 
     /* State of the data stream read. */
@@ -238,39 +238,39 @@ struct _output_dnssim {
     /* Array of clients, mapped by client ID (ranges from 0 to max_clients). */
     _output_dnssim_client_t* client_arr;
 
-    gnutls_priority_t* tls_priority;
+    gnutls_priority_t*               tls_priority;
     gnutls_certificate_credentials_t tls_cred;
-    char wire_buf[WIRE_BUF_SIZE];  /* thread-local buffer for processing tls input */
+    char                             wire_buf[WIRE_BUF_SIZE]; /* thread-local buffer for processing tls input */
 };
 
 /*
  * Forward function declarations.
  */
 
-int _output_dnssim_bind_before_connect(output_dnssim_t* self, uv_handle_t* handle);
-int _output_dnssim_create_query_udp(output_dnssim_t* self, _output_dnssim_request_t* req);
-int _output_dnssim_create_query_tcp(output_dnssim_t* self, _output_dnssim_request_t* req);
+int  _output_dnssim_bind_before_connect(output_dnssim_t* self, uv_handle_t* handle);
+int  _output_dnssim_create_query_udp(output_dnssim_t* self, _output_dnssim_request_t* req);
+int  _output_dnssim_create_query_tcp(output_dnssim_t* self, _output_dnssim_request_t* req);
 void _output_dnssim_close_query_udp(_output_dnssim_query_udp_t* qry);
 void _output_dnssim_close_query_tcp(_output_dnssim_query_tcp_t* qry);
 void _output_dnssim_request_answered(_output_dnssim_request_t* req, core_object_dns_t* msg);
 void _output_dnssim_maybe_free_request(_output_dnssim_request_t* req);
 void _output_dnssim_on_uv_alloc(uv_handle_t* handle, size_t suggested_size, uv_buf_t* buf);
 void _output_dnssim_create_request(output_dnssim_t* self, _output_dnssim_client_t* client, core_object_payload_t* payload);
-int _output_dnssim_handle_pending_queries(_output_dnssim_client_t* client);
-int _output_dnssim_tcp_connect(output_dnssim_t* self, _output_dnssim_connection_t* conn);
+int  _output_dnssim_handle_pending_queries(_output_dnssim_client_t* client);
+int  _output_dnssim_tcp_connect(output_dnssim_t* self, _output_dnssim_connection_t* conn);
 void _output_dnssim_tcp_close(_output_dnssim_connection_t* conn);
 void _output_dnssim_tcp_write_query(_output_dnssim_connection_t* conn, _output_dnssim_query_tcp_t* qry);
 void _output_dnssim_conn_close(_output_dnssim_connection_t* conn);
 void _output_dnssim_conn_idle(_output_dnssim_connection_t* conn);
-int _output_dnssim_handle_pending_queries(_output_dnssim_client_t* client);
+int  _output_dnssim_handle_pending_queries(_output_dnssim_client_t* client);
 void _output_dnssim_conn_activate(_output_dnssim_connection_t* conn);
 void _output_dnssim_conn_maybe_free(_output_dnssim_connection_t* conn);
 void _output_dnssim_read_dns_stream(_output_dnssim_connection_t* conn, size_t len, const char* data);
 
 #if GNUTLS_VERSION_NUMBER >= DNSSIM_MIN_GNUTLS_VERSION
-int _output_dnssim_create_query_tls(output_dnssim_t* self, _output_dnssim_request_t* req);
+int  _output_dnssim_create_query_tls(output_dnssim_t* self, _output_dnssim_request_t* req);
 void _output_dnssim_close_query_tls(_output_dnssim_query_tcp_t* qry);
-int _output_dnssim_tls_init(_output_dnssim_connection_t* conn);
+int  _output_dnssim_tls_init(_output_dnssim_connection_t* conn);
 void _output_dnssim_tls_process_input_data(_output_dnssim_connection_t* conn);
 void _output_dnssim_tls_close(_output_dnssim_connection_t* conn);
 void _output_dnssim_tls_write_query(_output_dnssim_connection_t* conn, _output_dnssim_query_tcp_t* qry);

--- a/src/output/dnssim/ll.h
+++ b/src/output/dnssim/ll.h
@@ -42,7 +42,7 @@
         else if ((node) != NULL) {                                                \
             typeof(list) _current = (list);                                       \
             while (_current->next != NULL)                                        \
-                _current   = _current->next;                                      \
+                _current = _current->next;                                        \
             _current->next = node;                                                \
         }                                                                         \
     }

--- a/src/output/dnssim/tcp.c
+++ b/src/output/dnssim/tcp.c
@@ -151,18 +151,18 @@ void _output_dnssim_tcp_write_query(_output_dnssim_connection_t* conn, _output_d
 static void _on_tcp_read(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf)
 {
     _output_dnssim_connection_t* conn = (_output_dnssim_connection_t*)handle->data;
-    output_dnssim_t* self = conn->client->dnssim;
+    output_dnssim_t*             self = conn->client->dnssim;
 
     if (nread > 0) {
         mldebug("tcp nread: %d", nread);
-        switch(_self->transport) {
+        switch (_self->transport) {
         case OUTPUT_DNSSIM_TRANSPORT_TCP:
             _output_dnssim_read_dns_stream(conn, nread, buf->base);
             break;
         case OUTPUT_DNSSIM_TRANSPORT_TLS:
 #if GNUTLS_VERSION_NUMBER >= DNSSIM_MIN_GNUTLS_VERSION
             mlassert(conn->tls, "con must have tls ctx");
-            conn->tls->buf = (uint8_t*)buf->base;
+            conn->tls->buf     = (uint8_t*)buf->base;
             conn->tls->buf_pos = 0;
             conn->tls->buf_len = nread;
             _output_dnssim_tls_process_input_data(conn);
@@ -216,7 +216,7 @@ static void _on_tcp_connected(uv_connect_t* conn_req, int status)
     case OUTPUT_DNSSIM_TRANSPORT_TLS:
 #if GNUTLS_VERSION_NUMBER >= DNSSIM_MIN_GNUTLS_VERSION
         mldebug("init tls handshake");
-        _output_dnssim_tls_process_input_data(conn);  /* Initiate TLS handshake. */
+        _output_dnssim_tls_process_input_data(conn); /* Initiate TLS handshake. */
 #else
         mlfatal(DNSSIM_MIN_GNUTLS_ERRORMSG);
 #endif

--- a/src/output/null.hh
+++ b/src/output/null.hh
@@ -30,8 +30,8 @@ typedef struct output_null {
 } output_null_t;
 
 core_log_t* output_null_log();
-void output_null_init(output_null_t* self);
-void output_null_destroy(output_null_t* self);
-void output_null_run(output_null_t* self, int64_t num);
+void        output_null_init(output_null_t* self);
+void        output_null_destroy(output_null_t* self);
+void        output_null_run(output_null_t* self, int64_t num);
 
 core_receiver_t output_null_receiver();

--- a/src/output/pcap.hh
+++ b/src/output/pcap.hh
@@ -33,9 +33,9 @@ typedef struct output_pcap {
 } output_pcap_t;
 
 core_log_t* output_pcap_log();
-void output_pcap_init(output_pcap_t* self);
-void output_pcap_destroy(output_pcap_t* self);
-int output_pcap_open(output_pcap_t* self, const char* file, int linktype, int snaplen);
-void output_pcap_close(output_pcap_t* self);
+void        output_pcap_init(output_pcap_t* self);
+void        output_pcap_destroy(output_pcap_t* self);
+int         output_pcap_open(output_pcap_t* self, const char* file, int linktype, int snaplen);
+void        output_pcap_close(output_pcap_t* self);
 
 core_receiver_t output_pcap_receiver(output_pcap_t* self);

--- a/src/output/respdiff.hh
+++ b/src/output/respdiff.hh
@@ -29,8 +29,8 @@ typedef struct output_respdiff {
 } output_respdiff_t;
 
 core_log_t* output_respdiff_log();
-void output_respdiff_init(output_respdiff_t* self, const char* path, size_t mapsize);
-void output_respdiff_destroy(output_respdiff_t* self);
-void output_respdiff_commit(output_respdiff_t* self, const char* origname, const char* recvname, uint64_t start_time, uint64_t end_time);
+void        output_respdiff_init(output_respdiff_t* self, const char* path, size_t mapsize);
+void        output_respdiff_destroy(output_respdiff_t* self);
+void        output_respdiff_commit(output_respdiff_t* self, const char* origname, const char* recvname, uint64_t start_time, uint64_t end_time);
 
 core_receiver_t output_respdiff_receiver(output_respdiff_t* self);

--- a/src/output/tcpcli.hh
+++ b/src/output/tcpcli.hh
@@ -43,9 +43,9 @@ core_log_t* output_tcpcli_log();
 
 void output_tcpcli_init(output_tcpcli_t* self);
 void output_tcpcli_destroy(output_tcpcli_t* self);
-int output_tcpcli_connect(output_tcpcli_t* self, const char* host, const char* port);
-int output_tcpcli_nonblocking(output_tcpcli_t* self);
-int output_tcpcli_set_nonblocking(output_tcpcli_t* self, int nonblocking);
+int  output_tcpcli_connect(output_tcpcli_t* self, const char* host, const char* port);
+int  output_tcpcli_nonblocking(output_tcpcli_t* self);
+int  output_tcpcli_set_nonblocking(output_tcpcli_t* self, int nonblocking);
 
 core_receiver_t output_tcpcli_receiver(output_tcpcli_t* self);
 core_producer_t output_tcpcli_producer(output_tcpcli_t* self);

--- a/src/output/tlscli.hh
+++ b/src/output/tlscli.hh
@@ -46,7 +46,7 @@ core_log_t* output_tlscli_log();
 
 void output_tlscli_init(output_tlscli_t* self);
 void output_tlscli_destroy(output_tlscli_t* self);
-int output_tlscli_connect(output_tlscli_t* self, const char* host, const char* port);
+int  output_tlscli_connect(output_tlscli_t* self, const char* host, const char* port);
 
 core_receiver_t output_tlscli_receiver(output_tlscli_t* self);
 core_producer_t output_tlscli_producer(output_tlscli_t* self);

--- a/src/output/udpcli.hh
+++ b/src/output/udpcli.hh
@@ -45,9 +45,9 @@ core_log_t* output_udpcli_log();
 
 void output_udpcli_init(output_udpcli_t* self);
 void output_udpcli_destroy(output_udpcli_t* self);
-int output_udpcli_connect(output_udpcli_t* self, const char* host, const char* port);
-int output_udpcli_nonblocking(output_udpcli_t* self);
-int output_udpcli_set_nonblocking(output_udpcli_t* self, int nonblocking);
+int  output_udpcli_connect(output_udpcli_t* self, const char* host, const char* port);
+int  output_udpcli_nonblocking(output_udpcli_t* self);
+int  output_udpcli_set_nonblocking(output_udpcli_t* self, int nonblocking);
 
 core_receiver_t output_udpcli_receiver(output_udpcli_t* self);
 core_producer_t output_udpcli_producer(output_udpcli_t* self);


### PR DESCRIPTION
- Update clang-format
- `output.dnssim`: Fix compile warning, redefine of `MIN(a,b)`