### PR TITLE
core/object: add cast_to() method

### DIFF
--- a/src/core/object.lua
+++ b/src/core/object.lua
@@ -126,6 +126,22 @@ function Object:cast()
     return ffi.cast(_cast[self.obj_type], self)
 end
 
+-- Cast the object to the specified object module and return it.
+-- Returns nil if the object chain doesn't contained the specified object type.
+function Object:cast_to(obj_type)
+    if obj_type == nil then
+        obj_type = self.obj_type
+    end
+
+    local obj = self
+    while obj.obj_type ~= obj_type do
+        obj = obj.obj_prev
+        if obj == nil then return nil end
+    end
+
+    return ffi.cast(_cast[obj_type], obj)
+end
+
 -- Cast the object to the generic object module and return it.
 function Object:uncast()
     return self


### PR DESCRIPTION
I often have to re-write the object chain iteration loop in scripts. It seems such a common operation that I think it makes sense to have it in the object API.

Casting to one of multiple types can also be elegantly done, although at a slightly worse performance:
```
local protocol = obj:cast_to(object.UDP) or obj:cast_to(object.TCP)
```
compared to:
```
local protocol = obj
while protocol ~= nil do
    if protocol.obj_type == object.UDP or protocol.obj_type == object.TCP then
        break
    end
    protocol = protocol.obj_prev
end
if protocol ~= nil then
    protocol = protocol:cast()
end
```