### PR TITLE
core/object/ip+ip6: allow string conversion to be used without object

### DIFF
--- a/src/core/object/ip.lua
+++ b/src/core/object/ip.lua
@@ -106,12 +106,17 @@ end
 
 -- Return the IP source as a string.
 function Ip:source()
-    return self.src[0] ..".".. self.src[1] ..".".. self.src[2] ..".".. self.src[3]
+    return self.tostring(self.src)
 end
 
 -- Return the IP destination as a string.
 function Ip:destination()
-    return self.dst[0] ..".".. self.dst[1] ..".".. self.dst[2] ..".".. self.dst[3]
+    return self.tostring(self.dst)
+end
+
+-- Return the IP as a string.
+function Ip.tostring(ip)
+    return ip[0] ..".".. ip[1] ..".".. ip[2] ..".".. ip[3]
 end
 
 core_object_ip_t = ffi.metatype(t_name, { __index = Ip })

--- a/src/core/object/ip.lua
+++ b/src/core/object/ip.lua
@@ -115,7 +115,12 @@ function Ip:destination()
 end
 
 -- Return the IP as a string.
+-- The input is a 4-byte cdata array.
+-- Returns nil on invalid input.
 function Ip.tostring(ip)
+    if type(ip) ~= "cdata" or ffi.sizeof(ip) ~= 4 then
+        return ""
+    end
     return ip[0] ..".".. ip[1] ..".".. ip[2] ..".".. ip[3]
 end
 

--- a/src/core/object/ip6.lua
+++ b/src/core/object/ip6.lua
@@ -174,10 +174,16 @@ function Ip6:destination(pretty)
     return self.tostring(self.dst, pretty)
 end
 
--- Return the IPv6 as a string. If
+-- Return the IPv6 as a string.
+-- The input is a 16-byte cdata array.
+-- If
 -- .I pretty
 -- is true then return an easier to read IPv6 address.
+-- Returns empty string on invalid input.
 function Ip6.tostring(ip6, pretty)
+    if type(ip6) ~= "cdata" or ffi.sizeof(ip6) ~= 16 then
+        return ""
+    end
     if pretty == true then
         return _pretty(ip6)
     end

--- a/src/core/object/ip6.lua
+++ b/src/core/object/ip6.lua
@@ -160,32 +160,30 @@ local function _pretty(ip)
     return table.concat(src,":")
 end
 
--- Return the IP source as a string. If
+-- Return the IPv6 source as a string. If
 -- .I pretty
--- is true then return a easier to read IPv6 address.
+-- is true then return an easier to read IPv6 address.
 function Ip6:source(pretty)
-    if pretty == true then
-        return _pretty(self.src)
-    end
-    return string.format("%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x",
-        self.src[0], self.src[1], self.src[2], self.src[3],
-        self.src[4], self.src[5], self.src[6], self.src[7],
-        self.src[8], self.src[9], self.src[10], self.src[11],
-        self.src[12], self.src[13], self.src[14], self.src[15])
+    return self.tostring(self.src, pretty)
 end
 
--- Return the IP destination as a string. If
+-- Return the IPv6 destination as a string. If
 -- .I pretty
--- is true then return a easier to read IPv6 address.
+-- is true then return an easier to read IPv6 address.
 function Ip6:destination(pretty)
+    return self.tostring(self.dst, pretty)
+end
+
+-- Return the IPv6 as a string. If
+-- .I pretty
+-- is true then return an easier to read IPv6 address.
+function Ip6.tostring(ip6, pretty)
     if pretty == true then
-        return _pretty(self.dst)
+        return _pretty(ip6)
     end
     return string.format("%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x",
-        self.dst[0], self.dst[1], self.dst[2], self.dst[3],
-        self.dst[4], self.dst[5], self.dst[6], self.dst[7],
-        self.dst[8], self.dst[9], self.dst[10], self.dst[11],
-        self.dst[12], self.dst[13], self.dst[14], self.dst[15])
+        ip6[0], ip6[1], ip6[2], ip6[3], ip6[4], ip6[5], ip6[6], ip6[7],
+        ip6[8], ip6[9], ip6[10], ip6[11], ip6[12], ip6[13], ip6[14], ip6[15])
 end
 
 core_object_ip6_t = ffi.metatype(t_name, { __index = Ip6 })


### PR DESCRIPTION
It's useful to be able to convert IP from byte array to string representation without having any actual ip/ip6 object, e.g.:

```
local ip6 = require("dnsjit.core.object.ip6")
-- node.key is uint8_t[16] cdata
print(ip6.tostring(node.key, true))
```