### PR TITLE
output/dnssim: fix handling CONGESTED and closing connections

### DIFF
--- a/src/output/dnssim/connection.c
+++ b/src/output/dnssim/connection.c
@@ -92,10 +92,13 @@ void _output_dnssim_conn_close(_output_dnssim_connection_t* conn)
         self->stats_sum->conn_handshakes_failed++;
         break;
     case _OUTPUT_DNSSIM_CONN_ACTIVE:
+    case _OUTPUT_DNSSIM_CONN_CONGESTED:
         self->stats_current->conn_active--;
         break;
-    default:
+    case _OUTPUT_DNSSIM_CONN_INITIALIZED:
         break;
+    default:
+        lfatal("unknown conn state: %d", conn->state);
     }
     conn->state = _OUTPUT_DNSSIM_CONN_CLOSING;
 

--- a/src/output/dnssim/connection.c
+++ b/src/output/dnssim/connection.c
@@ -96,9 +96,15 @@ void _output_dnssim_conn_close(_output_dnssim_connection_t* conn)
         self->stats_current->conn_active--;
         break;
     case _OUTPUT_DNSSIM_CONN_INITIALIZED:
+    case _OUTPUT_DNSSIM_CONN_CLOSE_REQUESTED:
         break;
     default:
         lfatal("unknown conn state: %d", conn->state);
+    }
+    if (conn->prevent_close) {
+        lassert(conn->state <= _OUTPUT_DNSSIM_CONN_CLOSE_REQUESTED, "conn already closing");
+        conn->state = _OUTPUT_DNSSIM_CONN_CLOSE_REQUESTED;
+        return;
     }
     conn->state = _OUTPUT_DNSSIM_CONN_CLOSING;
 

--- a/src/output/dnssim/https2.c
+++ b/src/output/dnssim/https2.c
@@ -335,9 +335,14 @@ void _output_dnssim_https2_process_input_data(_output_dnssim_connection_t* conn,
 
     /* Process incoming frames. */
     ssize_t ret = 0;
+    conn->prevent_close = true;
     ret         = nghttp2_session_mem_recv(conn->http2->session, (uint8_t*)data, len);
+    conn->prevent_close = false;
     if (ret < 0) {
         mlwarning("failed nghttp2_session_mem_recv: %s", nghttp2_strerror(ret));
+        _output_dnssim_conn_close(conn);
+        return;
+    } else if (conn->state == _OUTPUT_DNSSIM_CONN_CLOSE_REQUESTED) {
         _output_dnssim_conn_close(conn);
         return;
     }

--- a/src/output/dnssim/https2.c
+++ b/src/output/dnssim/https2.c
@@ -61,7 +61,6 @@ static ssize_t _http2_send(nghttp2_session* session, const uint8_t* data, size_t
     ssize_t len = 0;
     if ((len = gnutls_record_send(conn->tls->session, data, length)) < 0) {
         mlwarning("gnutls_record_send failed: %s", gnutls_strerror(len));
-        _output_dnssim_conn_close(conn);
         len = NGHTTP2_ERR_CALLBACK_FAILURE;
     }
 

--- a/src/output/dnssim/internal.h
+++ b/src/output/dnssim/internal.h
@@ -204,6 +204,7 @@ struct _output_dnssim_connection {
         _OUTPUT_DNSSIM_CONN_TLS_HANDSHAKE = 20,
         _OUTPUT_DNSSIM_CONN_ACTIVE        = 30,
         _OUTPUT_DNSSIM_CONN_CONGESTED     = 35,
+        _OUTPUT_DNSSIM_CONN_CLOSE_REQUESTED = 38,
         _OUTPUT_DNSSIM_CONN_CLOSING       = 40,
         _OUTPUT_DNSSIM_CONN_CLOSED        = 50
     } state;
@@ -229,6 +230,11 @@ struct _output_dnssim_connection {
 
     /* HTTP/2-related data. */
     _output_dnssim_http2_ctx_t* http2;
+
+    /* Prevents immediate closure of connection. Instead, connection is moved
+     * to CLOSE_REQUESTED state and setter of this flag is responsible for
+     * closing the connection when clearing this flag. */
+    bool prevent_close;
 };
 
 /*

--- a/src/output/dnssim/internal.h
+++ b/src/output/dnssim/internal.h
@@ -195,7 +195,9 @@ struct _output_dnssim_connection {
     /* Client this connection belongs to. */
     _output_dnssim_client_t* client;
 
-    /* State of the connection. */
+    /* State of the connection.
+     * Numeric ordering of constants is significant and follows the typical connection lifecycle.
+     * Ensure new states are added to a proper place. */
     enum {
         _OUTPUT_DNSSIM_CONN_INITIALIZED   = 0,
         _OUTPUT_DNSSIM_CONN_TCP_HANDSHAKE = 10,

--- a/src/output/dnssim/tls.c
+++ b/src/output/dnssim/tls.c
@@ -104,7 +104,7 @@ void _output_dnssim_tls_process_input_data(_output_dnssim_connection_t* conn)
     /* See https://gnutls.org/manual/html_node/Data-transfer-and-termination.html#Data-transfer-and-termination */
     while (true) {
         /* Connection might have been closed due to an error, don't try to use it. */
-        if (conn->state != _OUTPUT_DNSSIM_CONN_ACTIVE)
+        if (conn->state < _OUTPUT_DNSSIM_CONN_ACTIVE || conn->state >= _OUTPUT_DNSSIM_CONN_CLOSING)
             return;
 
         ssize_t count = gnutls_record_recv(conn->tls->session, _self->wire_buf, WIRE_BUF_SIZE);


### PR DESCRIPTION
Allow receiving of data when connection is marked as CONGESTED,
which is used by HTTP layer to indicate another connection should be
opened instead of re-using this one for new queries.