### PR TITLE
output/dnssim: rename udp_only() to udp()

### DIFF
--- a/src/output/dnssim.c
+++ b/src/output/dnssim.c
@@ -261,7 +261,7 @@ void output_dnssim_set_transport(output_dnssim_t* self, output_dnssim_transport_
 #endif
         break;
     case OUTPUT_DNSSIM_TRANSPORT_UDP:
-        lfatal("UDP tranport with TCP fallback not supported yet. Please use udp_only() instead.");
+        lfatal("UDP tranport with TCP fallback not supported yet.");
         break;
     default:
         lfatal("unknown or unsupported transport");

--- a/src/output/dnssim.lua
+++ b/src/output/dnssim.lua
@@ -20,7 +20,7 @@
 -- Simulate independent DNS clients over various transports
 --   output = require("dnsjit.output.dnssim").new()
 -- .SS Usage
---   output:udp_only()
+--   output:udp()
 --   output:target("::1", 53)
 --   recv, rctx = output:receive()
 --   -- pass in objects using recv(rctx, obj)
@@ -99,16 +99,9 @@ function DnsSim:bind(ip)
     return C.output_dnssim_bind(self.obj, ip)
 end
 
--- Set the transport to UDP (without any TCP fallback).
-function DnsSim:udp_only()
-    C.output_dnssim_set_transport(self.obj, C.OUTPUT_DNSSIM_TRANSPORT_UDP_ONLY)
-end
-
--- Set the preferred transport to UDP.
--- This transport falls back to TCP for individual queries if TC bit is set
--- in received answer.
+-- Set the preferred transport to UDP (without any TCP fallback).
 function DnsSim:udp()
-    C.output_dnssim_set_transport(self.obj, C.OUTPUT_DNSSIM_TRANSPORT_UDP)
+    C.output_dnssim_set_transport(self.obj, C.OUTPUT_DNSSIM_TRANSPORT_UDP_ONLY)
 end
 
 -- Set the transport to TCP.

--- a/src/output/dnssim.lua
+++ b/src/output/dnssim.lua
@@ -28,7 +28,7 @@
 -- .SS DNS-over-TLS example configuration
 --   output:tls("NORMAL:-VERS-ALL:+VERS-TLS1.3")  -- enforce TLS 1.3
 -- .SS DNS-over-HTTPS/2 example configuration
---   output:https2({ method = "GET", uri_path = "/doh" })
+--   output:https2({ method = "POST", uri_path = "/doh" })
 --
 -- Output module for simulating traffic from huge number of independent,
 -- individual DNS clients.
@@ -143,16 +143,16 @@ end
 --
 -- .B method:
 -- .B GET
+-- (default)
 -- or
 -- .B POST
--- (default)
 --
 -- .B uri_path:
 -- where queries will be sent.
 -- Defaults to
 -- .B /dns-query
 --
--- .B zero_out_msgig:
+-- .B zero_out_msgid:
 -- when
 -- .B true
 -- (default), query ID is always set to 0
@@ -191,7 +191,7 @@ end
 --
 -- .BR Beware :
 -- increasing this value while the target resolver isn't very responsive
--- (cold cache, heavy load) may degrade shotgun's performance and skew
+-- (cold cache, heavy load) may degrade dnssim's performance and skew
 -- the results.
 function DnsSim:timeout(seconds)
     if seconds == nil then

--- a/src/output/dnssim.lua
+++ b/src/output/dnssim.lua
@@ -43,7 +43,7 @@
 -- This also applies for state-full transports.
 -- The complete set-up is quite complex and requires other components.
 -- See DNS Shotgun
--- .RI ( https://gitlab.labs.nic.cz/knot/shotgun )
+-- .RI ( https://gitlab.nic.cz/knot/shotgun )
 -- for dnsjit scripts ready for use for high-performance
 -- benchmarking.
 module(...,package.seeall)
@@ -362,5 +362,5 @@ end
 -- dnsjit.filter.ipsplit (3),
 -- dnsjit.filter.core.object.ip (3),
 -- dnsjit.filter.core.object.ip6 (3),
--- https://gitlab.labs.nic.cz/knot/shotgun
+-- https://gitlab.nic.cz/knot/shotgun
 return DnsSim

--- a/src/output/respdiff.lua
+++ b/src/output/respdiff.lua
@@ -90,5 +90,5 @@ function Respdiff:commit(start_time, end_time)
     C.output_respdiff_commit(self.obj, self.origname, self.recvname, start_time, end_time)
 end
 
--- respdiff " https://gitlab.labs.nic.cz/knot/respdiff"
+-- respdiff " https://gitlab.nic.cz/knot/respdiff"
 return Respdiff


### PR DESCRIPTION
I think simple udp() to select UDP transport is more user-friendly.
When TCP fallback is implemented, it can be configured as an argument.

This is technically a backward-incompatible change, but I think it's
very likely DNS Shotgun is the only user of this API so far.

Related #159