### PR TITLE
output/dnssim: allow user-set instance log name

### DIFF
--- a/src/output/dnssim.c
+++ b/src/output/dnssim.c
@@ -31,6 +31,7 @@
 #include <string.h>
 
 static core_log_t _log = LOG_T_INIT("output.dnssim");
+static output_dnssim_t _defaults = { LOG_T_INIT_OBJ("output.dnssim") };
 
 static uint64_t _now_ms()
 {
@@ -60,6 +61,7 @@ output_dnssim_t* output_dnssim_new(size_t max_clients)
     int              ret, i;
 
     mlfatal_oom(self = calloc(1, sizeof(_output_dnssim_t)));
+    *self = _defaults;
     self->handshake_timeout_ms = 5000;
     self->idle_timeout_ms      = 10000;
     output_dnssim_timeout_ms(self, 2000);
@@ -134,6 +136,13 @@ void output_dnssim_free(output_dnssim_t* self)
     }
 
     free(self);
+}
+
+void output_dnssim_log_name(output_dnssim_t* self, const char* name)
+{
+    memcpy(self->_log.name, name, sizeof(self->_log.name));
+    self->_log.name[sizeof(self->_log.name) - 1] = '\0';
+    self->_log.is_obj = false;
 }
 
 static uint32_t _extract_client(const core_object_t* obj)

--- a/src/output/dnssim.c
+++ b/src/output/dnssim.c
@@ -140,8 +140,11 @@ void output_dnssim_free(output_dnssim_t* self)
 
 void output_dnssim_log_name(output_dnssim_t* self, const char* name)
 {
-    memcpy(self->_log.name, name, sizeof(self->_log.name));
-    self->_log.name[sizeof(self->_log.name) - 1] = '\0';
+    mlassert_self();
+    lassert(name, "name is nil");
+
+    strncpy(self->_log.name, name, sizeof(self->_log.name) - 1);
+    self->_log.name[sizeof(self->_log.name) - 1] = 0;
     self->_log.is_obj = false;
 }
 

--- a/src/output/dnssim.hh
+++ b/src/output/dnssim.hh
@@ -107,6 +107,7 @@ core_log_t* output_dnssim_log();
 output_dnssim_t* output_dnssim_new(size_t max_clients);
 void             output_dnssim_free(output_dnssim_t* self);
 
+void output_dnssim_log_name(output_dnssim_t* self, const char* name);
 void output_dnssim_set_transport(output_dnssim_t* self, output_dnssim_transport_t tr);
 int  output_dnssim_target(output_dnssim_t* self, const char* ip, uint16_t port);
 int  output_dnssim_bind(output_dnssim_t* self, const char* ip);

--- a/src/output/dnssim.lua
+++ b/src/output/dnssim.lua
@@ -69,7 +69,8 @@ function DnsSim.new(max_clients)
 end
 
 -- Return the Log object to control logging of this instance or module.
--- Optionally, set the instance's log name. Unique name should be used for each instance.
+-- Optionally, set the instance's log name.
+-- Unique name should be used for each instance.
 function DnsSim:log(name)
     if self == nil then
         return C.output_dnssim_log()

--- a/src/output/dnssim.lua
+++ b/src/output/dnssim.lua
@@ -69,9 +69,13 @@ function DnsSim.new(max_clients)
 end
 
 -- Return the Log object to control logging of this instance or module.
-function DnsSim:log()
+-- Optionally, set the instance's log name. Unique name should be used for each instance.
+function DnsSim:log(name)
     if self == nil then
         return C.output_dnssim_log()
+    end
+    if name ~= nil then
+        C.output_dnssim_log_name(self.obj, name)
     end
     return self.obj._log
 end


### PR DESCRIPTION
It's useful if the user can customize the instance log name for dnssim,
especially since the component typically has multiple instances than can
be configured differently.