### PR TITLE
filter/ipsplit: extend PRNG modulus to 2^31

### DIFF
--- a/src/filter/ipsplit.c
+++ b/src/filter/ipsplit.c
@@ -124,21 +124,17 @@ void filter_ipsplit_add(filter_ipsplit_t* self, core_receiver_t recv, void* ctx,
 /*
  * Use portable pseudo-random number generator.
  */
-static uint32_t _rand_next = 1;
+static uint32_t _rand_val = 1;
 
-static uint32_t _rand(uint32_t mod)
+static uint32_t _rand()
 {
-    mlassert(mod >= 1, "modulus must be positive integer");
-    _rand_next   = _rand_next * 1103515245 + 12345;
-    uint32_t ret = (uint32_t)(_rand_next / 65536) % mod;
-    mldebug("rand: %d", ret);
-    return ret;
+    _rand_val = ((_rand_val * 1103515245) + 12345) & 0x7fffffff;
+    return _rand_val;
 }
 
 void filter_ipsplit_srand(uint32_t seed)
 {
-    _rand_next = seed;
-    mldebug("rand seed %d", seed);
+    _rand_val = seed;
 }
 
 static void _assign_client_to_receiver(filter_ipsplit_t* self, _client_t* client)
@@ -157,7 +153,7 @@ static void _assign_client_to_receiver(filter_ipsplit_t* self, _client_t* client
     case IPSPLIT_MODE_RANDOM: {
         /* Get random number from [1, weight_total], then iterate through
          * receivers until their weights add up to at least this value. */
-        int32_t random = (int32_t)_rand(_self->weight_total) + 1;
+        int32_t random = (int32_t)(_rand() % _self->weight_total) + 1;
         while (random > 0) {
             random -= self->recv->weight;
             if (random > 0)

--- a/src/test/test_ipsplit.lua
+++ b/src/test/test_ipsplit.lua
@@ -217,8 +217,8 @@ out1:close()
 out2:close()
 
 assert(ipsplit:discarded() == 0, "some valid packets have been discarded")
-assert(out1:size() == 73, "out1: some IPv6 packets lost by filter")
-assert(out2:size() == 18, "out2: some IPv6 packets lost by filter")
+assert(out1:size() == 81, "out1: some IPv6 packets lost by filter")
+assert(out2:size() == 10, "out2: some IPv6 packets lost by filter")
 
 -- out1: test individual packets
 local i = 0
@@ -226,12 +226,11 @@ while true do
     local obj = out1:get()
     if obj == nil then break end
     i = i + 1
-    if i == 1 then assert(dns_msgid(obj) == 0x0a31, "pkt 1: client 1, pkt 1 -> out1") end
-    if i == 2 then assert(dns_msgid(obj) == 0xe6bd, "pkt 2: client 2, pkt 1 -> out1") end
-    if i == 3 then assert(dns_msgid(obj) == 0xb3e8, "pkt 3: client 3, pkt 1 -> out1") end
-    if i == 4 then assert(dns_msgid(obj) == 0xb3e9, "pkt 4: client 3, pkt 2 -> out1") end
-    if i == 15 then assert(dns_msgid(obj) == 0x4a05, "pkt 16: client 8, pkt 1 -> out1") end
-    if i == 16 then assert(dns_msgid(obj) == 0x4a06, "pkt 17: client 8, pkt 2 -> out1") end
+    if i == 1 then assert(dns_msgid(obj) == 0xe6bd, "pkt 1: client 2, pkt 1 -> out1") end
+    if i == 2 then assert(dns_msgid(obj) == 0xb3e8, "pkt 2: client 3, pkt 1 -> out1") end
+    if i == 3 then assert(dns_msgid(obj) == 0xb3e9, "pkt 3: client 3, pkt 2 -> out1") end
+    if i == 5 then assert(dns_msgid(obj) == 0xaea6, "pkt 4: client 5, pkt 1 -> out1") end
+    if i == 29 then assert(dns_msgid(obj) == 0xaeaf, "pkt 29: client 5, pkt 10 -> out1") end
 end
 
 -- out2: test individual packets
@@ -240,9 +239,9 @@ while true do
     local obj = out2:get()
     if obj == nil then break end
     i = i + 1
-    if i == 1 then assert(dns_msgid(obj) == 0x0a6f, "pkt 9: client 6, pkt 1 -> out2") end
-    if i == 2 then assert(dns_msgid(obj) == 0xabfe, "pkt 18: client 9, pkt 1 -> out2") end
-    if i == 3 then assert(dns_msgid(obj) == 0xabff, "pkt 21: client 9, pkt 2 -> out2") end
+    if i == 1 then assert(dns_msgid(obj) == 0x0a31, "pkt 1: client 1, pkt 1 -> out2") end
+    if i == 2 then assert(dns_msgid(obj) == 0x0a6f, "pkt 2: client 6, pkt 1 -> out2") end
+    if i == 10 then assert(dns_msgid(obj) == 0x0a70, "pkt 10: client 6, pkt 2 -> out2") end
 end
 
 -----------------------------------------------------


### PR DESCRIPTION
The new implementation is the same as glibc's rand(). Now maximum random
numbers can be up to 2^31 -1, compared to the previous max of 2^15 - 1.