### PR TITLE
Output PCAP man-page, errors

### DIFF
--- a/src/output/pcap.c
+++ b/src/output/pcap.c
@@ -82,6 +82,15 @@ void output_pcap_close(output_pcap_t* self)
     }
 }
 
+int output_pcap_have_errors(output_pcap_t* self)
+{
+    mlassert_self();
+    if (self->dumper) {
+        return ferror(pcap_dump_file(self->dumper));
+    }
+    return 0;
+}
+
 static void _receive(output_pcap_t* self, const core_object_t* obj)
 {
     struct pcap_pkthdr hdr;

--- a/src/output/pcap.hh
+++ b/src/output/pcap.hh
@@ -37,5 +37,6 @@ void        output_pcap_init(output_pcap_t* self);
 void        output_pcap_destroy(output_pcap_t* self);
 int         output_pcap_open(output_pcap_t* self, const char* file, int linktype, int snaplen);
 void        output_pcap_close(output_pcap_t* self);
+int         output_pcap_have_errors(output_pcap_t* self);
 
 core_receiver_t output_pcap_receiver(output_pcap_t* self);

--- a/src/output/pcap.lua
+++ b/src/output/pcap.lua
@@ -60,6 +60,10 @@ end
 -- .I linktype
 -- and
 -- .IR snaplen .
+-- Uses
+-- .B pcap_dump_open()
+-- so you can pass "-" to it to open stdout, see it's man-page for more
+-- information.
 -- Returns 0 on success.
 function Pcap:open(file, linktype, snaplen)
     return C.output_pcap_open(self.obj, file, linktype, snaplen)
@@ -68,6 +72,16 @@ end
 -- Close the PCAP.
 function Pcap:close()
     C.output_pcap_close(self.obj)
+end
+
+-- Return true if the underlying
+-- .I FILE*
+-- indicates that there's been an error.
+function Pcap:have_errors()
+    if C.output_pcap_have_errors(self.obj) == 0 then
+        return false
+    end
+    return true
 end
 
 -- Return the C functions and context for receiving objects.


### PR DESCRIPTION
- `output/pcap`:
  - Update `open()` man-page, indicate usage of `pcap_dump_open()`
  - Add `have_errors()` to check for write errors during/after dumping