### PR TITLE
Stand-alone tool example

### DIFF
--- a/examples/stand-alone-tool/src/test/Makefile.am
+++ b/examples/stand-alone-tool/src/test/Makefile.am
@@ -6,7 +6,7 @@ TESTS = test.sh
 BUILT_SOURCES = env.sh
 
 env.sh:
-	echo "export PATH=\"\$PATH:@DNSJIT_ROOT@/bin\"" >"$@"
+	echo "export PATH=\"\$$PATH:@DNSJIT_ROOT@/bin\"" >"$@"
 	echo "export LUA_CPATH=\"@DNSJIT_ROOT@/lib/lua/5.1/?.so;;\"" >>"$@"
 	echo "export LUA_PATH=\"@DNSJIT_ROOT@/share/lua/5.1/?.lua;;\"" >>"$@"
 


### PR DESCRIPTION
- `examples/stand-alone-tool`: Fix variable quoting when creating `env.sh`