### PR TITLE
DNS reset, dnslen TCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ while true do
     local object = producer(ctx)
     if object == nil then break end
     if object:type() == "payload" then
+        dns:reset()
         dns.obj_prev = object
         if dns:parse_header() == 0 then
             print(dns.id)
@@ -128,6 +129,9 @@ while true do
     end
 end
 ```
+
+Disclaimer, to keep the above example short it only works on pre-prepared
+PCAPs with only UDP DNS traffic in them.
 
 See more examples in the [examples](https://github.com/DNS-OARC/dnsjit/tree/develop/examples) directory.
 

--- a/examples/capture.lua
+++ b/examples/capture.lua
@@ -36,6 +36,10 @@ while true do
             protocol = protocol.obj_prev
         end
 
+        dns:reset()
+        if protocol ~= nil and protocol.obj_type == object.TCP then
+            dns.includes_dnslen = 1
+        end
         dns.obj_prev = obj
         if transport ~= nil and protocol ~= nil then
             transport = transport:cast()

--- a/examples/dumpdns-qr.lua
+++ b/examples/dumpdns-qr.lua
@@ -43,6 +43,10 @@ while true do
             protocol = protocol.obj_prev
         end
 
+        dns:reset()
+        if protocol ~= nil and protocol.obj_type == object.TCP then
+            dns.includes_dnslen = 1
+        end
         dns.obj_prev = obj
         if transport ~= nil and protocol ~= nil and dns:parse_header() == 0 then
             transport = transport:cast()

--- a/examples/dumpdns.lua
+++ b/examples/dumpdns.lua
@@ -47,6 +47,10 @@ while true do
             protocol = protocol.obj_prev
         end
 
+        dns:reset()
+        if protocol ~= nil and protocol.obj_type == object.TCP then
+            dns.includes_dnslen = 1
+        end
         dns.obj_prev = obj
         if transport ~= nil and protocol ~= nil then
             transport = transport:cast()

--- a/examples/dumpdns2pcap.lua
+++ b/examples/dumpdns2pcap.lua
@@ -26,6 +26,18 @@ while true do
     if obj == nil then break end
     local pl = obj:cast()
     if obj:type() == "payload" and pl.len > 0 then
+        local protocol = obj.obj_prev
+        while protocol ~= nil do
+            if protocol.obj_type == object.UDP or protocol.obj_type == object.TCP then
+                break
+            end
+            protocol = protocol.obj_prev
+        end
+
+        dns:reset()
+        if protocol ~= nil and protocol.obj_type == object.TCP then
+            dns.includes_dnslen = 1
+        end
         dns.obj_prev = obj
         if dns:parse_header() == 0 then
             receiver(rctx, obj)

--- a/examples/filter_rcode.lua
+++ b/examples/filter_rcode.lua
@@ -28,9 +28,20 @@ while true do
             end
             transport = transport.obj_prev
         end
+        local protocol = obj.obj_prev
+        while protocol ~= nil do
+            if protocol.obj_type == object.UDP or protocol.obj_type == object.TCP then
+                break
+            end
+            protocol = protocol.obj_prev
+        end
 
+        dns:reset()
+        if protocol ~= nil and protocol.obj_type == object.TCP then
+            dns.includes_dnslen = 1
+        end
         dns.obj_prev = obj
-        if transport and dns and dns:parse_header() == 0 and dns.have_rcode == 1 and dns.rcode == rcode then
+        if transport ~= nil and dns:parse_header() == 0 and dns.have_rcode == 1 and dns.rcode == rcode then
             transport = transport:cast()
             print(dns.id, transport:source().." -> "..transport:destination())
         end

--- a/examples/qr-multi-pcap-state.lua
+++ b/examples/qr-multi-pcap-state.lua
@@ -155,6 +155,10 @@ while true do
             pcap = pcap.obj_prev
         end
 
+        dns:reset()
+        if protocol ~= nil and protocol.obj_type == object.TCP then
+            dns.includes_dnslen = 1
+        end
         dns.obj_prev = obj
         if pcap ~= nil and transport ~= nil and protocol ~= nil and dns:parse_header() == 0 then
             transport = transport:cast()

--- a/examples/readme.lua
+++ b/examples/readme.lua
@@ -1,4 +1,8 @@
 #!/usr/bin/env dnsjit
+
+-- Disclaimer, to keep this example short it only works on pre-prepared
+-- PCAPs with only UDP DNS traffic in them.
+
 require("dnsjit.core.objects")
 local input = require("dnsjit.input.pcap").new()
 local layer = require("dnsjit.filter.layer").new()
@@ -12,6 +16,7 @@ while true do
     local object = producer(ctx)
     if object == nil then break end
     if object:type() == "payload" then
+        dns:reset()
         dns.obj_prev = object
         if dns:parse_header() == 0 then
             print(dns.id)

--- a/examples/replay.lua
+++ b/examples/replay.lua
@@ -71,6 +71,7 @@ while true do
     if obj == nil then break end
     local pl = obj:cast()
     if obj:type() == "payload" and pl.len > 0 then
+        query:reset()
         query.obj_prev = obj
 
         local trs = pl.obj_prev:cast()

--- a/examples/replay_multicli.lua
+++ b/examples/replay_multicli.lua
@@ -120,6 +120,7 @@ while true do
             end
             local pl = obj:cast()
             if obj:type() == "payload" and pl.len > 0 then
+                query:reset()
                 query.obj_prev = obj
 
                 local trs = pl.obj_prev:cast()

--- a/src/core/object/dns.c
+++ b/src/core/object/dns.c
@@ -95,6 +95,12 @@ void core_object_dns_free(core_object_dns_t* self)
     free(self);
 }
 
+void core_object_dns_reset(core_object_dns_t* self)
+{
+    mlassert_self();
+    *self = _defaults;
+}
+
 #define need8(v, p, l) \
     if (l < 1) {       \
         break;         \

--- a/src/core/object/dns.hh
+++ b/src/core/object/dns.hh
@@ -112,7 +112,7 @@ core_log_t* core_object_dns_log();
 core_object_dns_t* core_object_dns_new();
 core_object_dns_t* core_object_dns_copy(const core_object_dns_t* self);
 void               core_object_dns_free(core_object_dns_t* self);
-void               core_object_dns_reset(core_object_dns_t* self, const core_object_t* obj);
+void               core_object_dns_reset(core_object_dns_t* self);
 
 int core_object_dns_parse_header(core_object_dns_t* self);
 int core_object_dns_parse_q(core_object_dns_t* self, core_object_dns_q_t* q, core_object_dns_label_t* label, size_t labels);

--- a/src/core/object/dns.lua
+++ b/src/core/object/dns.lua
@@ -517,6 +517,11 @@ function Dns:free()
     C.core_object_dns_free(self)
 end
 
+-- Reset the object readying it for reuse.
+function Dns:reset()
+    C.core_object_dns_reset(self)
+end
+
 -- Return the Log object to control logging of this module.
 function Dns:log()
     return C.core_object_dns_log()


### PR DESCRIPTION
- `core.object.dns`: Add `reset()` to reset the object so it can be reused correctly
- `examples`:
  - Add usage of DNS object reset
  - Fix handling of TCP payload when it includes the DNS length