### PR TITLE
thread push number

### DIFF
--- a/src/core/channel.hh
+++ b/src/core/channel.hh
@@ -18,7 +18,7 @@
  * along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-//lua:require("dnsjit.core.compat_h")
+// lua:require("dnsjit.core.compat_h")
 // lua:require("dnsjit.core.log")
 // lua:require("dnsjit.core.receiver_h")
 

--- a/src/core/thread.c
+++ b/src/core/thread.c
@@ -185,7 +185,7 @@ void core_thread_push_string(core_thread_t* self, const char* str, size_t len)
     _push(self, item);
 }
 
-void core_thread_push_int64(core_thread_t* self, int64_t i64)
+void core_thread_push_number(core_thread_t* self, lua_Number num)
 {
     core_thread_item_t* item;
     mlassert_self();
@@ -194,7 +194,7 @@ void core_thread_push_int64(core_thread_t* self, int64_t i64)
     item->next = 0;
     item->ptr  = 0;
     item->str  = 0;
-    item->i64  = i64;
+    item->num  = num;
 
     _push(self, item);
 }

--- a/src/core/thread.h
+++ b/src/core/thread.h
@@ -25,6 +25,7 @@
 
 #include <pthread.h>
 #include <unistd.h>
+#include <lua.h>
 
 #include <dnsjit/core/thread.hh>
 

--- a/src/core/thread.hh
+++ b/src/core/thread.hh
@@ -27,8 +27,8 @@ struct core_thread_item {
     void*               ptr;
     char *              type, *module;
 
-    char*   str;
-    int64_t i64;
+    char*      str;
+    lua_Number num;
 };
 
 typedef struct core_thread {
@@ -52,5 +52,5 @@ int                       core_thread_start(core_thread_t* self, const char* byt
 int                       core_thread_stop(core_thread_t* self);
 void                      core_thread_push(core_thread_t* self, void* ptr, const char* type, size_t type_len, const char* module, size_t module_len);
 void                      core_thread_push_string(core_thread_t* self, const char* str, size_t len);
-void                      core_thread_push_int64(core_thread_t* self, int64_t i64);
+void                      core_thread_push_number(core_thread_t* self, lua_Number num);
 const core_thread_item_t* core_thread_pop(core_thread_t* self);

--- a/src/core/thread.lua
+++ b/src/core/thread.lua
@@ -87,7 +87,7 @@ function Thread:push(...)
         if t == "string" then
             C.core_thread_push_string(self, obj, #obj)
         elseif t == "number" then
-            C.core_thread_push_int64(self, obj)
+            C.core_thread_push_number(self, obj)
         else
             local ptr, type, module = obj:share()
             C.core_thread_push(self, ptr, type, #type, module, #module)
@@ -108,7 +108,7 @@ function Thread:pop(num)
         end
         if item.ptr == nil then
             if item.str == nil then
-                return tonumber(item.i64)
+                return tonumber(item.num)
             end
             return ffi.string(item.str)
         end
@@ -123,7 +123,7 @@ function Thread:pop(num)
 
         if item.ptr == nil then
             if item.str == nil then
-                table.insert(ret, tonumber(item.i64))
+                table.insert(ret, tonumber(item.num))
             else
                 table.insert(ret, ffi.string(item.str))
             end


### PR DESCRIPTION
- `core.thread`: Fix #233: Replace `core_thread_push_int64()` with `core_thread_push_number()` and use `lua_Number` instead of `int64_t` to actually push/pop numbers