### PR TITLE
Fix a potential memory leak in trie

### DIFF
--- a/src/lib/trie.c
+++ b/src/lib/trie.c
@@ -490,6 +490,10 @@ static int ns_longer_alloc(nstack_t* ns)
             memcpy(st, ns->stack, ns->len * sizeof(node_t*));
     } else {
         st = realloc(ns->stack, new_size);
+        if (st == NULL) {
+            free(ns->stack); // left behind by realloc, callers bail out
+            ns->stack = NULL;
+        }
     }
     if (st == NULL)
         return KNOT_ENOMEM;


### PR DESCRIPTION
This should resolve https://sonarcloud.io/project/issues?open=AYw_KgZGcvK1YDgPXu_c&id=dns-oarc%3Adnsjit

Taken from https://gitlab.nic.cz/knot/knot-resolver/-/commit/c1bdcd06cb20948971c0110e6f28a4254828ea23