### PR TITLE
torfc1035

### DIFF
--- a/src/core/object/dns.c
+++ b/src/core/object/dns.c
@@ -51,6 +51,7 @@
 #define bswap_64(x) bswap64(x)
 #endif
 #endif
+#include <ctype.h>
 
 #define _ERR_MALFORMED -2
 #define _ERR_NEEDLABELS -3
@@ -474,4 +475,33 @@ int core_object_dns_parse_rr(core_object_dns_t* self, core_object_dns_rr_t* rr, 
 
     // TODO: error here on malformed/truncated? could be quite spammy
     return _ERR_MALFORMED;
+}
+
+const char* core_object_dns_torfc1035(const char* str, size_t len)
+{
+    mlassert(str, "str is nil");
+    static char res[512];
+
+    size_t i, j = 0;
+    for (i = 0; i < len; i++) {
+        if (j + 4 >= sizeof(res) - 1) {
+            return 0;
+        }
+
+        if (isalnum(str[i]) || str[i] == '-' || str[i] == '_') {
+            res[j++] = str[i];
+        } else if (isprint(str[i])) {
+            res[j++] = '\\';
+            res[j++] = str[i];
+        } else {
+            res[j++] = '\\';
+            res[j++] = '0' + (((unsigned char)str[i] >> 6) & 0x07);
+            res[j++] = '0' + (((unsigned char)str[i] >> 3) & 0x07);
+            res[j++] = '0' + ((unsigned char)str[i] & 0x07);
+        }
+    }
+
+    res[j] = 0;
+
+    return res;
 }

--- a/src/core/object/dns.hh
+++ b/src/core/object/dns.hh
@@ -117,3 +117,5 @@ void               core_object_dns_reset(core_object_dns_t* self);
 int core_object_dns_parse_header(core_object_dns_t* self);
 int core_object_dns_parse_q(core_object_dns_t* self, core_object_dns_q_t* q, core_object_dns_label_t* label, size_t labels);
 int core_object_dns_parse_rr(core_object_dns_t* self, core_object_dns_rr_t* rr, core_object_dns_label_t* label, size_t labels);
+
+const char* core_object_dns_torfc1035(const char* str, size_t len);

--- a/src/core/object/dns/label.lua
+++ b/src/core/object/dns/label.lua
@@ -67,8 +67,16 @@ function Label.new(size)
 end
 
 -- Returns labels as a string and an offset to the next label.
--- The string may be nil if the first label was an offset.
--- The offset may be nil if the last label was an extension bits or end marker.
+-- Takes argument
+-- .IR labels ,
+-- an array of labels returned by any of the parse functions, and
+-- .IR num_labels ,
+-- number of labels in the array.
+-- Optional
+-- .I offset_labels
+-- can be used to skip labels at the start.
+-- The return string may be nil if the first label was an offset.
+-- The return offset may be nil if the last label was an extension bits or end marker.
 function Label.tostring(dns, labels, num_labels, offset_labels)
     if offset_labels == nil then
         offset_labels = 0
@@ -91,9 +99,50 @@ function Label.tostring(dns, labels, num_labels, offset_labels)
     return dn, nil
 end
 
+-- Returns a RFC1035 domain name of the labels and an offset to the next label.
+-- Takes argument
+-- .IR labels ,
+-- an array of labels returned by any of the parse functions, and
+-- .IR num_labels ,
+-- number of labels in the array.
+-- Optional
+-- .I offset_labels
+-- can be used to skip labels at the start.
+-- The return string may be nil if the first label was an offset.
+-- The return offset may be nil if the last label was an extension bits or end marker.
+function Label.torfc1035(dns, labels, num_labels, offset_labels)
+    if offset_labels == nil then
+        offset_labels = 0
+    end
+    local dn
+    for n = 1, tonumber(num_labels) do
+        local label = labels[n - 1 + offset_labels]
+
+        if label.have_dn == 1 then
+            if dn == nil then
+                dn = ""
+            end
+            dn = dn .. ffi.string(ffi.C.core_object_dns_torfc1035(dns.payload + label.offset + 1, label.length)) .. "."
+        elseif label.have_offset == 1 then
+            return dn, label.offset
+        else
+            return dn, nil
+        end
+    end
+    return dn, nil
+end
+
 -- Returns labels as a string which also includes a textual notation of the
 -- offset in the form of
 -- .IR "<offset>label" .
+-- Takes argument
+-- .IR labels ,
+-- an array of labels returned by any of the parse functions, and
+-- .IR num_labels ,
+-- number of labels in the array.
+-- Optional
+-- .I offset_labels
+-- can be used to skip labels at the start.
 function Label.tooffstr(dns, labels, num_labels, offset_labels)
     if offset_labels == nil then
         offset_labels = 0


### PR DESCRIPTION
- `core.object.dns.label`:
  - Add `torfc1035()`
  - Improve man-page documentation